### PR TITLE
More consistent status codes, added 'query' endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The command line tool is available at `cli/lib/ovsx`.
  * `./gradlew build` &mdash; build and test the server
  * `./gradlew assemble -t` &mdash; build continuously (the server is restarted after every change)
  * `./gradlew runServer` &mdash; start the Spring server on port 8080
+ * `./scripts/test-report.sh` &mdash; display test results on port 8081
 
 The Spring server is started automatically in Gitpod. It includes `spring-boot-devtools` which detects changes in the compiled class files and restarts the server.
 

--- a/cli/src/registry.ts
+++ b/cli/src/registry.ts
@@ -159,9 +159,10 @@ export class Registry {
                 if (response.statusCode !== undefined && (response.statusCode < 200 || response.statusCode > 299)) {
                     if (json.startsWith('{')) {
                         try {
-                            const error = JSON.parse(json) as ErrorResponse;
-                            if (error.message) {
-                                reject(new Error(error.message));
+                            const parsed = JSON.parse(json) as ErrorResponse;
+                            const message = parsed.message || parsed.error;
+                            if (message) {
+                                reject(new Error(message));
                                 return;
                             }
                         } catch (err) {

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -5,4 +5,5 @@
 .classpath
 .project
 DEPENDENCIES
+/src/dev/resources/static/
 /src/dev/resources/application-ovsx.properties

--- a/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
@@ -34,6 +34,7 @@ import org.eclipse.openvsx.util.ErrorResultException;
 import org.eclipse.openvsx.util.LicenseDetection;
 import org.elasticsearch.common.Strings;
 import org.springframework.data.util.Pair;
+import org.springframework.http.HttpStatus;
 
 /**
  * Processes uploaded extension files and extracts their metadata.
@@ -82,7 +83,7 @@ public class ExtensionProcessor implements AutoCloseable {
         try {
             content = ByteStreams.toByteArray(inputStream);
             if (content.length > MAX_CONTENT_SIZE)
-                throw new ErrorResultException("The extension package exceeds the size limit of 512 MB.");
+                throw new ErrorResultException("The extension package exceeds the size limit of 512 MB.", HttpStatus.PAYLOAD_TOO_LARGE);
             var tempFile = File.createTempFile("extension_", ".vsix");
             Files.write(content, tempFile);
             zipFile = new ZipFile(tempFile);

--- a/server/src/main/java/org/eclipse/openvsx/IExtensionRegistry.java
+++ b/server/src/main/java/org/eclipse/openvsx/IExtensionRegistry.java
@@ -11,6 +11,8 @@ package org.eclipse.openvsx;
 
 import org.eclipse.openvsx.json.ExtensionJson;
 import org.eclipse.openvsx.json.NamespaceJson;
+import org.eclipse.openvsx.json.QueryParamJson;
+import org.eclipse.openvsx.json.QueryResultJson;
 import org.eclipse.openvsx.json.ReviewListJson;
 import org.eclipse.openvsx.json.SearchResultJson;
 import org.eclipse.openvsx.search.SearchService;
@@ -32,5 +34,7 @@ public interface IExtensionRegistry {
     ReviewListJson getReviews(String namespace, String extension);
 
     SearchResultJson search(SearchService.Options options);
+
+    QueryResultJson query(QueryParamJson param);
 
 }

--- a/server/src/main/java/org/eclipse/openvsx/UpstreamRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/UpstreamRegistryService.java
@@ -30,6 +30,8 @@ import org.springframework.web.server.ResponseStatusException;
 
 import org.eclipse.openvsx.json.ExtensionJson;
 import org.eclipse.openvsx.json.NamespaceJson;
+import org.eclipse.openvsx.json.QueryParamJson;
+import org.eclipse.openvsx.json.QueryResultJson;
 import org.eclipse.openvsx.json.ReviewListJson;
 import org.eclipse.openvsx.json.SearchResultJson;
 import org.eclipse.openvsx.search.SearchService;
@@ -134,6 +136,17 @@ public class UpstreamRegistryService implements IExtensionRegistry {
                 "includeAllVersions", Boolean.toString(options.includeAllVersions)
             );
             return restTemplate.getForObject(requestUrl, SearchResultJson.class);
+        } catch (RestClientException exc) {
+            handleError(exc);
+            throw exc;
+        }
+    }
+
+    @Override
+    public QueryResultJson query(QueryParamJson param) {
+        try {
+            String requestUrl = createApiUrl(upstreamUrl, "api", "-", "query");
+            return restTemplate.postForObject(requestUrl, param, QueryResultJson.class);
         } catch (RestClientException exc) {
             handleError(exc);
             throw exc;

--- a/server/src/main/java/org/eclipse/openvsx/json/QueryParamJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/QueryParamJson.java
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.json;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(
+    value = "QueryParam",
+    description = "Metadata query parameter"
+)
+@JsonInclude(Include.NON_NULL)
+public class QueryParamJson {
+
+    @ApiModelProperty("Name of a namespace")
+    public String namespaceName;
+
+    @ApiModelProperty("Name of an extension")
+    public String extensionName;
+
+    @ApiModelProperty("Version of an extension")
+    public String extensionVersion;
+
+    @ApiModelProperty("Identifier in the form {namespace}.{extension}")
+    public String extensionId;
+
+    @ApiModelProperty("Universally unique identifier of an extension")
+    public String extensionUuid;
+
+    @ApiModelProperty("Universally unique identifier of a namespace")
+    public String namespaceUuid;
+
+    @ApiModelProperty("Whether to include all versions of an extension")
+    public boolean includeAllVersions;
+    
+}

--- a/server/src/main/java/org/eclipse/openvsx/json/QueryResultJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/QueryResultJson.java
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.json;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(
+    value = "QueryResult",
+    description = "Metadata query result"
+)
+@JsonInclude(Include.NON_NULL)
+public class QueryResultJson extends ResultJson {
+
+    public static QueryResultJson error(String message) {
+        var result = new QueryResultJson();
+        result.error = message;
+        return result;
+    }
+
+    @ApiModelProperty("Extensions that match the given query (may be empty)")
+    public List<ExtensionJson> extensions;
+    
+}

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionRepository.java
@@ -18,6 +18,8 @@ import org.eclipse.openvsx.entities.Namespace;
 
 public interface ExtensionRepository extends Repository<Extension, Long> {
 
+    Streamable<Extension> findByNameIgnoreCase(String name);
+
     Streamable<Extension> findByNamespace(Namespace namespace);
 
     Streamable<Extension> findByNamespaceOrderByNameAsc(Namespace namespace);

--- a/server/src/main/java/org/eclipse/openvsx/repositories/NamespaceRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/NamespaceRepository.java
@@ -15,9 +15,9 @@ import org.eclipse.openvsx.entities.Namespace;
 
 public interface NamespaceRepository extends Repository<Namespace, Long> {
 
-    Namespace findByName(String name);
-
     Namespace findByNameIgnoreCase(String name);
+
+    Namespace findByPublicId(String publicId);
 
     long count();
 

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -43,6 +43,10 @@ public class RepositoryService {
         return namespaceRepo.findByNameIgnoreCase(name);
     }
 
+    public Namespace findNamespaceByPublicId(String publicId) {
+        return namespaceRepo.findByPublicId(publicId);
+    }
+
     public long countNamespaces() {
         return namespaceRepo.count();
     }
@@ -61,6 +65,10 @@ public class RepositoryService {
 
     public Streamable<Extension> findExtensions(Namespace namespace) {
         return extensionRepo.findByNamespaceOrderByNameAsc(namespace);
+    }
+
+    public Streamable<Extension> findExtensions(String name) {
+        return extensionRepo.findByNameIgnoreCase(name);
     }
 
     public Streamable<Extension> findAllExtensions() {

--- a/server/src/main/java/org/eclipse/openvsx/security/SecurityConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/security/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
@@ -56,7 +57,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
         // Publishing is done only via explicit access tokens, so we don't need CSRF protection here.
         http.csrf()
-            .ignoringAntMatchers("/api/-/publish", "/api/-/namespace/create", "/admin/**", "/vscode/**");
+            .ignoringAntMatchers("/api/-/publish", "/api/-/namespace/create", "/api/-/query", "/admin/**", "/vscode/**");
+
+        // Respond with 403 status when the user is not logged in
+        http.exceptionHandling()
+            .authenticationEntryPoint(new Http403ForbiddenEntryPoint());
     }
 
     @Override

--- a/server/src/main/java/org/eclipse/openvsx/util/ErrorResultException.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/ErrorResultException.java
@@ -9,22 +9,37 @@
  ********************************************************************************/
 package org.eclipse.openvsx.util;
 
+import org.springframework.http.HttpStatus;
+
 /**
  * Throw this exception to reply with a JSON object of the form
+ * 
  * <pre>
- * { "error": "«message»" }
- * </pre
+ * { "error": "«message»" } </pre
  */
 public class ErrorResultException extends RuntimeException {
 
     private static final long serialVersionUID = 147466147310091931L;
 
+    private final HttpStatus status;
+
     public ErrorResultException(String message) {
         super(message);
+        this.status = null;
     }
 
     public ErrorResultException(String message, Throwable cause) {
         super(message, cause);
+        this.status = null;
+    }
+
+    public ErrorResultException(String message, HttpStatus status) {
+        super(message);
+        this.status = status;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
     }
 
 }

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -256,6 +256,102 @@ public class RegistryAPITest {
     }
 
     @Test
+    public void testQueryExtensionName() throws Exception {
+        mockExtension();
+        mockMvc.perform(post("/api/-/query")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{ \"extensionName\": \"bar\" }"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(queryResultJson(e -> {
+                    e.namespace = "foo";
+                    e.name = "bar";
+                    e.version = "1";
+                    e.namespaceAccess = "public";
+                    e.timestamp = "2000-01-01T10:00Z";
+                    e.displayName = "Foo Bar";
+                })));
+    }
+
+    @Test
+    public void testQueryNamespace() throws Exception {
+        mockExtension();
+        mockMvc.perform(post("/api/-/query")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{ \"namespaceName\": \"foo\" }"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(queryResultJson(e -> {
+                    e.namespace = "foo";
+                    e.name = "bar";
+                    e.version = "1";
+                    e.namespaceAccess = "public";
+                    e.timestamp = "2000-01-01T10:00Z";
+                    e.displayName = "Foo Bar";
+                })));
+    }
+
+    @Test
+    public void testQueryUnknownExtension() throws Exception {
+        mockExtension();
+        Mockito.when(repositories.findExtensions("baz")).thenReturn(Streamable.empty());
+        mockMvc.perform(post("/api/-/query")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{ \"extensionName\": \"baz\" }"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("{ \"extensions\": [] }"));
+    }
+
+    @Test
+    public void testQueryExtensionId() throws Exception {
+        mockExtension();
+        mockMvc.perform(post("/api/-/query")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{ \"extensionId\": \"foo.bar\" }"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(queryResultJson(e -> {
+                    e.namespace = "foo";
+                    e.name = "bar";
+                    e.version = "1";
+                    e.namespaceAccess = "public";
+                    e.timestamp = "2000-01-01T10:00Z";
+                    e.displayName = "Foo Bar";
+                })));
+    }
+
+    @Test
+    public void testQueryExtensionUuid() throws Exception {
+        mockExtension();
+        mockMvc.perform(post("/api/-/query")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{ \"extensionUuid\": \"5678\" }"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(queryResultJson(e -> {
+                    e.namespace = "foo";
+                    e.name = "bar";
+                    e.version = "1";
+                    e.namespaceAccess = "public";
+                    e.timestamp = "2000-01-01T10:00Z";
+                    e.displayName = "Foo Bar";
+                })));
+    }
+
+    @Test
+    public void testQueryNamespaceUuid() throws Exception {
+        mockExtension();
+        mockMvc.perform(post("/api/-/query")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{ \"namespaceUuid\": \"1234\" }"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(queryResultJson(e -> {
+                    e.namespace = "foo";
+                    e.name = "bar";
+                    e.version = "1";
+                    e.namespaceAccess = "public";
+                    e.timestamp = "2000-01-01T10:00Z";
+                    e.displayName = "Foo Bar";
+                })));
+    }
+
+    @Test
     public void testCreateNamespace() throws Exception {
         mockAccessToken();
         mockMvc.perform(post("/api/-/namespace/create?token={token}", "my_token")
@@ -281,7 +377,7 @@ public class RegistryAPITest {
         mockMvc.perform(post("/api/-/namespace/create?token={token}", "my_token")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(namespaceJson(n -> { n.name = "foo.bar"; })))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("Invalid namespace name: foo.bar")));
     }
     
@@ -292,7 +388,7 @@ public class RegistryAPITest {
         mockMvc.perform(post("/api/-/namespace/create?token={token}", "my_token")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(namespaceJson(n -> { n.name = "foobar"; })))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("Invalid access token.")));
     }
     
@@ -307,7 +403,7 @@ public class RegistryAPITest {
         mockMvc.perform(post("/api/-/namespace/create?token={token}", "my_token")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(namespaceJson(n -> { n.name = "foobar"; })))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("Namespace already exists: foobar")));
     }
     
@@ -336,7 +432,7 @@ public class RegistryAPITest {
         mockMvc.perform(post("/api/-/publish?token={token}", "my_token")
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .content(bytes))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("Invalid access token.")));
     }
     
@@ -347,7 +443,7 @@ public class RegistryAPITest {
         mockMvc.perform(post("/api/-/publish?token={token}", "my_token")
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .content(bytes))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("Unknown publisher: foo"
                         + "\nUse the 'create-namespace' command to create a namespace corresponding to your publisher name.")));
     }
@@ -414,7 +510,7 @@ public class RegistryAPITest {
         mockMvc.perform(post("/api/-/publish?token={token}", "my_token")
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .content(bytes))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("Insufficient access rights for publisher: foo")));
     }
     
@@ -425,7 +521,7 @@ public class RegistryAPITest {
         mockMvc.perform(post("/api/-/publish?token={token}", "my_token")
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .content(bytes))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("Extension foo.bar version 1 is already published.")));
     }
     
@@ -436,7 +532,7 @@ public class RegistryAPITest {
         mockMvc.perform(post("/api/-/publish?token={token}", "my_token")
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .content(bytes))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("Invalid extension name: b.a.r")));
     }
     
@@ -447,7 +543,7 @@ public class RegistryAPITest {
         mockMvc.perform(post("/api/-/publish?token={token}", "my_token")
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .content(bytes))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("The version string 'latest' is reserved.")));
     }
     
@@ -489,7 +585,7 @@ public class RegistryAPITest {
                 .content(reviewJson(r -> {
                     r.rating = 100;
                 })).with(csrf()))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("The rating must be an integer number between 0 and 5.")));
     }
     
@@ -501,7 +597,7 @@ public class RegistryAPITest {
                 .content(reviewJson(r -> {
                     r.rating = 3;
                 })).with(csrf()))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("Extension not found: foo.bar")));
     }
     
@@ -524,7 +620,7 @@ public class RegistryAPITest {
                 .content(reviewJson(r -> {
                     r.rating = 3;
                 })).with(csrf()))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("You must not submit more than one review for an extension.")));
     }
     
@@ -550,7 +646,7 @@ public class RegistryAPITest {
     }
     
     @Test
-    public void testDeletReviewNotLoggedIn() throws Exception {
+    public void testDeleteReviewNotLoggedIn() throws Exception {
         mockMvc.perform(post("/api/{namespace}/{extension}/review/delete", "foo", "bar").with(csrf()))
                 .andExpect(status().isForbidden());
     }
@@ -559,7 +655,7 @@ public class RegistryAPITest {
     public void testDeleteReviewUnknownExtension() throws Exception {
         mockUserData();
         mockMvc.perform(post("/api/{namespace}/{extension}/review/delete", "foo", "bar").with(csrf()))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("Extension not found: foo.bar")));
     }
     
@@ -574,7 +670,7 @@ public class RegistryAPITest {
                 .thenReturn(Streamable.empty());
 
         mockMvc.perform(post("/api/{namespace}/{extension}/review/delete", "foo", "bar").with(csrf()))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("You have not submitted any review yet.")));
     }
 
@@ -600,9 +696,11 @@ public class RegistryAPITest {
     private ExtensionVersion mockExtension() {
         var namespace = new Namespace();
         namespace.setName("foo");
+        namespace.setPublicId("1234");
         var extension = new Extension();
         extension.setName("bar");
         extension.setNamespace(namespace);
+        extension.setPublicId("5678");
         var extVersion = new ExtensionVersion();
         extension.setLatest(extVersion);
         extVersion.setExtension(extension);
@@ -615,6 +713,8 @@ public class RegistryAPITest {
                 .thenReturn(extVersion);
         Mockito.when(repositories.findVersions(extension))
                 .thenReturn(Streamable.of(extVersion));
+        Mockito.when(repositories.findExtensions(namespace))
+                .thenReturn(Streamable.of(extension));
         Mockito.when(repositories.getVersionStrings(extension))
                 .thenReturn(Streamable.of(extVersion.getVersion()));
         Mockito.when(repositories.countMemberships(namespace, NamespaceMembership.ROLE_OWNER))
@@ -623,6 +723,14 @@ public class RegistryAPITest {
                 .thenReturn(0l);
         Mockito.when(repositories.findFilesByType(eq(extVersion), anyCollection()))
                 .thenReturn(Streamable.empty());
+        Mockito.when(repositories.findNamespace("foo"))
+                .thenReturn(namespace);
+        Mockito.when(repositories.findExtensions("bar"))
+                .thenReturn(Streamable.of(extension));
+        Mockito.when(repositories.findNamespaceByPublicId("1234"))
+                .thenReturn(namespace);
+        Mockito.when(repositories.findExtensionByPublicId("5678"))
+                .thenReturn(extension);
         return extVersion;
     }
 
@@ -630,6 +738,10 @@ public class RegistryAPITest {
         var json = new ExtensionJson();
         content.accept(json);
         return new ObjectMapper().writeValueAsString(json);
+    }
+
+    private String queryResultJson(Consumer<ExtensionJson> content) throws JsonProcessingException {
+        return "{\"extensions\":[" + extensionJson(content) + "]}";
     }
 
     private FileResource mockReadme() {

--- a/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
@@ -142,7 +142,7 @@ public class UserAPITest {
                 .thenReturn(token);
 
         mockMvc.perform(post("/user/token/delete/{id}", 100).with(csrf()))
-                .andExpect(status().isOk())
+                .andExpect(status().isNotFound())
                 .andExpect(content().json(errorJson("Token does not exist.")));
     }
 
@@ -159,7 +159,7 @@ public class UserAPITest {
                 .thenReturn(token);
 
         mockMvc.perform(post("/user/token/delete/{id}", 100).with(csrf()))
-                .andExpect(status().isOk())
+                .andExpect(status().isNotFound())
                 .andExpect(content().json(errorJson("Token does not exist.")));
     }
 
@@ -310,7 +310,7 @@ public class UserAPITest {
 
         mockMvc.perform(post("/user/namespace/{namespace}/role?user={user}&role={role}", "foobar",
                     "other_user", "contributor").with(csrf()))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("You must be an owner of this namespace.")));
     }
 
@@ -340,7 +340,7 @@ public class UserAPITest {
 
         mockMvc.perform(post("/user/namespace/{namespace}/role?user={user}&role={role}", "foobar",
                     "other_user", "contributor").with(csrf()))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(errorJson("User other_user already has the role contributor.")));
     }
 

--- a/webui/package.json
+++ b/webui/package.json
@@ -90,6 +90,7 @@
         "build:default": "webpack --config ./configs/webpack.config.js --mode production",
         "watch:default": "webpack --config ./configs/webpack.config.js --mode development --watch",
         "start:default": "node lib/default/server",
+        "copy2server": "cp -rfv static ../server/src/dev/resources/",
         "publish:next": "yarn publish --new-version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" --tag next --no-git-tag-version",
         "publish:latest": "yarn publish --tag latest"
     }


### PR DESCRIPTION
Fixes #163.

 * Most HTTP endpoints now return proper status codes in case of error (400 or 404).
 * Endpoints related to extension metadata are left unchanged. These will be adapted after a few weeks so clients have time to migrate.
 * Added a new endpoint `/api/-/query` that can be POSTed to get extension metadata. This is now the preferred endpoint for IDEs such as Theia. In case an extension is not found, it returns status 200 with an empty result.