### PR TITLE
adjust [extension-detail] page for small devices.

### DIFF
--- a/webui/src/main.css
+++ b/webui/src/main.css
@@ -1,3 +1,7 @@
 html, body, #main, .extension-list-container {
     height: 100%;
 }
+
+img {
+    object-fit: contain;
+}

--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -26,6 +26,19 @@ import { PageSettings } from "../../page-settings";
 import { ExtensionDetailRoutes } from "./extension-detail";
 
 const overviewStyles = (theme: Theme) => createStyles({
+    overview: {
+        display: 'flex',
+        [theme.breakpoints.down('lg')]: {
+            flexDirection: 'column',
+        }
+    },
+    resourcesWrapper: {
+        margin: "4rem 0",
+        width: "100%",
+        [theme.breakpoints.up('lg')]: {
+            margin: '0 0 0 4.8rem',
+        }
+    },
     link: {
         textDecoration: 'none',
         color: theme.palette.primary.contrastText,
@@ -65,7 +78,13 @@ const overviewStyles = (theme: Theme) => createStyles({
     },
     code: {
         fontFamily: 'monospace',
-        fontSize: '1rem'
+        fontSize: '.85rem',
+        [theme.breakpoints.down('lg')]: {
+            fontSize: '.7rem'
+        }
+    },
+    moreInfo: {
+        maxWidth: '30rem',
     }
 });
 
@@ -99,17 +118,17 @@ class ExtensionDetailOverviewComponent extends React.Component<ExtensionDetailOv
 
     render() {
         if (!this.state.readme) {
-            return <DelayedLoadIndicator loading={this.state.loading}/>;
+            return <DelayedLoadIndicator loading={this.state.loading} />;
         }
         const { classes, extension } = this.props;
         const zonedDate = toLocalTime(extension.timestamp);
         return <React.Fragment>
-            <Box display='flex' >
+            <Box className={this.props.classes.overview}>
                 <Box className={classes.markdown} flex={5} overflow="auto">
                     {this.renderMarkdown(this.state.readme)}
                 </Box>
                 <Box flex={3} display='flex' justifyContent='flex-end' minWidth='290px'>
-                    <Box width='80%'>
+                    <Box className={this.props.classes.resourcesWrapper}>
                         {this.renderButtonList('category', 'Categories', extension.categories)}
                         <Box mt={2}>
                             {this.renderButtonList('search', 'Tags', extension.tags)}
@@ -138,13 +157,13 @@ class ExtensionDetailOverviewComponent extends React.Component<ExtensionDetailOv
                                 {extension.dependencies!.map(ref => this.renderExtensionRef(ref))}
                             </Box>
                         </Optional>
-                        <Box mt={2}>
+                        <Box mt={2} className={this.props.classes.moreInfo}>
                             <Typography variant='h6'>More Info</Typography>
                             {extension.version ? this.renderInfo('Version', extension.version + (extension.preview ? ' (preview)' : '')) : ''}
                             {zonedDate ? this.renderInfo('Released on', zonedDate.toLocaleString()) : ''}
                             {this.renderInfo('Namespace',
                                 <RouteLink
-                                    to={addQuery(ExtensionListRoutes.MAIN, [{ key: 'search', value: extension.namespace}])}
+                                    to={addQuery(ExtensionListRoutes.MAIN, [{ key: 'search', value: extension.namespace }])}
                                     className={this.props.classes.link}>
                                     {extension.namespace}
                                 </RouteLink>)}
@@ -199,16 +218,16 @@ class ExtensionDetailOverviewComponent extends React.Component<ExtensionDetailOv
             <Link href={href} target='_blank' variant='body2' color='secondary'
                 className={this.props.classes.resourceLink} >
                 <Optional enabled={label === 'Homepage'}>
-                    <HomeIcon fontSize='small'/>&nbsp;
+                    <HomeIcon fontSize='small' />&nbsp;
                 </Optional>
                 <Optional enabled={label === 'Repository' && href.startsWith('https://github.com/')}>
-                    <GitHubIcon fontSize='small'/>&nbsp;
+                    <GitHubIcon fontSize='small' />&nbsp;
                 </Optional>
                 <Optional enabled={label === 'Bugs'}>
-                    <BugReportIcon fontSize='small'/>&nbsp;
+                    <BugReportIcon fontSize='small' />&nbsp;
                 </Optional>
                 <Optional enabled={label === 'Q\'n\'A'}>
-                    <QuestionAnswerIcon fontSize='small'/>&nbsp;
+                    <QuestionAnswerIcon fontSize='small' />&nbsp;
                 </Optional>
                 {label}
             </Link>

--- a/webui/src/pages/extension-detail/extension-detail.tsx
+++ b/webui/src/pages/extension-detail/extension-detail.tsx
@@ -71,6 +71,10 @@ const detailStyles = (theme: Theme) => createStyles({
         display: 'flex',
         alignItems: 'center'
     },
+    extensionLogo: {
+        height: '7.5rem',
+        maxWidth: '9rem'
+    },
     preview: {
         fontSize: '0.6em',
         fontStyle: 'italic',
@@ -168,8 +172,7 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
                     <Box display='flex' py={4} className={this.props.classes.headerWrapper}>
                         <Box display='flex' justifyContent='center' alignItems='center'>
                             <img src={extension.files.icon || this.props.pageSettings.extensionDefaultIconURL}
-                                width='auto'
-                                height='120px'
+                                className={this.props.classes.extensionLogo}
                                 alt={extension.displayName || extension.name} />
                         </Box>
                         {this.renderHeader(extension)}

--- a/webui/src/pages/extension-detail/extension-detail.tsx
+++ b/webui/src/pages/extension-detail/extension-detail.tsx
@@ -87,6 +87,30 @@ const detailStyles = (theme: Theme) => createStyles({
     avatar: {
         width: '20px',
         height: '20px'
+    },
+    headerWrapper: {
+        [theme.breakpoints.down('sm')]: {
+            flexDirection: 'column',
+            textAlign: 'center',
+            fontSize: '85%',
+        },
+        '& > *': {
+            '&:first-child': {
+                [theme.breakpoints.up('md')]: {
+                    marginRight: '2rem'
+                }
+            }
+        }
+    },
+    info: {
+        [theme.breakpoints.down('sm')]: {
+            justifyContent: 'center'
+        }
+    },
+    count: {
+        [theme.breakpoints.down('sm')]: {
+            justifyContent: 'center'
+        }
     }
 });
 
@@ -132,17 +156,17 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
     render() {
         const { extension } = this.state;
         if (!extension) {
-            return <DelayedLoadIndicator loading={this.state.loading}/>;
+            return <DelayedLoadIndicator loading={this.state.loading} />;
         }
 
         return <React.Fragment>
             <Box className={this.props.classes.head} style={{
-                    backgroundColor: extension.galleryColor,
-                    color: extension.galleryTheme === 'dark' ? '#ffffff' : undefined
-                }} >
+                backgroundColor: extension.galleryColor,
+                color: extension.galleryTheme === 'dark' ? '#ffffff' : undefined
+            }} >
                 <Container maxWidth='lg'>
-                    <Box display='flex' py={4}>
-                        <Box display='flex' justifyContent='center' alignItems='center' mr={4}>
+                    <Box display='flex' py={4} className={this.props.classes.headerWrapper}>
+                        <Box display='flex' justifyContent='center' alignItems='center'>
                             <img src={extension.files.icon || this.props.pageSettings.extensionDefaultIconURL}
                                 width='auto'
                                 height='120px'
@@ -155,7 +179,7 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
             <Container maxWidth='lg'>
                 <Box>
                     <Box>
-                        <ExtensionDetailTabs/>
+                        <ExtensionDetailTabs />
                     </Box>
                     <Box>
                         <Switch>
@@ -187,48 +211,48 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
                     <span className={`${this.props.classes.preview} ${themeClass}`}>preview</span>
                     : ''}
             </Typography>
-            <Box display='flex' className={themeClass}>
+            <Box display='flex' className={`${themeClass} ${this.props.classes.info}`}>
                 <Box className={this.props.classes.alignVertically} >
                     {this.renderAccessInfo(extension, themeClass)}&nbsp;<RouteLink
-                        to={addQuery(ExtensionListRoutes.MAIN, [{ key: 'search', value: extension.namespace}])}
+                        to={addQuery(ExtensionListRoutes.MAIN, [{ key: 'search', value: extension.namespace }])}
                         className={`${this.props.classes.link} ${themeClass}`}
                         title={`Namespace: ${extension.namespace}`} >
                         {extension.namespace}
                     </RouteLink>
                 </Box>
-                <TextDivider theme={extension.galleryTheme}/>
+                <TextDivider theme={extension.galleryTheme} />
                 <Box className={this.props.classes.alignVertically}>
                     Published&nbsp;by&nbsp;<Link href={extension.publishedBy.homepage}
                         className={`${this.props.classes.link} ${themeClass} ${this.props.classes.alignVertically}`}>{
-                        extension.publishedBy.avatarUrl ?
-                        <React.Fragment>
-                            {extension.publishedBy.loginName}&nbsp;<Avatar
-                                src={extension.publishedBy.avatarUrl}
-                                alt={extension.publishedBy.loginName}
-                                variant='circle'
-                                classes={{ root: this.props.classes.avatar }} />
-                        </React.Fragment>
-                        : extension.publishedBy.loginName
-                    }</Link>
+                            extension.publishedBy.avatarUrl ?
+                                <React.Fragment>
+                                    {extension.publishedBy.loginName}&nbsp;<Avatar
+                                        src={extension.publishedBy.avatarUrl}
+                                        alt={extension.publishedBy.loginName}
+                                        variant='circle'
+                                        classes={{ root: this.props.classes.avatar }} />
+                                </React.Fragment>
+                                : extension.publishedBy.loginName
+                        }</Link>
                 </Box>
-                <TextDivider theme={extension.galleryTheme}/>
+                <TextDivider theme={extension.galleryTheme} />
                 <Box className={this.props.classes.alignVertically}>{this.renderLicense(extension, themeClass)}</Box>
             </Box>
             <Box mt={2} mb={2} overflow='auto'>
                 <Typography classes={{ root: this.props.classes.description }}>{extension.description}</Typography>
             </Box>
-            <Box display='flex' className={themeClass}>
+            <Box display='flex' className={`${themeClass} ${this.props.classes.count}`}>
                 <Box className={this.props.classes.alignVertically}>
-                    <SaveAltIcon fontSize='small'/>&nbsp;{extension.downloadCount || 0}&nbsp;{extension.downloadCount === 1 ? 'download' : 'downloads'}
+                    <SaveAltIcon fontSize='small' />&nbsp;{extension.downloadCount || 0}&nbsp;{extension.downloadCount === 1 ? 'download' : 'downloads'}
                 </Box>
-                <TextDivider theme={extension.galleryTheme}/>
+                <TextDivider theme={extension.galleryTheme} />
                 <RouteLink
                     to={createRoute([ExtensionDetailRoutes.ROOT, extension.namespace, extension.name, ExtensionDetailRoutes.TAB_REVIEWS])}
                     className={`${this.props.classes.link} ${themeClass}`}
                     title={
                         extension.averageRating !== undefined ?
-                        `Average rating: ${this.getRoundedRating(extension.averageRating)} out of 5`
-                        : 'Not rated yet'
+                            `Average rating: ${this.getRoundedRating(extension.averageRating)} out of 5`
+                            : 'Not rated yet'
                     }>
                     <Box className={this.props.classes.alignVertically}>
                         <ExportRatingStars number={extension.averageRating || 0} fontSize='small' />
@@ -248,11 +272,11 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
         let description: string;
         switch (extension.namespaceAccess) {
             case 'public':
-                icon = <PublicIcon fontSize='small'/>;
+                icon = <PublicIcon fontSize='small' />;
                 description = 'Everyone can publish to this namespace, so the identity of the publisher cannot be verified.';
                 break;
             case 'restricted':
-                icon = <VerifiedUserIcon fontSize='small'/>;
+                icon = <VerifiedUserIcon fontSize='small' />;
                 description = 'Only verified owners and contributors can publish to this namespace.';
                 break;
             default:
@@ -264,7 +288,7 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
                 {extension.namespace}
             </span>. {description}
             <Optional enabled={Boolean(this.props.pageSettings.namespaceAccessInfoURL)}>
-                <br/>Click on the icon to learn more.
+                <br />Click on the icon to learn more.
             </Optional>
         </Typography>;
 
@@ -290,8 +314,8 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
     protected renderLicense(extension: Extension, themeClass: string): React.ReactNode {
         if (extension.files.license) {
             return <Link
-                    href={extension.files.license}
-                    className={`${this.props.classes.link} ${themeClass}`} >
+                href={extension.files.license}
+                className={`${this.props.classes.link} ${themeClass}`} >
                 {extension.license || 'Provided license'}
             </Link>;
         } else {

--- a/webui/src/pages/extension-list/extension-list-item.tsx
+++ b/webui/src/pages/extension-list/extension-list-item.tsx
@@ -33,7 +33,6 @@ const itemStyles = (theme: Theme) => createStyles({
     img: {
         width: '5rem',
         maxHeight: '5.8rem',
-        objectFit: 'contain',
     }
 });
 


### PR DESCRIPTION
Fixes #56 

This is how it looks now:

![image](https://user-images.githubusercontent.com/46004116/78736820-84832100-7967-11ea-8898-2da376548eef.png)

![image](https://user-images.githubusercontent.com/46004116/78736874-a381b300-7967-11ea-89a3-ca834aebe64c.png)
