### PR TITLE
Improve display of non-quadratic extension icons.

### DIFF
--- a/webui/src/pages/extension-list/extension-list-item.tsx
+++ b/webui/src/pages/extension-list/extension-list-item.tsx
@@ -26,6 +26,11 @@ const itemStyles = (theme: Theme) => createStyles({
     },
     link: {
         textDecoration: 'none'
+    },
+    img: {
+        width: '5rem',
+        maxHeight: '5.8rem',
+        objectFit: 'contain',
     }
 });
 
@@ -40,7 +45,7 @@ class ExtensionListItemComponent extends React.Component<ExtensionListItemCompon
                         <Paper className={classes.paper}>
                             <Box display='flex' justifyContent='center' alignItems='center' width='100%' height={80}>
                                 <img src={extension.files.icon || this.props.pageSettings.extensionDefaultIconURL}
-                                    width='80px'
+                                    className={classes.img}
                                     alt={extension.displayName || extension.name} />
                             </Box>
                             <Box display='flex' justifyContent='center'>


### PR DESCRIPTION
Fixes eclipse/openvsx#44

This is how it looks with the change in place:

![image](https://user-images.githubusercontent.com/46004116/77714465-e43e0b80-6ffa-11ea-8759-cc077103ac7f.png)

I have used `rem` because It is better for accessibility:

According to W3: https://www.w3.org/WAI/tutorials/page-structure/styling/

![image](https://user-images.githubusercontent.com/46004116/77715490-8eb72e00-6ffd-11ea-9081-dd0a22674fcf.png)
