### PR TITLE
Render license links to spdx.org, improved detection

### DIFF
--- a/webui/src/pages/extension-detail/extension-detail.tsx
+++ b/webui/src/pages/extension-detail/extension-detail.tsx
@@ -444,8 +444,15 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
                 title={extension.license ? 'License type' : undefined} >
                 {extension.license || 'Provided license'}
             </Link>;
+        } else if (extension.license) {
+            return <Link
+                href={`https://spdx.org/licenses/${encodeURIComponent(extension.license)}.html`}
+                className={`${this.props.classes.link} ${themeClass}`}
+                title={extension.license ? 'License type' : undefined} >
+                {extension.license}
+            </Link>;
         } else {
-            return extension.license || 'Unlicensed';
+            return 'Unlicensed';
         }
     }
 


### PR DESCRIPTION
 * In case an extension has not packaged its license, a link to the respective license page on [spdx.org](https://spdx.org/) is shown.
 * Improved license detection when the license is given in the form `SEE MIT LICENSE IN LICENSE.md`, see for example [vscode-language-pack-de](https://github.com/microsoft/vscode-loc/blob/e81f98af158141ec32e25c22ec37b51945121eae/i18n/vscode-language-pack-de/package.json#L11) (currently rendered like [this](https://open-vsx.org/extension/MS-CEINTL/vscode-language-pack-de)).