### PR TITLE
fix elasticsearch search error when no extension is published

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/search/SearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/SearchService.java
@@ -180,7 +180,7 @@ public class SearchService {
 
         // Configure default sorting of results
         queryBuilder.withSort(SortBuilders.scoreSort());
-        queryBuilder.withSort(SortBuilders.fieldSort("relevance").order(SortOrder.DESC));
+        queryBuilder.withSort(SortBuilders.fieldSort("relevance").unmappedType("float").order(SortOrder.DESC));
 
         try {
             rwLock.readLock().lock();


### PR DESCRIPTION
When no extension is published and elasticsearch search,  an error will occur

```
{
    "error":{
        "root_cause":[
            {
                "type":"query_shard_exception",
                "reason":"No mapping found for [relevance] in order to sort on",
                "index_uuid":"QeBIwqzCQZ6rMtavW-WBVA",
                "index":"extensions"
            }
        ],
        "type":"search_phase_execution_exception",
        "reason":"all shards failed",
        "phase":"dfs",
        "grouped":true,
        "failed_shards":[
            {
                "shard":0,
                "index":"extensions",
                "node":"-_gAqPHiTLObSesuEKIP7A",
                "reason":{
                    "type":"query_shard_exception",
                    "reason":"No mapping found for [relevance] in order to sort on",
                    "index_uuid":"QeBIwqzCQZ6rMtavW-WBVA",
                    "index":"extensions"
                }
            }
        ]
    },
    "status":400
}
```
