### PR TITLE
Privileged publishing, info banners for extensions

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -435,6 +435,9 @@ public class LocalRegistryService implements IExtensionRegistry {
         var extension = extVersion.getExtension();
         var json = extVersion.toExtensionJson();
         json.namespaceAccess = getAccessString(extension.getNamespace());
+        if (NamespaceJson.RESTRICTED_ACCESS.equals(json.namespaceAccess)) {
+            json.unrelatedPublisher = isUnrelatedPublisher(extVersion);
+        }
         json.reviewCount = repositories.countActiveReviews(extension);
         var serverUrl = UrlUtil.getBaseUrl();
         json.namespaceUrl = createApiUrl(serverUrl, "api", json.namespace);
@@ -463,6 +466,15 @@ public class LocalRegistryService implements IExtensionRegistry {
             });
         }
         return json;
+    }
+
+    private boolean isUnrelatedPublisher(ExtensionVersion extVersion) {
+        if (extVersion.getPublishedWith() == null)
+            return false;
+        var user = extVersion.getPublishedWith().getUser();
+        var namespace = extVersion.getExtension().getNamespace();
+        var membership = repositories.findMembership(user, namespace);
+        return membership == null;
     }
 
 }

--- a/server/src/main/java/org/eclipse/openvsx/UserService.java
+++ b/server/src/main/java/org/eclipse/openvsx/UserService.java
@@ -108,6 +108,11 @@ public class UserService {
     }
 
     public boolean hasPublishPermission(UserData user, Namespace namespace) {
+        if (UserData.ROLE_PRIVILEGED.equals(user.getRole())) {
+            // Privileged users can publish to every namespace.
+            return true;
+        }
+
         var ownerships = repositories.findMemberships(namespace, NamespaceMembership.ROLE_OWNER);
         if (ownerships.isEmpty()) {
             // If the namespace has no owner, everyone has publish permission to it.

--- a/server/src/main/java/org/eclipse/openvsx/entities/UserData.java
+++ b/server/src/main/java/org/eclipse/openvsx/entities/UserData.java
@@ -23,6 +23,7 @@ import org.eclipse.openvsx.json.UserJson;
 public class UserData {
 
     public static final String ROLE_ADMIN = "admin";
+    public static final String ROLE_PRIVILEGED = "privileged";
 
     @Id
     @GeneratedValue

--- a/server/src/main/java/org/eclipse/openvsx/json/ExtensionJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/ExtensionJson.java
@@ -39,6 +39,8 @@ public class ExtensionJson extends ResultJson {
 
     public UserJson publishedBy;
 
+    public boolean unrelatedPublisher;
+
     // see constants in NamespaceJson
     public String namespaceAccess;
 

--- a/webui/dev/page-settings.tsx
+++ b/webui/dev/page-settings.tsx
@@ -104,14 +104,16 @@ export default function createPageSettings(theme: Theme, prefersDarkMode: boolea
 
     return {
         pageTitle: 'Open VSX Registry',
+        themeType: prefersDarkMode ? 'dark' : 'light',
         toolbarContent,
         footerContent,
         searchHeader,
         additionalRoutes,
         reportAbuse,
         claimNamespace,
-        extensionDefaultIconURL: '/default-icon.png',
-        namespaceAccessInfoURL: 'https://github.com/eclipse/openvsx/wiki/Namespace-Access',
-        themeType: prefersDarkMode ? 'dark' : 'light',
+        urls: {
+            extensionDefaultIcon: '/default-icon.png',
+            namespaceAccessInfo: 'https://github.com/eclipse/openvsx/wiki/Namespace-Access'
+        }
     };
 }

--- a/webui/src/custom-mui-components/text-divider.tsx
+++ b/webui/src/custom-mui-components/text-divider.tsx
@@ -29,7 +29,7 @@ const dividerStyles = (theme: Theme) => createStyles({
 
 export class TextDividerComponent extends React.Component<TextDividerComponent.Props> {
     render() {
-        const themeClass = this.props.theme === 'dark' ? this.props.classes.darkTheme : this.props.classes.lightTheme;
+        const themeClass = this.props.themeType === 'dark' ? this.props.classes.darkTheme : this.props.classes.lightTheme;
         return <Divider orientation='vertical' classes={{
             root: `${this.props.classes.root} ${themeClass}`
         }} />;
@@ -38,7 +38,7 @@ export class TextDividerComponent extends React.Component<TextDividerComponent.P
 
 export namespace TextDividerComponent {
     export interface Props extends WithStyles<typeof dividerStyles> {
-        theme?: 'light' | 'dark';
+        themeType?: 'light' | 'dark';
     }
 }
 

--- a/webui/src/extension-registry-types.ts
+++ b/webui/src/extension-registry-types.ts
@@ -48,6 +48,7 @@ export interface Extension extends ExtensionRaw {
     readonly reviewsUrl: UrlString;
 
     readonly publishedBy: UserData;
+    readonly unrelatedPublisher: boolean;
     readonly namespaceAccess: 'public' | 'restricted';
 
     readonly allVersions: { [version: string]: UrlString };

--- a/webui/src/page-settings.ts
+++ b/webui/src/page-settings.ts
@@ -13,15 +13,17 @@ import { Extension } from "./extension-registry-types";
 
 export interface PageSettings {
     pageTitle: string;
+    themeType?: 'light' | 'dark';
     toolbarContent?: React.FunctionComponent;
     footerContent?: React.FunctionComponent;
     searchHeader?: React.FunctionComponent,
     reportAbuse?: React.FunctionComponent<{ extension: Extension } & Styleable>;
     claimNamespace?: React.FunctionComponent<{ extension: Extension } & Styleable>;
     additionalRoutes?: React.FunctionComponent,
-    extensionDefaultIconURL?: string;
-    namespaceAccessInfoURL?: string;
-    themeType?: 'light' | 'dark';
+    urls: {
+        extensionDefaultIcon: string;
+        namespaceAccessInfo: string;
+    }
 }
 
 export interface Styleable {

--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -197,7 +197,13 @@ class ExtensionDetailOverviewComponent extends React.Component<ExtensionDetailOv
                                     className={this.props.classes.link}>
                                     {extension.namespace}
                                 </RouteLink>)}
-                            {this.renderInfo('Access Type', this.renderAccessInfo(extension))}
+                            {this.renderInfo('Access Type',
+                                <Link
+                                    href={this.props.pageSettings.urls.namespaceAccessInfo}
+                                    target='_blank'
+                                    className={this.props.classes.link}>
+                                    {extension.namespaceAccess || 'unknown'}
+                                </Link>)}
                         </Box>
                         <Box mt={2}>
                             {ClaimNamespace ? <ClaimNamespace extension={extension} className={this.props.classes.resourceLink} /> : ''}
@@ -274,20 +280,6 @@ class ExtensionDetailOverviewComponent extends React.Component<ExtensionDetailOv
                 <Typography variant='body2'>{value}</Typography>
             </Box>
         </Box>;
-    }
-
-    protected renderAccessInfo(extension: Extension): React.ReactNode {
-        const text = extension.namespaceAccess || 'unknown';
-        if (this.props.pageSettings.namespaceAccessInfoURL) {
-            return <Link
-                href={this.props.pageSettings.namespaceAccessInfoURL}
-                target='_blank'
-                className={this.props.classes.link}>
-                {text}
-            </Link>;
-        } else {
-            return text;
-        }
     }
 
     protected renderMarkdown(md: string): React.ReactNode {

--- a/webui/src/pages/extension-detail/extension-detail.tsx
+++ b/webui/src/pages/extension-detail/extension-detail.tsx
@@ -114,6 +114,7 @@ const detailStyles = (theme: Theme) => createStyles({
     banner: {
         margin: `0 ${theme.spacing(6)}px ${theme.spacing(4)}px ${theme.spacing(6)}px`,
         padding: theme.spacing(2),
+        display: 'flex',
         [theme.breakpoints.down('sm')]: {
             margin: `0 0 ${theme.spacing(2)}px 0`,
         }
@@ -121,7 +122,7 @@ const detailStyles = (theme: Theme) => createStyles({
     warningLight: {
         backgroundColor: theme.palette.warning.light,
         color: '#000',
-        '& > a': {
+        '& a': {
             color: '#000',
             fontWeight: 'bold'
         }
@@ -129,7 +130,7 @@ const detailStyles = (theme: Theme) => createStyles({
     warningDark: {
         backgroundColor: theme.palette.warning.dark,
         color: '#fff',
-        '& > a': {
+        '& a': {
             color: '#fff',
             fontWeight: 'bold'
         }
@@ -236,35 +237,39 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
         const classes = this.props.classes;
         const warningClass = themeType === 'dark' ? classes.warningDark : classes.warningLight;
         const themeClass = themeType === 'dark' ? classes.darkTheme : classes.lightTheme;
-        let extensionName = extension.displayName || extension.name;
-        if (!extensionName.toLowerCase().endsWith('extension')) {
-            extensionName += ' extension';
-        }
         if (extension.namespaceAccess === 'public') {
             return <Paper className={`${classes.banner} ${warningClass} ${themeClass}`}>
-                The namespace <span className={classes.code}>{extension.namespace}</span> is public,
-                which means that everyone can publish new versions of the {extensionName}.
-                If you would like to become the owner of <span className={classes.code}>{extension.namespace}</span>,
-                please <Link
-                    href={this.props.pageSettings.urls.namespaceAccessInfo}
-                    target='_blank'
-                    className={`${classes.link}`} >
-                    read this guide
-                </Link>.
+                <PublicIcon fontSize='large' />
+                <Box ml={1}>
+                    The namespace <span className={classes.code}>{extension.namespace}</span> is public,
+                    which means that everyone can publish new versions of
+                    the "{extension.displayName || extension.name}" extension.
+                    If you would like to become the owner of <span className={classes.code}>{extension.namespace}</span>,
+                    please <Link
+                        href={this.props.pageSettings.urls.namespaceAccessInfo}
+                        target='_blank'
+                        className={`${classes.link}`} >
+                        read this guide
+                    </Link>.
+                </Box>
             </Paper>;
         } else if (extension.unrelatedPublisher) {
             return <Paper className={`${classes.banner} ${warningClass} ${themeClass}`}>
-                The {extensionName} was published by <Link href={extension.publishedBy.homepage}
-                    className={`${classes.link}`}>
-                    {extension.publishedBy.loginName}
-                </Link>. This user account is not related to
-                the namespace <span className={classes.code}>{extension.namespace}</span> of
-                this extension. <Link
-                    href={this.props.pageSettings.urls.namespaceAccessInfo}
-                    target='_blank'
-                    className={`${classes.link}`} >
-                    See the documentation
-                </Link> to learn how we handle namespaces.
+                <WarningIcon fontSize='large' />
+                <Box ml={1}>
+                    The "{extension.displayName || extension.name}" extension was published
+                    by <Link href={extension.publishedBy.homepage}
+                        className={`${classes.link}`}>
+                        {extension.publishedBy.loginName}
+                    </Link>. This user account is not related to
+                    the namespace <span className={classes.code}>{extension.namespace}</span> of
+                    this extension. <Link
+                        href={this.props.pageSettings.urls.namespaceAccessInfo}
+                        target='_blank'
+                        className={`${classes.link}`} >
+                        See the documentation
+                    </Link> to learn how we handle namespaces.
+                </Box>
             </Paper>;
         }
         return null;

--- a/webui/src/pages/extension-list/extension-list-item.tsx
+++ b/webui/src/pages/extension-list/extension-list-item.tsx
@@ -51,7 +51,7 @@ class ExtensionListItemComponent extends React.Component<ExtensionListItemCompon
                     <RouteLink to={route} className={classes.link}>
                         <Paper className={classes.paper}>
                             <Box display='flex' justifyContent='center' alignItems='center' width='100%' height={80}>
-                                <img src={extension.files.icon || this.props.pageSettings.extensionDefaultIconURL}
+                                <img src={extension.files.icon || this.props.pageSettings.urls.extensionDefaultIcon}
                                     className={classes.img}
                                     alt={extension.displayName || extension.name} />
                             </Box>


### PR DESCRIPTION
This PR adds two things:

 * A `privileged` user role that allows to publish to any namespace. We will use this for (any _only_ for) @open-vsx.
 * Two kinds of banners for extension detail pages:
   - namespace is public (it has no owner)
   - namespace is restricted (it has an owner), but the extension was published by a user who is not related to that namespace (neither owner nor contributor)

The second case can happen if
 * @open-vsx publishes to a restricted namespace with its privileged role.
 * A user publishes to a public namespace and then a different user is granted ownership of that namespace.
 * A contributor of a restricted namespace publishes an extension and then an owner removes her from that namespace via #96.