### PR TITLE
[user-settings] make user profile + tokens responsive for small devices.

### DIFF
--- a/webui/src/pages/user/user-setting-tabs.tsx
+++ b/webui/src/pages/user/user-setting-tabs.tsx
@@ -9,35 +9,41 @@
  ********************************************************************************/
 
 import * as React from "react";
-import { Tabs, Tab } from "@material-ui/core";
+import { Tabs, Tab, useTheme, useMediaQuery } from "@material-ui/core";
 import { RouteComponentProps } from "react-router-dom";
 import { createRoute } from "../../utils";
 import { ExtensionRaw } from "../../extension-registry-types";
 import { UserSettingsRoutes } from "./user-settings";
 
-export class UserSettingTabs extends React.Component<UserSettingTabs.Props> {
+export const UserSettingTabs = (props: UserSettingTabs.Props) => {
 
-    protected resolvedRoute: string[];
+    const theme = useTheme();
+    const isATablet = useMediaQuery(theme.breakpoints.down('md'));
+    const isAMobile = useMediaQuery(theme.breakpoints.down('sm'));
+    const params = props.match.params as UserSettingTabs.Params;
 
-    protected handleChange = (event: React.ChangeEvent, newTab: string) => {
-        this.props.history.push(this.createRoute(newTab));
-        this.setState({ tab: newTab });
-    }
+    const handleChange = (event: React.ChangeEvent, newTab: string) => {
+        props.history.push(generateRoute(newTab));
+    };
 
-    protected createRoute(tab: string) {
+    const generateRoute = (tab: string) => {
         return createRoute([UserSettingsRoutes.ROOT, tab]);
-    }
+    };
 
-    render() {
-        const params = this.props.match.params as UserSettingTabs.Params;
-        return <React.Fragment>
-            <Tabs value={params.tab} onChange={this.handleChange} orientation='vertical'>
+    return (
+        <React.Fragment>
+            <Tabs
+                value={params.tab}
+                onChange={handleChange}
+                orientation={isATablet ? 'horizontal' : 'vertical'}
+                centered={isAMobile ? true : false}
+            >
                 <Tab value='profile' label='Profile' />
                 <Tab value='tokens' label='Access Tokens' />
             </Tabs>
-        </React.Fragment>;
-    }
-}
+        </React.Fragment>
+    );
+};
 
 export namespace UserSettingTabs {
     export interface Props extends RouteComponentProps {

--- a/webui/src/pages/user/user-settings-profile.tsx
+++ b/webui/src/pages/user/user-settings-profile.tsx
@@ -14,9 +14,32 @@ import { UserData } from "../../extension-registry-types";
 import { ExtensionRegistryService } from "../../extension-registry-service";
 
 const profileStyle = (theme: Theme) => createStyles({
+    profile: {
+        [theme.breakpoints.up('lg')]: {
+            justifyContent: 'space-between'
+        },
+        ['@media(max-width: 1040px)']: {
+            flexDirection: 'row-reverse',
+            justifyContent: 'flex-end',
+            '& > div:first-of-type': {
+                marginLeft: '2rem'
+            }
+        },
+        [theme.breakpoints.down('sm')]: {
+            textAlign: 'center',
+            flexDirection: 'column-reverse',
+            '& > div:first-of-type': {
+                marginLeft: '0',
+                marginTop: '2rem'
+            }
+        }
+    },
     avatar: {
         width: '150px',
-        height: '150px'
+        height: '150px',
+        [theme.breakpoints.down('sm')]: {
+            margin: '0 auto',
+        }
     }
 });
 
@@ -30,13 +53,13 @@ class UserSettingsProfileComponent extends React.Component<UserSettingsProfileCo
 
     render() {
         return <React.Fragment>
-            <Grid container>
-                <Grid item md={9}>
+            <Grid container className={this.props.classes.profile}>
+                <Grid item>
                     <Typography variant='h5' gutterBottom>Profile</Typography>
                     <Typography variant='body1'>Login name: {this.props.user.loginName}</Typography>
                     <Typography variant='body1'>Full name: {this.props.user.fullName}</Typography>
                 </Grid>
-                <Grid item md={3}>
+                <Grid item>
                     <Avatar classes={{ root: this.props.classes.avatar }} variant='rounded' src={this.props.user.avatarUrl} />
                 </Grid>
             </Grid>

--- a/webui/src/pages/user/user-settings-tokens.tsx
+++ b/webui/src/pages/user/user-settings-tokens.tsx
@@ -18,6 +18,21 @@ import { ExtensionRegistryService } from "../../extension-registry-service";
 import { GenerateTokenDialog } from "./generate-token-dialog";
 
 const tokensStyle = (theme: Theme) => createStyles({
+    header: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        [theme.breakpoints.down('sm')]: {
+            flexDirection: 'column',
+            alignItems: 'center'
+        }
+    },
+    buttons: {
+        display: 'flex',
+        flexWrap: 'wrap',
+        [theme.breakpoints.down('sm')]: {
+            justifyContent: 'center'
+        }
+    },
     description: {
         fontWeight: 'bold',
         overflow: 'hidden',
@@ -78,12 +93,12 @@ class UserSettingsTokensComponent extends React.Component<UserSettingsTokensComp
 
     render() {
         return <React.Fragment>
-            <Box display='flex' justifyContent='space-between'>
+            <Box className={this.props.classes.header}>
                 <Box>
                     <Typography variant='h5' gutterBottom>Access Tokens</Typography>
                 </Box>
-                <Box display='flex'>
-                    <Box mr={1}>
+                <Box className={this.props.classes.buttons}>
+                    <Box mr={1} mb={1}>
                         <GenerateTokenDialog
                             handleTokenGenerated={this.handleTokenGenerated}
                             service={this.props.service}

--- a/webui/src/pages/user/user-settings.tsx
+++ b/webui/src/pages/user/user-settings.tsx
@@ -28,7 +28,23 @@ export namespace UserSettingsRoutes {
 }
 
 const profileStyles = (theme: Theme) => createStyles({
-
+    container: {
+        [theme.breakpoints.down('md')]: {
+            flexDirection: 'column'
+        }
+    },
+    tabs: {
+        [theme.breakpoints.down('lg')]: {
+            marginBottom: '3rem'
+        },
+    },
+    info: {
+        [theme.breakpoints.up('lg')]: {
+            paddingTop: '.5rem',
+            paddingLeft: '3rem',
+            flex: '1'
+        }
+    }
 });
 
 class UserSettingsComponent extends React.Component<UserSettingsComponent.Props> {
@@ -52,12 +68,12 @@ class UserSettingsComponent extends React.Component<UserSettingsComponent.Props>
         return <React.Fragment>
             <Container>
                 <Box mt={6}>
-                    <Grid container>
-                        <Grid item md={2}>
+                    <Grid container className={this.props.classes.container}>
+                        <Grid item className={this.props.classes.tabs}>
                             <UserSettingTabs {...this.props} />
                         </Grid>
-                        <Grid item md={10}>
-                            <Box pt={1} pl={6}>
+                        <Grid item className={this.props.classes.info}>
+                            <Box>
                                 <Route path={UserSettingsRoutes.PROFILE}>
                                     <UserSettingsProfile service={this.props.service} user={user} />
                                 </Route>


### PR DESCRIPTION
Fixes #71 #72


This is how it looks at mobile size:

![image](https://user-images.githubusercontent.com/46004116/78962105-082a4280-7b0d-11ea-974a-ea80c2d485f1.png)

![image](https://user-images.githubusercontent.com/46004116/78962158-2b54f200-7b0d-11ea-80a6-6d10deb4dde7.png)

tablet size:

![image](https://user-images.githubusercontent.com/46004116/78962082-f21c8200-7b0c-11ea-9b27-b892ab16f598.png)

![image](https://user-images.githubusercontent.com/46004116/78962204-43c50c80-7b0d-11ea-983b-231f7c1b9b21.png)


Signed-off-by: Nisar Hassan Naqvi <syednisarhassan12@gmail.com>