### PR TITLE
Include Elasticsearch testcontainer for integration test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,22 @@ jobs:
         node-version: 10.x
     - name: Set up Yarn
       run: npm install --global yarn
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
     - uses: actions/checkout@v2
     - name: Build CLI
       run: yarn --cwd cli
     - name: Build Web UI Image
       run: docker build -t $WEB_UI_TAG:$WEB_UI_VERSION webui
+    - name: Run Server Tests
+      run: server/gradlew --no-daemon -p server check
+    - name: Upload Test Report
+      uses: actions/upload-artifact@v2
+      with:
+        name: server-test-report
+        path: server/build/reports/tests/
     - name: Build Server Image
       run: docker build -t $SERVER_TAG:$SERVER_VERSION server
     - name: Push Docker Images

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,10 +19,10 @@ ports:
 tasks:
 - init: |
     # Build all components
+    yarn --cwd cli
     yarn --cwd webui
     yarn --cwd webui build:default
-    yarn --cwd cli
-    server/gradlew -p server build downloadTestExtensions
+    server/gradlew -p server assemble downloadTestExtensions
   name: Server
   command: |
     if [[ $NPM_TOKEN ]]; then echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc; fi

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,8 +6,8 @@ COPY --chown=gradle:gradle gradlew *.gradle ./
 COPY --chown=gradle:gradle gradle ./gradle/
 COPY --chown=gradle:gradle src ./src/
 
-# Build and test the server application
-RUN ./gradlew --no-daemon build
+# Build the server application
+RUN ./gradlew --no-daemon assemble
 
 
 FROM openjdk:11.0.7-jdk

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -15,7 +15,8 @@ def versions = [
     flyway: '6.3.3',
     spdx: '2.2.1',
     guava: '28.2-jre',
-    junit: '5.6.2'
+    junit: '5.6.2',
+    testcontainers: '1.14.3'
 ]
 ext['junit-jupiter.version'] = versions.junit
 sourceCompatibility = versions.java
@@ -59,9 +60,10 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
+    testImplementation "org.testcontainers:elasticsearch:${versions.testcontainers}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${versions.junit}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${versions.junit}"
-    testRuntimeOnly "com.h2database:h2"
+    testRuntimeOnly "org.testcontainers:postgresql:${versions.testcontainers}"
 }
 
 task runServer(type: JavaExec) {

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAdapter.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAdapter.java
@@ -113,6 +113,9 @@ public class VSCodeAdapter {
             sortBy = getSortBy(filter.sortBy);
         }
 
+        if (!search.isEnabled()) {
+            return toQueryResult(Collections.emptyList());
+        }
         try {
             var searchResult = search.search(queryString, category, pageRequest, sortOrder, sortBy);
             return findExtensions(searchResult, param.flags);

--- a/server/src/main/java/org/eclipse/openvsx/search/SearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/SearchService.java
@@ -107,6 +107,9 @@ public class SearchService {
     }
 
     public void updateSearchEntry(Extension extension) {
+        if (!isEnabled()) {
+            return;
+        }
         try {
             rwLock.writeLock().lock();
             var stats = new SearchStats();
@@ -120,6 +123,9 @@ public class SearchService {
     }
 
     public void removeSearchEntry(Extension extension) {
+        if (!isEnabled()) {
+            return;
+        }
         try {
             rwLock.writeLock().lock();
             searchOperations.delete(ExtensionSearch.class, Long.toString(extension.getId()));

--- a/server/src/test/java/org/eclipse/openvsx/TestSearchConfig.java
+++ b/server/src/test/java/org/eclipse/openvsx/TestSearchConfig.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 TypeFox and others
+ * Copyright (c) 2020 TypeFox and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -7,33 +7,26 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
-package org.eclipse.openvsx.search;
+package org.eclipse.openvsx;
 
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.common.Strings;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.client.RestClients;
 import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 @Configuration
-@Profile("!test")
-public class SearchConfig extends AbstractElasticsearchConfiguration {
-
-    @Value("${ovsx.elasticsearch.host:}")
-    String searchHost;
+@Profile("test")
+public class TestSearchConfig extends AbstractElasticsearchConfiguration {
 
     @Override
     public RestHighLevelClient elasticsearchClient() {
-        ClientConfiguration config;
-        if (Strings.isNullOrEmpty(searchHost)) {
-            config = ClientConfiguration.localhost();
-        } else {
-            config = ClientConfiguration.create(searchHost);
-        }
+        var container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:6.8.6");
+        container.start();
+        var config = ClientConfiguration.create(container.getHttpHostAddress());
         return RestClients.create(config).rest();
     }
-
+    
 }

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -1,18 +1,17 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:test_db;MODE=PostgreSQL
-  flyway:
-    enabled: false
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:postgresql:9.6.8:///test
   jpa:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
   session:
     store-type: jdbc
     jdbc:
-      initialize-schema: always
+      initialize-schema: never
 
   security:
       oauth2:
@@ -21,7 +20,3 @@ spring:
             github:
               client-id: dummy-client-id
               client-secret: dummy-client-secret
-
-ovsx:
-  elasticsearch:
-    enabled: false


### PR DESCRIPTION
This change adds a testcontainer for Elasticsearch so the search functionality can be included in the integration test.