### PR TITLE
code in markup gets wrapped now.

### DIFF
--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -33,6 +33,9 @@ const overviewStyles = (theme: Theme) => createStyles({
     markdown: {
         '& img': {
             maxWidth: '100%'
+        },
+        '& code': {
+            whiteSpace: 'pre-line'
         }
     },
     resourceLink: {
@@ -91,10 +94,10 @@ class ExtensionDetailOverviewComponent extends React.Component<ExtensionDetailOv
         const zonedDate = toLocalTime(extension.timestamp);
         return <React.Fragment>
             <Box display='flex' >
-                <Box className={classes.markdown} flex={5}>
+                <Box className={classes.markdown} flex={5} overflow="auto">
                     {this.renderMarkdown(this.state.readme)}
                 </Box>
-                <Box flex={3} display='flex' justifyContent='flex-end'>
+                <Box flex={3} display='flex' justifyContent='flex-end' minWidth='290px'>
                     <Box width='80%'>
                         {this.renderButtonList('category', 'Categories', extension.categories)}
                         <Box mt={2}>


### PR DESCRIPTION
Additionally the right detail area has an min-width of 290px now.

To try this out install https://open-vsx.org/extension/msjsdiag/debugger-for-chrome in dev environment.

Fixes eclipse/openvsx#42

