### PR TITLE
adjust [extension-detail] page for small devices.

### DIFF
--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -26,6 +26,19 @@ import { PageSettings } from "../../page-settings";
 import { ExtensionDetailRoutes } from "./extension-detail";
 
 const overviewStyles = (theme: Theme) => createStyles({
+    overview: {
+        display: 'flex',
+        [theme.breakpoints.down('lg')]: {
+            flexDirection: 'column',
+        }
+    },
+    resourcesWrapper: {
+        margin: "4rem 0",
+        width: "100%",
+        [theme.breakpoints.up('lg')]: {
+            margin: '0 0 0 4.8rem',
+        }
+    },
     link: {
         textDecoration: 'none',
         color: theme.palette.primary.contrastText,
@@ -65,7 +78,13 @@ const overviewStyles = (theme: Theme) => createStyles({
     },
     code: {
         fontFamily: 'monospace',
-        fontSize: '1rem'
+        fontSize: '.85rem',
+        [theme.breakpoints.down('lg')]: {
+            fontSize: '.7rem'
+        }
+    },
+    moreInfo: {
+        maxWidth: '30rem',
     }
 });
 
@@ -104,12 +123,12 @@ class ExtensionDetailOverviewComponent extends React.Component<ExtensionDetailOv
         const { classes, extension } = this.props;
         const zonedDate = toLocalTime(extension.timestamp);
         return <React.Fragment>
-            <Box display='flex' >
+            <Box className={this.props.classes.overview}>
                 <Box className={classes.markdown} flex={5} overflow="auto">
                     {this.renderMarkdown(this.state.readme)}
                 </Box>
                 <Box flex={3} display='flex' justifyContent='flex-end' minWidth='290px'>
-                    <Box width='80%'>
+                    <Box className={this.props.classes.resourcesWrapper}>
                         {this.renderButtonList('category', 'Categories', extension.categories)}
                         <Box mt={2}>
                             {this.renderButtonList('search', 'Tags', extension.tags)}
@@ -138,7 +157,7 @@ class ExtensionDetailOverviewComponent extends React.Component<ExtensionDetailOv
                                 {extension.dependencies!.map(ref => this.renderExtensionRef(ref))}
                             </Box>
                         </Optional>
-                        <Box mt={2}>
+                        <Box mt={2} className={this.props.classes.moreInfo}>
                             <Typography variant='h6'>More Info</Typography>
                             {extension.version ? this.renderInfo('Version', extension.version + (extension.preview ? ' (preview)' : '')) : ''}
                             {zonedDate ? this.renderInfo('Released on', zonedDate.toLocaleString()) : ''}

--- a/webui/src/pages/extension-detail/extension-detail.tsx
+++ b/webui/src/pages/extension-detail/extension-detail.tsx
@@ -87,6 +87,30 @@ const detailStyles = (theme: Theme) => createStyles({
     avatar: {
         width: '20px',
         height: '20px'
+    },
+    headerWrapper: {
+        [theme.breakpoints.down('sm')]: {
+            flexDirection: 'column',
+            textAlign: 'center',
+            fontSize: '85%',
+        },
+        '& > *': {
+            '&:first-child': {
+                [theme.breakpoints.up('md')]: {
+                    marginRight: '2rem'
+                }
+            }
+        }
+    },
+    info: {
+        [theme.breakpoints.down('sm')]: {
+            justifyContent: 'center'
+        }
+    },
+    count: {
+        [theme.breakpoints.down('sm')]: {
+            justifyContent: 'center'
+        }
     }
 });
 
@@ -141,8 +165,8 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
                     color: extension.galleryTheme === 'dark' ? '#ffffff' : undefined
                 }} >
                 <Container maxWidth='lg'>
-                    <Box display='flex' py={4}>
-                        <Box display='flex' justifyContent='center' alignItems='center' mr={4}>
+                    <Box display='flex' py={4} className={this.props.classes.headerWrapper}>
+                        <Box display='flex' justifyContent='center' alignItems='center'>
                             <img src={extension.files.icon || this.props.pageSettings.extensionDefaultIconURL}
                                 width='auto'
                                 height='120px'
@@ -184,10 +208,10 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
         return <Box overflow='auto'>
             <Typography variant='h5' className={this.props.classes.titleRow}>
                 {extension.displayName || extension.name} {extension.preview ?
-                    <span className={`${this.props.classes.preview} ${themeClass}`}>preview</span>
+                    <span className={`${this.props.classes.preview} ${themeClass}`}>preview!!!!</span>
                     : ''}
             </Typography>
-            <Box display='flex' className={themeClass}>
+            <Box display='flex' className={`${themeClass} ${this.props.classes.info}`}>
                 <Box className={this.props.classes.alignVertically} >
                     {this.renderAccessInfo(extension, themeClass)}&nbsp;<RouteLink
                         to={addQuery(ExtensionListRoutes.MAIN, [{ key: 'search', value: extension.namespace}])}
@@ -217,7 +241,7 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
             <Box mt={2} mb={2} overflow='auto'>
                 <Typography classes={{ root: this.props.classes.description }}>{extension.description}</Typography>
             </Box>
-            <Box display='flex' className={themeClass}>
+            <Box display='flex' className={`${themeClass} ${this.props.classes.count}`}>
                 <Box className={this.props.classes.alignVertically}>
                     <SaveAltIcon fontSize='small'/>&nbsp;{extension.downloadCount || 0}&nbsp;{extension.downloadCount === 1 ? 'download' : 'downloads'}
                 </Box>


### PR DESCRIPTION
This is how it looks now:

![image](https://user-images.githubusercontent.com/46004116/78736820-84832100-7967-11ea-8898-2da376548eef.png)

![image](https://user-images.githubusercontent.com/46004116/78736874-a381b300-7967-11ea-89a3-ca834aebe64c.png)
