### PR TITLE
[extension-list-item] reduce the title font size.

### DIFF
--- a/webui/src/pages/extension-list/extension-list-item.tsx
+++ b/webui/src/pages/extension-list/extension-list-item.tsx
@@ -21,18 +21,23 @@ import { PageSettings } from "../../page-settings";
 
 const itemStyles = (theme: Theme) => createStyles({
     extensionCard: {
-        maxWidth: '12.875rem',
+        maxWidth: '14.875rem',
         minWidth: '11.875rem',
     },
     paper: {
         padding: theme.spacing(3, 2),
+        '& > *': {
+            '&:not(:last-child)': {
+                marginBottom: '.5rem',
+            }
+        }
     },
     link: {
         textDecoration: 'none'
     },
     img: {
-        width: '5rem',
-        maxHeight: '5.8rem',
+        width: '4.5rem',
+        maxHeight: '5.4rem',
     }
 });
 
@@ -51,7 +56,7 @@ class ExtensionListItemComponent extends React.Component<ExtensionListItemCompon
                                     alt={extension.displayName || extension.name} />
                             </Box>
                             <Box display='flex' justifyContent='center'>
-                                <Typography variant='h6' noWrap style={{fontSize: '1rem'}}>
+                                <Typography variant='h6' noWrap style={{fontSize: '1.15rem'}}>
                                     {extension.displayName || extension.name}
                                 </Typography>
                             </Box>
@@ -64,7 +69,7 @@ class ExtensionListItemComponent extends React.Component<ExtensionListItemCompon
                                 </Typography>
                             </Box>
                             <Box display='flex' justifyContent='center'>
-                                <ExportRatingStars number={extension.averageRating || 0} />
+                                <ExportRatingStars number={extension.averageRating || 0} fontSize="small"/>
                             </Box>
                         </Paper>
                     </RouteLink>

--- a/webui/src/pages/extension-list/extension-list-item.tsx
+++ b/webui/src/pages/extension-list/extension-list-item.tsx
@@ -25,7 +25,7 @@ const itemStyles = (theme: Theme) => createStyles({
         minWidth: '11.875rem',
     },
     paper: {
-        padding: theme.spacing(3, 2)
+        padding: theme.spacing(3, 2),
     },
     link: {
         textDecoration: 'none'
@@ -51,7 +51,7 @@ class ExtensionListItemComponent extends React.Component<ExtensionListItemCompon
                                     alt={extension.displayName || extension.name} />
                             </Box>
                             <Box display='flex' justifyContent='center'>
-                                <Typography variant='h6' noWrap>
+                                <Typography variant='h6' noWrap style={{fontSize: '1rem'}}>
                                     {extension.displayName || extension.name}
                                 </Typography>
                             </Box>

--- a/webui/src/pages/extension-list/extension-list.tsx
+++ b/webui/src/pages/extension-list/extension-list.tsx
@@ -148,7 +148,7 @@ export class ExtensionListComponent extends React.Component<ExtensionListCompone
                 loader={loader}
                 threshold={200}
                 useWindow={false} >
-                <Container>
+                <Container maxWidth="xl">
                     <Grid container spacing={2} className={this.props.classes.container}>
                         {extensionList}
                     </Grid>


### PR DESCRIPTION
Fixes #64 

This is how it looks with the change in place.

![image](https://user-images.githubusercontent.com/46004116/78963216-4117e680-7b10-11ea-861f-69aaaa22e00e.png)

It is better than before but there are still some papers where the ellipsis is still there.
![image](https://user-images.githubusercontent.com/46004116/78963315-863c1880-7b10-11ea-9908-3df24817c58f.png) 
