### PR TITLE
fixed css to respect long version lists in admin dashboard

### DIFF
--- a/webui/src/pages/admin-dashboard/extension-version-container.tsx
+++ b/webui/src/pages/admin-dashboard/extension-version-container.tsx
@@ -27,6 +27,13 @@ const useStyles = makeStyles((theme) => ({
     },
     titleRow: {
         fontWeight: 'bold'
+    },
+    extensionContainer: {
+        height: '100%'
+    },
+    versionsContainer: {
+        overflow: 'auto',
+        flex: '1'
     }
 }));
 
@@ -76,7 +83,7 @@ export const ExtensionVersionContainer: FunctionComponent<ExtensionVersionContai
     };
 
     return <>
-        <Grid container direction='column'>
+        <Grid container direction='column' className={classes.extensionContainer}>
             <Grid item container>
                 {
                     extension.files.icon ?
@@ -103,7 +110,7 @@ export const ExtensionVersionContainer: FunctionComponent<ExtensionVersionContai
                     </Grid>
                 </Grid>
             </Grid>
-            <Grid item container>
+            <Grid item container className={classes.versionsContainer}>
                 <Grid item xs={12} md={4}></Grid>
                 <Grid item container xs={12} md={8} direction='column'>
                     <FormControl component='fieldset'>
@@ -123,6 +130,12 @@ export const ExtensionVersionContainer: FunctionComponent<ExtensionVersionContai
                             }
                         </FormGroup>
                     </FormControl>
+                </Grid>
+            </Grid>
+            <Grid item container>
+                <Grid item xs={12} md={4}>
+                </Grid>
+                <Grid item container xs={12} md={8}>
                     <ExtensionRemoveDialog
                         onUpdate={handleUpdate}
                         extension={extension}

--- a/webui/src/pages/admin-dashboard/search-list-container.tsx
+++ b/webui/src/pages/admin-dashboard/search-list-container.tsx
@@ -13,7 +13,8 @@ import { Grid, makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
     containerRoot: {
-        height: '100%'
+        height: '100%',
+        flexWrap: 'nowrap'
     },
 }));
 
@@ -35,8 +36,8 @@ export const SearchListContainer: FunctionComponent<SearchListContainerProps> = 
                     </Grid>;
                 })}
             </Grid>
-            <Grid style={{ flex: 4 }} item container justify='center'>
-                <Grid item xs={8}>
+            <Grid style={{ flex: 4, overflow: 'hidden' }} item container justify='center'>
+                <Grid style={{ height: '100%' }} item xs={8}>
                     {props.listContainer}
                 </Grid>
             </Grid>


### PR DESCRIPTION
in admin dashboard for extension management there was a layout bug if the list of versions gets very long.