### PR TITLE
Reject unlicensed extensions in default registry instance

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,6 +20,9 @@ ports:
   onOpen: ignore
 - port: 9300
   onOpen: ignore
+# NodeJS debugging
+- port: 9229
+  onOpen: ignore
 
 tasks:
 - init: |

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,18 +17,9 @@
         },
         {
             "type": "node",
-            "request": "launch",
-            "name": "CLI create-namespace",
-            "program": "${workspaceFolder}/cli/lib/ovsx",
-            "args": [
-                "-r",
-                "http://localhost:8080",
-                "-p",
-                "super_token",
-                "create-namespace",
-                "foo"
-            ],
-            "sourceMaps": true
+            "name": "Debug NodeJS (Attach)",
+            "request": "attach",
+            "processId": "${command:PickProcess}"
         }
     ]
 }

--- a/cli/src/check-license.ts
+++ b/cli/src/check-license.ts
@@ -1,0 +1,107 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { readManifest, writeManifest, Manifest, getUserInput, getUserChoice, writeFile } from './util';
+
+export async function checkLicense(packagePath?: string): Promise<void> {
+    if (await hasLicenseFile(packagePath)) {
+        // The extension has a LICENSE file that can be packaged
+        return;
+    }
+    const manifest = await readManifest(packagePath);
+    if (!manifest.publisher) {
+        throw new Error("Missing required field 'publisher'.");
+    }
+    if (!manifest.name) {
+        throw new Error("Missing required field 'name'.");
+    }
+    if (manifest.license) {
+        // The extension has a license identifier or a pointer to an alternative LICENSE file
+        return;
+    }
+    console.log('Extension ' + manifest.publisher + '.' + manifest.name + ' has no license. All Open VSX '
+        + 'Registry Content Offerings must be licensed. You may choose to publish this extension under '
+        + 'the MIT License (https://opensource.org/licenses/MIT). Please note you are responsible to '
+        + 'ensure that you have the necessary rights to permit this extension to be made available under '
+        + 'the MIT license and for compliance with that license.');
+    let answer: 'yes' | 'help' | 'no';
+    do {
+        console.log();
+        answer = await getUserChoice('Would you like to publish your extension '
+            + manifest.publisher + '.' + manifest.name
+            + ' under the MIT license?',
+            ['yes', 'help', 'no'], 'no');
+        switch (answer) {
+            case 'yes':
+                await useMITLicense(manifest, packagePath);
+                break;
+            case 'help':
+                console.log('If you select "yes" your extension will be published under the MIT License. '
+                    + 'You must enter the Copyright Year and Copyright Holder information. This information '
+                    + 'along with the text of the MIT License will be written to a LICENSE file and '
+                    + 'packaged with the uploaded extension.\n');
+                console.log(MIT_LICENSE_TEXT);
+                break;
+            case 'no':
+                throw new Error('This extension cannot be accepted because it has no license.');
+        }
+    } while (answer === 'help');
+}
+
+async function useMITLicense(manifest: Manifest, packagePath?: string) {
+    console.log('Please enter a value for Copyright Year and Copyright Holder.\n'
+        + 'Example: "Copyright 2020 John Doe"\n');
+    const copyright = await getUserInput('Copyright ');
+    if (!copyright) {
+        throw new Error('A copyright declaration is necessary for the MIT license.');
+    }
+    manifest.license = 'MIT';
+    await writeManifest(manifest, packagePath);
+    const license = MIT_LICENSE_TEXT.replace('<YEAR> <COPYRIGHT HOLDER>', copyright);
+    await writeFile('LICENSE', license, packagePath);
+    console.log('LICENSE file has been written. Please commit it to the source repository.');
+}
+
+const LICENSE_FILE_NAMES = ['LICENSE.md', 'LICENSE', 'LICENSE.txt'];
+
+async function hasLicenseFile(packagePath?: string): Promise<boolean> {
+    for (const fileName of LICENSE_FILE_NAMES) {
+        const promise = new Promise(resolve => fs.access(
+            path.join(packagePath || '.', fileName),
+            err => resolve(!err)
+        ));
+        if (await promise) {
+            return true;
+        }
+    }
+    return false;
+}
+
+const MIT_LICENSE_TEXT: string = `Copyright <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.`;

--- a/cli/src/registry.ts
+++ b/cli/src/registry.ts
@@ -36,6 +36,10 @@ export class Registry {
         this.maxPublishSize = options.maxPublishSize || DEFAULT_PUBLISH_SIZE;
     }
 
+    get requiresLicense(): boolean {
+        return this.url === DEFAULT_URL;
+    }
+
     createNamespace(name: string, pat: string): Promise<Response> {
         try {
             const query: { [key: string]: string } = { token: pat };

--- a/server/scripts/generate-properties.sh
+++ b/server/scripts/generate-properties.sh
@@ -33,6 +33,7 @@ echo "spring.security.oauth2.client.registration.eclipse.client-secret=${ECLIPSE
 if [ -n "$ECLIPSE_CLIENT_ID" ] && [ -n "$ECLIPSE_CLIENT_SECRET" ]
 then
     echo "ovsx.eclipse.publisher-agreement.version=1" >> $OVSX_APP_PROFILE
+    echo "ovsx.publishing.require-license=true" >> $OVSX_APP_PROFILE
     echo "Eclipse OAuth is enabled."
 fi
 

--- a/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
@@ -13,6 +13,7 @@ import java.net.URI;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
@@ -96,11 +97,16 @@ public class EclipseService {
     }
 
     private final Function<String, LocalDateTime> parseDate = dateString -> {
-        var local = LocalDateTime.parse(dateString, CUSTOM_DATE_TIME);
-        if (Strings.isNullOrEmpty(publisherAgreementTimeZone)) {
-            return local;
+        try {
+            var local = LocalDateTime.parse(dateString, CUSTOM_DATE_TIME);
+            if (Strings.isNullOrEmpty(publisherAgreementTimeZone)) {
+                return local;
+            }
+            return TimeUtil.convertToUTC(local, publisherAgreementTimeZone);
+        } catch (DateTimeParseException exc) {
+            logger.error("Failed to parse timestamp.", exc);
+            return null;
         }
-        return TimeUtil.convertToUTC(local, publisherAgreementTimeZone);
     };
 
     public boolean isActive() {

--- a/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
@@ -58,7 +58,6 @@ public class EclipseServiceTest {
     public void setup() {
         eclipse.publisherAgreementVersion = "1";
         eclipse.eclipseApiUrl = "https://test.openvsx.eclipse.org/";
-        eclipse.publisherAgreementTimeZone = "US/Eastern";
     }
 
     @Test
@@ -90,7 +89,7 @@ public class EclipseServiceTest {
         assertThat(agreement.documentId).isEqualTo("abcd");
         assertThat(agreement.version).isEqualTo("1");
         assertThat(agreement.timestamp).isNotNull();
-        assertThat(agreement.timestamp.toString()).isEqualTo("2020-10-09T09:10:32");
+        assertThat(agreement.timestamp.toString()).isEqualTo("2020-10-09T05:10:32");
     }
 
     @Test
@@ -133,7 +132,7 @@ public class EclipseServiceTest {
         assertThat(ed.publisherAgreement.documentId).isEqualTo("abcd");
         assertThat(ed.publisherAgreement.version).isEqualTo("1");
         assertThat(ed.publisherAgreement.timestamp).isNotNull();
-        assertThat(ed.publisherAgreement.timestamp.toString()).isEqualTo("2020-10-09T09:10:32");
+        assertThat(ed.publisherAgreement.timestamp.toString()).isEqualTo("2020-10-09T05:10:32");
     }
 
     @Test


### PR DESCRIPTION
This is a preparation for the upcoming transfer of open-vsx.org to the Eclipse Foundation. Extensions without license are going to be rejected.

The CLI offers to use the MIT license in case an extension is unlicensed. This is the output when the user denies this question:

```
$ ovsx publish
Extension namespace.name has no license. Would you like to publish it under the MIT license?
yes/[no]: No
❌  This extension cannot be accepted because it has no license.
```

And the output when the user accepts the change:

```
$ ovsx publish
Extension namespace.name has no license. Would you like to publish it under the MIT license?
yes/[no]: Yes
 DONE  Packaged: /tmp/tmp-528018co4YOf55ycE.vsix (25 files, 1.7MB)

🚀  Published namespace.name v1.2.3
```

### Remarks and Questions

 * Current users of the CLI are not affected by this change after merging this PR. We will publish a new version to [npm](https://www.npmjs.com/package/ovsx) in order to activate the new check.
 * The server-side check must be enabled in the application.yml configuration, so the check won't be active by default for custom deployments.
 * The CLI checks the license only when publishing to the default registry instance `https://open-vsx.org`.
 * The CLI checks the license only when publishing an extension from source, where we can read and modify the package.json file that declares the license identifier. Users who publish an already packaged `.vsix` file will not see the question for accepting the MIT license, but they will see the same error message in case the extension is unlicensed because the server checks it in any case.
 * Shall we print the URL of the MIT license text at [opensource.org](https://opensource.org/licenses/MIT) so users can look it up before answering the question?
 * The license text states

> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

Shall we generate a LICENSE file with the text in order to comply with this?
This would require us to ask the user what to write at the `<COPYRIGHT HOLDER>` placeholder.