### PR TITLE
Added localhost port in dev environment

### DIFF
--- a/webui/src/default/default-app.tsx
+++ b/webui/src/default/default-app.tsx
@@ -26,6 +26,9 @@ let serverHost = location.hostname;
 if (serverHost.startsWith('3000-')) {
     // Gitpod dev environment: the frontend runs on port 3000, but the server runs on port 8080
     serverHost = '8080-' + serverHost.substring(5);
+} else if (location.port === '3000') {
+        // Localhost dev environment
+        serverHost = serverHost + ':8080'
 }
 const service = new ExtensionRegistryService(`${location.protocol}//${serverHost}`);
 


### PR DESCRIPTION
as metioned in [server launched by ./gradlew runServer, webui launched by yarn start:default, but page is empty on http://localhost:3000/ #168](https://github.com/eclipse/openvsx/issues/168#issuecomment-685666078)