### PR TITLE
Fix sortOrder error thrown for VSCodium

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/search/SearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/SearchService.java
@@ -198,21 +198,15 @@ public class SearchService {
             queryBuilder.withFilter(QueryBuilders.matchPhraseQuery("categories", category));
         }
 
-        if (sortOrder == "asc") {
+        if (sortOrder == "asc" || sortOrder == 1) {
             sortOrder = "1";
-        } else if (sortOrder == "desc") {
+        } else if (sortOrder == "desc" || sortOrder == 0) {
             sortOrder = "0";
         }
 
-        if (sortOrder instanceof String) {
-            (int) sortOrder = Integer.parseInt(sortOrder);
-        } else {
-            logger.debug(sortOrder.getClass().getName());
-        }
-
-        if (!(sortOrder == 0) && !(sortOrder == 1)) {
+        if (!(sortOrder == "0") && !(sortOrder == "1")) {
             logger.error("value of sortOrder is {}", sortOrder);
-            throw new ErrorResultException("sortOrder parameter must be either 'asc' or 'desc'.");
+            throw new ErrorResultException("sortOrder parameter must be either 'asc' or 'desc', or '0' or '1'.");
         }
 
         if ("relevance".equals(sortBy)) {

--- a/server/src/main/java/org/eclipse/openvsx/search/SearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/SearchService.java
@@ -198,7 +198,20 @@ public class SearchService {
             queryBuilder.withFilter(QueryBuilders.matchPhraseQuery("categories", category));
         }
 
-        if (!"asc".equals(sortOrder) && !"desc".equals(sortOrder)) {
+        if (sortOrder == "asc") {
+            sortOrder = "1";
+        } else if (sortOrder == "desc") {
+            sortOrder = "0";
+        }
+
+        if (sortOrder instanceof String) {
+            sortOrder = Integer.parseInt(sortOrder);
+        } else {
+            logger.debug(sortOrder.getClass().getName());
+        }
+
+        if (!(sortOrder == 0) && !(sortOrder == 1)) {
+            logger.error("value of sortOrder is {}", sortOrder);
             throw new ErrorResultException("sortOrder parameter must be either 'asc' or 'desc'.");
         }
 

--- a/server/src/main/java/org/eclipse/openvsx/search/SearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/SearchService.java
@@ -205,7 +205,7 @@ public class SearchService {
         }
 
         if (sortOrder instanceof String) {
-            sortOrder = Integer.parseInt(sortOrder);
+            (int) sortOrder = Integer.parseInt(sortOrder);
         } else {
             logger.debug(sortOrder.getClass().getName());
         }

--- a/server/src/main/java/org/eclipse/openvsx/search/SearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/SearchService.java
@@ -198,9 +198,9 @@ public class SearchService {
             queryBuilder.withFilter(QueryBuilders.matchPhraseQuery("categories", category));
         }
 
-        if (sortOrder == "asc" || sortOrder == 1) {
+        if (sortOrder == "asc") {
             sortOrder = "1";
-        } else if (sortOrder == "desc" || sortOrder == 0) {
+        } else if (sortOrder == "desc") {
             sortOrder = "0";
         }
 

--- a/server/src/main/java/org/eclipse/openvsx/search/SearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/SearchService.java
@@ -198,13 +198,7 @@ public class SearchService {
             queryBuilder.withFilter(QueryBuilders.matchPhraseQuery("categories", category));
         }
 
-        if (sortOrder == "asc") {
-            sortOrder = "1";
-        } else if (sortOrder == "desc") {
-            sortOrder = "0";
-        }
-
-        if (!(sortOrder == "0") && !(sortOrder == "1")) {
+        if (!(sortOrder == "0" || sortOrder == "1") || !(sortOrder == "asc" || sortOrder == "desc")) {
             logger.error("value of sortOrder is {}", sortOrder);
             throw new ErrorResultException("sortOrder parameter must be either 'asc' or 'desc', or '0' or '1'.");
         }


### PR DESCRIPTION
Fixes #126 and https://github.com/VSCodium/vscodium/issues/418.

Reason for converting "asc" and "desc" to Strings first and then parsing to and int later is to support any other applications that might use vsx which use String values for sortOrder that aren't "asc" or "desc", such as "0" or "1".