### PR TITLE
Enhanced License detection

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/util/LicenseDetection.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/LicenseDetection.java
@@ -9,7 +9,11 @@
  ********************************************************************************/
 package org.eclipse.openvsx.util;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -23,9 +27,8 @@ import org.spdx.rdfparser.license.LicenseInfoFactory;
 
 public class LicenseDetection {
 
-    protected static final String[] DEFAULT_LICENSE_IDS = {
-        "MIT", "Apache-2.0", "Apache-1.1", "EPL-2.0", "EPL-1.0", "ISC", "BSD-2-Clause", "BSD-3-Clause"
-    };
+    protected static final String[] DEFAULT_LICENSE_IDS = { "MIT", "Apache-2.0", "Apache-1.1", "EPL-2.0", "EPL-1.0",
+            "ISC", "BSD-2-Clause", "BSD-3-Clause" };
 
     protected final Logger logger = LoggerFactory.getLogger(LicenseDetection.class);
 
@@ -55,6 +58,15 @@ public class LicenseDetection {
         try {
             for (var licenseId : licenseIds) {
                 var license = LicenseInfoFactory.getListedLicenseById(licenseId);
+                var resource = getClass().getResource("/spdx-templates/" + licenseId.toLowerCase() + ".txt");
+                if (resource != null) {
+                    try {
+                        var data = new String(Files.readAllBytes(Paths.get(resource.toURI())));
+                        license.setStandardLicenseTemplate(data);
+                    } catch (URISyntaxException | IOException e) {
+                        logger.error("Failed to load spdx template", e);
+                    } 
+                }
                 var diff = LicenseCompareHelper.isTextStandardLicense(license, content);
                 if (!diff.isDifferenceFound()) {
                     return license.getLicenseId();

--- a/server/src/main/resources/spdx-templates/mit.txt
+++ b/server/src/main/resources/spdx-templates/mit.txt
@@ -4,4 +4,11 @@
 
 Permission is hereby granted, free of charge, to any person obtaining a copy 
 of <<var;name="software";original="this software and associated documentation files";match="this software and associated documentation files|this source file">> 
-(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice<<beginOptional>> (including the next paragraph)<<endOptional>> shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL <<var;name="copyrightHolder";original="THE AUTHORS OR COPYRIGHT HOLDERS";match=".+">> BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+(the <<var;name="software2";original=""Software"";match="["]+Software["]+">>), to deal in the Software without restriction, including without 
+limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, 
+and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright 
+notice and this permission notice<<beginOptional>> (including the next paragraph)<<endOptional>> shall be included in all 
+copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED <<var;name="asis";original=""AS IS"";match="[*"]+AS IS[*"]+">>, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL <<var;name="copyrightHolder";original="THE AUTHORS OR COPYRIGHT HOLDERS";match=".+">> BE LIABLE FOR ANY CLAIM, 
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/server/src/main/resources/spdx-templates/mit.txt
+++ b/server/src/main/resources/spdx-templates/mit.txt
@@ -1,0 +1,7 @@
+<<beginOptional>> MIT License<<endOptional>> 
+
+<<var;name="copyright";original="Copyright (c) <year> <copyright holders>";match=".{0,1000}">> 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of <<var;name="software";original="this software and associated documentation files";match="this software and associated documentation files|this source file">> 
+(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice<<beginOptional>> (including the next paragraph)<<endOptional>> shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL <<var;name="copyrightHolder";original="THE AUTHORS OR COPYRIGHT HOLDERS";match=".+">> BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/server/src/test/resources/org/eclipse/openvsx/util/MIT.txt
+++ b/server/src/test/resources/org/eclipse/openvsx/util/MIT.txt
@@ -7,7 +7,7 @@ All rights reserved.
 MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of 
-this software and associated documentation files (the "Software"), to deal in 
+this software and associated documentation files (the ""Software""), to deal in 
 the Software without restriction, including without limitation the rights to 
 use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
 of the Software, and to permit persons to whom the Software is furnished to do 
@@ -16,7 +16,7 @@ so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all 
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 

--- a/server/src/test/resources/org/eclipse/openvsx/util/MIT.txt
+++ b/server/src/test/resources/org/eclipse/openvsx/util/MIT.txt
@@ -1,19 +1,25 @@
-Copyright 2020 Tim Test
+PowerShell for Visual Studio Code
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in 
+the Software without restriction, including without limitation the rights to 
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is furnished to do 
 so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
+The above copyright notice and this permission notice shall be included in all 
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
 SOFTWARE.

--- a/webui/yarn.lock
+++ b/webui/yarn.lock
@@ -116,14 +116,12 @@
     prop-types "^15.7.2"
     react-is "^16.8.0"
 
-"@material-ui/utils@^4.9.6":
-  version "4.9.6"
-  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.9.6.tgz#5f1f9f6e4df9c8b6a263293b68c94834248ff157"
-  integrity sha512-gqlBn0JPPTUZeAktn1rgMcy9Iczrr74ecx31tyZLVGdBGGzsxzM6PP6zeS7FuoLS6vG4hoZP7hWnOoHtkR0Kvw==
+"@types/dompurify@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-2.0.2.tgz#94b5c05dc9b8a682a0abb4a8d6f0b82df61baeac"
+  integrity sha512-WHoQQTziRHm5/Fw/KsUKyh2V+wd3k2QUpJyjUXo8K7d9kMJ5i5wQnGDkO4URkwulhY2HuM/gbX25nSooi6+wUA==
   dependencies:
-    "@babel/runtime" "^7.4.4"
-    prop-types "^15.7.2"
-    react-is "^16.8.0"
+    "@types/trusted-types" "*"
 
 "@types/history@*":
   version "4.7.5"
@@ -203,6 +201,11 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/trusted-types@*":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.4.tgz#922d092c84a776a59acb0bd6785fd82b59b9bad5"
+  integrity sha512-6jtHrHpmiXOXoJ31Cg9R+iEVwuEKPf0XHwFUI93eEPXx492/J2JHyafkleKE2EYzZprayk9FSjTyK1GDqcwDng==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -1111,6 +1114,11 @@ domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
+
+dompurify@^2.0.11:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.0.11.tgz#cd47935774230c5e478b183a572e726300b3891d"
+  integrity sha512-qVoGPjIW9IqxRij7klDQQ2j6nSe4UNWANBhZNLnsS7ScTtLb+3YdxkRY8brNTpkUiTtcXsCJO+jS0UCDfenLuA==
 
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"


### PR DESCRIPTION
This PR enhances the license detection regarding MIT licenses. 
As an example the license of https://open-vsx.org/extension/ms-vscode/powershell-preview does not fit to MIT licenses because of too much quotation marks (which do not alter the semantics at all). 
This is identified as valid license now.  