### PR TITLE
[extension list] adjust the search to look good on mobile. 

### DIFF
--- a/webui/dev/index.tsx
+++ b/webui/dev/index.tsx
@@ -12,6 +12,15 @@ const theme = createMuiTheme({
     palette: {
         primary: { main: '#eeeeee', contrastText: '#352e37' },
         secondary: { main: '#a60ee5', contrastText: '#daf5ce' }
+    },
+    breakpoints: {
+        values: {
+            xs: 340,
+            sm: 550,
+            md: 800,
+            lg: 1040,
+            xl: 1240
+        }
     }
 });
 

--- a/webui/src/pages/extension-list/extension-list-header.tsx
+++ b/webui/src/pages/extension-list/extension-list-header.tsx
@@ -16,10 +16,26 @@ import { ExtensionCategory } from "../../extension-registry-types";
 import { PageSettings } from "../../page-settings";
 
 const headerStyles = (theme: Theme) => createStyles({
+    form: {
+        display: 'flex', 
+        flexDirection: 'column',
+        width: '100%',
+        [theme.breakpoints.up('md')]: {
+            flexDirection: 'row', 
+            width: '70%'
+        },
+        [theme.breakpoints.down('md')]: {
+            maxWidth: 500,
+        }  
+    },
     search: {
         flex: 2,
         display: 'flex',
-        marginRight: theme.spacing(1)
+        marginRight: theme.spacing(1),
+        [theme.breakpoints.down('sm')]: {
+            marginRight: 0,
+            marginBottom: theme.spacing(2),
+        },
     },
     category: {
         flex: 1,
@@ -93,7 +109,7 @@ class ExtensionListHeaderComp extends React.Component<ExtensionListHeaderComp.Pr
                 <Typography variant='h4' classes={{ root: classes.typo }}>
                     {this.props.pageSettings.listHeaderTitle}
                 </Typography>
-                <Box display='flex' width='70%'>
+                <Box className={classes.form}>
                     <Paper className={classes.search}>
                         <InputBase
                             autoFocus


### PR DESCRIPTION
Fixes eclipse/openvsx#48

This is how it looks now:

![image](https://user-images.githubusercontent.com/46004116/77814073-99da8e80-70cf-11ea-89f0-b88f7678a66c.png)
