### PR TITLE
Use white-space: 'pre' instead of 'pre-line' for code tags now.

### DIFF
--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -59,7 +59,7 @@ const overviewStyles = (theme: Theme) => createStyles({
             maxWidth: '100%'
         },
         '& code': {
-            whiteSpace: 'pre-line'
+            whiteSpace: 'pre'
         }
     },
     resourceLink: {


### PR DESCRIPTION
Fixes eclipse/openvsx#69