### PR TITLE
use multistage build to build open-vsx server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,6 @@ jobs:
         node-version: 10.x
     - name: Set up Yarn
       run: npm install --global yarn
-    - name: Set up Java JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
     - uses: actions/checkout@v2
     - name: Build Web UI
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,14 +29,7 @@ jobs:
     - name: Build CLI
       run: yarn --cwd cli
     - name: Build Server
-      run: |
-        server/gradlew --no-daemon -p server build
-        docker build -t $SERVER_TAG:$SERVER_VERSION server
-    - name: Upload Server Artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: openvsx-server
-        path: server/build/libs/openvsx-server.jar
+      run: docker build -t $SERVER_TAG:$SERVER_VERSION server
     - name: Push Docker Images
       run: |
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,3 +1,12 @@
+FROM gradle:jdk11 as builder
+
+COPY --chown=gradle:gradle . /home/gradle
+WORKDIR /home/gradle
+
+# Compile server
+RUN ./gradlew --no-daemon build
+
+
 FROM openjdk:11.0.7-jdk
 
 # Create user openvsx and set up home directory
@@ -7,11 +16,11 @@ USER openvsx
 WORKDIR /home/openvsx/server
 
 # Copy and unpack the server archive
-ADD --chown=openvsx:openvsx build/libs/openvsx-server.jar /home/openvsx/
+COPY --chown=openvsx:openvsx --from=builder /home/gradle/build/libs/openvsx-server.jar /home/openvsx/
 RUN jar -xf /home/openvsx/openvsx-server.jar && rm /home/openvsx/openvsx-server.jar
 
 # Copy the start script and make it executable
-ADD --chown=openvsx:openvsx scripts/run-server.sh ./
+COPY --chown=openvsx:openvsx scripts/run-server.sh ./
 RUN chmod u+x run-server.sh
 
 # Run sthe start script


### PR DESCRIPTION
# Changes
* Build the server within a container using a [multistage build](https://docs.docker.com/develop/develop-images/multistage-build/).
* Do not longer upload the raw `openvsx-server.jar` as GitHub action artifact
* Use the recommended `COPY` instead of `ADD` ([reference](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy))

# Related Issues
Fixes #118 
