### PR TITLE
Allow lowercase readme and license filenames

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
@@ -42,8 +42,14 @@ public class ExtensionProcessor implements AutoCloseable {
 
     private static final String PACKAGE_JSON = "extension/package.json";
     private static final String PACKAGE_NLS_JSON = "extension/package.nls.json";
-    private static final String[] README = { "extension/README.md", "extension/README", "extension/README.txt" };
-    private static final String[] LICENSE = { "extension/LICENSE.md", "extension/LICENSE", "extension/LICENSE.txt" };
+    private static final String[] README = {
+        "extension/README.md", "extension/README", "extension/README.txt",
+        "extension/readme.md", "extension/readme", "extension/readme.txt"
+    };
+    private static final String[] LICENSE = {
+        "extension/LICENSE.md", "extension/LICENSE", "extension/LICENSE.txt",
+        "extension/license.md", "extension/license", "extension/license.txt"
+    };
 
     private static final int MAX_CONTENT_SIZE = 512 * 1024 * 1024;
     private static final Pattern LICENSE_PATTERN = Pattern.compile("SEE( (?<license>\\S+))? LICENSE IN (?<file>\\S+)");


### PR DESCRIPTION
I can't test this, but it *should* work I think