### PR TITLE
Implemented new namespace policy

### DIFF
--- a/cli/src/registry.ts
+++ b/cli/src/registry.ts
@@ -211,8 +211,7 @@ export interface Extension extends Response {
     namespace: string;
     version: string;
     publishedBy: UserData;
-    unrelatedPublisher: boolean;
-    namespaceAccess: 'public' | 'restricted';
+    verified: boolean;
     // key: version, value: url
     allVersions: { [version: string]: string };
 

--- a/server/src/main/java/org/eclipse/openvsx/UserAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/UserAPI.java
@@ -224,7 +224,7 @@ public class UserAPI {
                 String url = createApiUrl(serverUrl, "api", namespace.getName(), ext.getName());
                 json.extensions.put(ext.getName(), url);
             }
-            json.access = NamespaceJson.RESTRICTED_ACCESS;
+            json.verified = true;
             json.membersUrl = createApiUrl(serverUrl, "user", "namespace", namespace.getName(), "members");
             json.roleUrl = createApiUrl(serverUrl, "user", "namespace", namespace.getName(), "role");
             return json;

--- a/server/src/main/java/org/eclipse/openvsx/UserService.java
+++ b/server/src/main/java/org/eclipse/openvsx/UserService.java
@@ -111,22 +111,14 @@ public class UserService {
             return true;
         }
 
-        var ownerships = repositories.findMemberships(namespace, NamespaceMembership.ROLE_OWNER);
-        if (ownerships.isEmpty()) {
-            // If the namespace has no owner, everyone has publish permission to it.
-            return true;
-        }
-        if (ownerships.stream().anyMatch(m -> m.getUser().equals(user))) {
-            // The requesting user is an owner of the namespace.
-            return true;
-        }
-
         var membership = repositories.findMembership(user, namespace);
         if (membership == null) {
-            // The namespace is owned by someone else and the requesting user is not a member.
+            // The requesting user is not a member of the namespace.
             return false;
         }
-        return membership.getRole().equalsIgnoreCase(NamespaceMembership.ROLE_CONTRIBUTOR);
+        var role = membership.getRole();
+        return NamespaceMembership.ROLE_CONTRIBUTOR.equalsIgnoreCase(role)
+                || NamespaceMembership.ROLE_OWNER.equalsIgnoreCase(role);
     }
 
     @Transactional(rollbackOn = ErrorResultException.class)

--- a/server/src/main/java/org/eclipse/openvsx/json/ExtensionJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/ExtensionJson.java
@@ -64,12 +64,18 @@ public class ExtensionJson extends ResultJson {
     @ApiModelProperty(hidden = true)
     public Boolean active;
 
-    @ApiModelProperty("The value 'true' means the extension's namespace is restricted, but the publishing user is not a member of that namespace")
+    @ApiModelProperty("The value 'true' means the publishing user is a member of the extension's namespace and the namespace has at least one owner.")
     @NotNull
-    public boolean unrelatedPublisher;
+    public Boolean verified;
 
-    @ApiModelProperty(value = "Access level of the extension's namespace", allowableValues = "public,restricted")
+    @ApiModelProperty("Deprecated: use 'verified' instead (this property is just the negation of 'verified')")
     @NotNull
+    @Deprecated
+    public Boolean unrelatedPublisher;
+
+    @ApiModelProperty(value = "Access level of the extension's namespace. Deprecated: namespaces are now always restricted", allowableValues = "public,restricted")
+    @NotNull
+    @Deprecated
     public String namespaceAccess;
 
     @ApiModelProperty("Map of available versions to their metadata URLs")

--- a/server/src/main/java/org/eclipse/openvsx/json/NamespaceJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/NamespaceJson.java
@@ -26,9 +26,6 @@ import io.swagger.annotations.ApiModelProperty;;
 @JsonInclude(Include.NON_NULL)
 public class NamespaceJson extends ResultJson {
 
-    public static final String PUBLIC_ACCESS = "public";
-    public static final String RESTRICTED_ACCESS = "restricted";
-
     public static NamespaceJson error(String message) {
         var result = new NamespaceJson();
         result.error = message;
@@ -42,7 +39,12 @@ public class NamespaceJson extends ResultJson {
     @ApiModelProperty("Map of extension names to their metadata URLs (not required for creating)")
     public Map<String, String> extensions;
 
-    @ApiModelProperty(value = "Access level of the namespace (not required for creating)", allowableValues = "public,restricted")
+    @ApiModelProperty("Indicates whether the namespace has an owner (not required for creating)")
+    @NotNull
+    public Boolean verified;
+
+    @ApiModelProperty(value = "Access level of the namespace. Deprecated: namespaces are now always restricted", allowableValues = "public,restricted")
+    @Deprecated
     public String access;
 
     @ApiModelProperty(hidden = true)

--- a/server/src/main/java/org/eclipse/openvsx/migration/OrphanNamespaceMigration.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/OrphanNamespaceMigration.java
@@ -1,0 +1,85 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.migration;
+
+import java.util.LinkedHashSet;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+import org.eclipse.openvsx.entities.NamespaceMembership;
+import org.eclipse.openvsx.entities.UserData;
+import org.eclipse.openvsx.repositories.RepositoryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrphanNamespaceMigration {
+
+    protected final Logger logger = LoggerFactory.getLogger(OrphanNamespaceMigration.class);
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Autowired
+    RepositoryService repositories;
+
+    @EventListener
+    @Transactional
+    public void fixOrphanNamespaces(ApplicationStartedEvent event) {
+        int[] count = new int[3];
+        repositories.findOrphanNamespaces().forEach(namespace -> {
+            var extensions = repositories.findExtensions(namespace);
+            if (extensions.isEmpty()) {
+                // The namespace is orphaned and empty - remove it
+                entityManager.remove(namespace);
+                count[0]++;
+            } else {
+
+                // Find all previous contributors
+                var contributors = new LinkedHashSet<UserData>();
+                for (var extension : extensions) {
+                    for (var extVersion : repositories.findActiveVersions(extension)) {
+                        if (extVersion.getPublishedWith() != null) {
+                            contributors.add(extVersion.getPublishedWith().getUser());
+                        }
+                    }
+                }
+
+                if (contributors.isEmpty()) {
+                    // This can happen if all extension versions are inactive
+                    count[2]++;
+                } else {
+                    // Assign explicit memberships to the previous contributors
+                    for (var contributor : contributors) {
+                        var membership = new NamespaceMembership();
+                        membership.setNamespace(namespace);
+                        membership.setUser(contributor);
+                        membership.setRole(NamespaceMembership.ROLE_CONTRIBUTOR);
+                        entityManager.persist(membership);
+                    }
+                    count[1]++;
+                }
+            }
+        });
+
+        if (count[0] > 0)
+            logger.info("Deleted " + count[0] + " namespaces that were orphaned and empty.");
+        if (count[1] > 0)
+            logger.info("Assigned explicit members to " + count[1] + " orphaned namespaces.");
+        if (count[2] > 0)
+            logger.info("Found " + count[2] + " orphaned namespaces that could not be fixed.");
+    }
+    
+}

--- a/server/src/main/java/org/eclipse/openvsx/repositories/NamespaceRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/NamespaceRepository.java
@@ -9,8 +9,9 @@
  ********************************************************************************/
 package org.eclipse.openvsx.repositories;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
-
+import org.springframework.data.util.Streamable;
 import org.eclipse.openvsx.entities.Namespace;
 
 public interface NamespaceRepository extends Repository<Namespace, Long> {
@@ -18,6 +19,9 @@ public interface NamespaceRepository extends Repository<Namespace, Long> {
     Namespace findByNameIgnoreCase(String name);
 
     Namespace findByPublicId(String publicId);
+
+    @Query("from Namespace n where not exists (from NamespaceMembership nm where nm.namespace = n)")
+    Streamable<Namespace> findOrphans();
 
     long count();
 

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -47,6 +47,10 @@ public class RepositoryService {
         return namespaceRepo.findByPublicId(publicId);
     }
 
+    public Streamable<Namespace> findOrphanNamespaces() {
+        return namespaceRepo.findOrphans();
+    }
+
     public long countNamespaces() {
         return namespaceRepo.count();
     }
@@ -65,6 +69,10 @@ public class RepositoryService {
 
     public Streamable<Extension> findActiveExtensions(Namespace namespace) {
         return extensionRepo.findByNamespaceAndActiveTrueOrderByNameAsc(namespace);
+    }
+
+    public Streamable<Extension> findExtensions(Namespace namespace) {
+        return extensionRepo.findByNamespace(namespace);
     }
 
     public Streamable<Extension> findExtensions(String name) {

--- a/webui/src/extension-registry-types.ts
+++ b/webui/src/extension-registry-types.ts
@@ -70,8 +70,7 @@ export interface Extension {
     namespace: string;
     version: string;
     publishedBy: UserData;
-    unrelatedPublisher: boolean;
-    namespaceAccess: 'public' | 'restricted';
+    verified: boolean;
     // key: version, value: url
     allVersions: { [version: string]: UrlString };
     active?: boolean;
@@ -197,7 +196,7 @@ export interface NamespaceMembershipList {
 export interface Namespace {
     name: string;
     extensions: { [key: string]: string };
-    access: 'public' | 'restricted';
+    verified: boolean;
     membersUrl: UrlString;
     roleUrl: UrlString;
 }

--- a/webui/src/pages/admin-dashboard/namespace-admin.tsx
+++ b/webui/src/pages/admin-dashboard/namespace-admin.tsx
@@ -82,6 +82,7 @@ export const NamespaceAdmin: FunctionComponent = props => {
                             setLoadingState={setLoading}
                             namespace={currentNamespace}
                             filterUsers={() => true}
+                            fixSelf={false}
                         />
                     </NamespaceDetailConfigContext.Provider>
                     : notFound ?

--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -193,22 +193,6 @@ class ExtensionDetailOverviewComponent extends React.Component<ExtensionDetailOv
                             </Box>
                             : null
                         }
-                        <Box mt={2} className={classes.moreInfo}>
-                            <Typography variant='h6'>More Information</Typography>
-                            {this.renderInfo('Namespace',
-                                <RouteLink
-                                    to={addQuery(ExtensionListRoutes.MAIN, [{ key: 'search', value: extension.namespace }])}
-                                    className={classes.link}>
-                                    {extension.namespace}
-                                </RouteLink>)}
-                            {this.renderInfo('Access Type',
-                                <Link
-                                    href={this.context.pageSettings.urls.namespaceAccessInfo}
-                                    target='_blank'
-                                    className={classes.link}>
-                                    {extension.namespaceAccess || 'unknown'}
-                                </Link>)}
-                        </Box>
                         <Box mt={2}>
                             {ClaimNamespace ? <ClaimNamespace extension={extension} className={classes.resourceLink} /> : ''}
                             {ReportAbuse ? <ReportAbuse extension={extension} className={classes.resourceLink} /> : ''}

--- a/webui/src/pages/extension-detail/extension-detail.tsx
+++ b/webui/src/pages/extension-detail/extension-detail.tsx
@@ -13,7 +13,6 @@ import { Typography, Box, createStyles, Theme, WithStyles, withStyles, Container
 import { RouteComponentProps, Switch, Route, Link as RouteLink } from 'react-router-dom';
 import SaveAltIcon from '@material-ui/icons/SaveAlt';
 import VerifiedUserIcon from '@material-ui/icons/VerifiedUser';
-import PublicIcon from '@material-ui/icons/Public';
 import WarningIcon from '@material-ui/icons/Warning';
 import { MainContext } from '../../context';
 import { createRoute } from '../../utils';
@@ -130,7 +129,7 @@ const detailStyles = (theme: Theme) => createStyles({
         color: '#000',
         '& a': {
             color: '#000',
-            fontWeight: 'bold'
+            textDecoration: 'underline'
         }
     },
     warningDark: {
@@ -138,7 +137,7 @@ const detailStyles = (theme: Theme) => createStyles({
         color: '#fff',
         '& a': {
             color: '#fff',
-            fontWeight: 'bold'
+            textDecoration: 'underline'
         }
     }
 });
@@ -294,38 +293,20 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
         const classes = this.props.classes;
         const warningClass = themeType === 'dark' ? classes.warningDark : classes.warningLight;
         const themeClass = themeType === 'dark' ? classes.darkTheme : classes.lightTheme;
-        if (extension.namespaceAccess === 'public') {
-            return <Paper className={`${classes.banner} ${warningClass} ${themeClass}`}>
-                <PublicIcon fontSize='large' />
-                <Box ml={1}>
-                    The namespace <span className={classes.code}>{extension.namespace}</span> is public,
-                    which means that everyone can publish new versions of
-                    the &ldquo;{extension.displayName || extension.name}&rdquo; extension.
-                    If you would like to become the owner of <span className={classes.code}>{extension.namespace}</span>,
-                    please <Link
-                        href={this.context.pageSettings.urls.namespaceAccessInfo}
-                        target='_blank'
-                        className={`${classes.link}`} >
-                        read this guide
-                    </Link>.
-                </Box>
-            </Paper>;
-        } else if (extension.unrelatedPublisher) {
+        if (!extension.verified) {
             return <Paper className={`${classes.banner} ${warningClass} ${themeClass}`}>
                 <WarningIcon fontSize='large' />
                 <Box ml={1}>
-                    The &ldquo;{extension.displayName || extension.name}&rdquo; extension was published
-                    by <Link href={extension.publishedBy.homepage}
-                        className={`${classes.link}`}>
+                    This version of the &ldquo;{extension.displayName || extension.name}&rdquo; extension was published
+                    by <Link href={extension.publishedBy.homepage}>
                         {extension.publishedBy.loginName}
-                    </Link>. This user account is not related to
-                    the namespace <span className={classes.code}>{extension.namespace}</span> of
+                    </Link>. That user account is not a verified publisher of
+                    the namespace &ldquo;{extension.namespace}&rdquo; of
                     this extension. <Link
                         href={this.context.pageSettings.urls.namespaceAccessInfo}
-                        target='_blank'
-                        className={`${classes.link}`} >
+                        target='_blank' >
                         See the documentation
-                    </Link> to learn how we handle namespaces.
+                    </Link> to learn how we handle namespaces and what you can do to eliminate this warning.
                 </Box>
             </Paper>;
         }
@@ -392,22 +373,12 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
     protected renderAccessInfo(extension: Extension, themeClass: string): React.ReactNode {
         let icon: React.ReactElement;
         let title: string;
-        switch (extension.namespaceAccess) {
-            case 'public':
-                icon = <PublicIcon fontSize='small' />;
-                title = 'Public namespace access';
-                break;
-            case 'restricted':
-                if (extension.unrelatedPublisher) {
-                    icon = <WarningIcon fontSize='small' />;
-                    title = 'Published to a restricted namespace by an unrelated user';
-                } else {
-                    icon = <VerifiedUserIcon fontSize='small' />;
-                    title = 'Restricted namespace access';
-                }
-                break;
-            default:
-                return null;
+        if (extension.verified) {
+            icon = <VerifiedUserIcon fontSize='small' />;
+            title = 'Verified publisher';
+        } else {
+            icon = <WarningIcon fontSize='small' />;
+            title = 'Unverified publisher';
         }
         return <Link
             href={this.context.pageSettings.urls.namespaceAccessInfo}

--- a/webui/src/pages/user/user-namespace-member-component.tsx
+++ b/webui/src/pages/user/user-namespace-member-component.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react';
 import { Box, Typography, Avatar, Select, MenuItem, Button, Theme, createStyles } from '@material-ui/core';
 import { withStyles, WithStyles } from '@material-ui/styles';
-import { NamespaceMembership, MembershipRole, Namespace } from '../../extension-registry-types';
+import { NamespaceMembership, MembershipRole, Namespace, UserData } from '../../extension-registry-types';
 import { MainContext } from '../../context';
 
 const memberStyle = (theme: Theme) => createStyles({
@@ -56,6 +56,7 @@ class UserNamespaceMemberComponent extends React.Component<UserNamespaceMember.P
 
     render(): React.ReactNode {
         const memberUser = this.props.member.user;
+        const contextUser = this.context.user;
         return <Box key={'member:' + memberUser.loginName} p={2} display='flex' alignItems='center'>
             <Box alignItems='center' overflow='auto' width='33%'>
                 <Typography classes={{ root: this.props.classes.memberName }}>{memberUser.loginName}</Typography>
@@ -70,41 +71,44 @@ class UserNamespaceMemberComponent extends React.Component<UserNamespaceMember.P
             }
             <Box className={this.props.classes.buttonContainer}>
                 {
-                    memberUser.loginName === this.context.user?.loginName && memberUser.provider === this.context.user?.provider && memberUser.role && memberUser.role !== 'admin' ?
-                        '' :
-                        <Box m={1}>
-                            <Select
-                                variant='outlined'
-                                classes={{ outlined: this.props.classes.selectOutlined }}
-                                value={this.props.member.role}
-                                onChange={(event: React.ChangeEvent<{ value: MembershipRole }>) => this.props.onChangeRole(event.target.value)}>
-                                <MenuItem value='contributor'>Contributor</MenuItem>
-                                <MenuItem value='owner'>Owner</MenuItem>
-                            </Select>
-                        </Box>
-                }
-                {
-                    memberUser.loginName === this.context.user?.loginName && memberUser.provider === this.context.user?.provider && memberUser.role !== 'admin' ?
+                    this.props.fixSelf && equalUser(memberUser, contextUser) ?
                         <Box className={this.props.classes.owner}>
                             Owner
                         </Box>
                         :
-                        <Button
-                            variant='outlined'
-                            classes={{ root: this.props.classes.deleteBtn }}
-                            onClick={() => this.props.onRemoveUser()}>
-                            Delete
-                        </Button>
+                        <>
+                            <Box m={1}>
+                                <Select
+                                    variant='outlined'
+                                    classes={{ outlined: this.props.classes.selectOutlined }}
+                                    value={this.props.member.role}
+                                    onChange={(event: React.ChangeEvent<{ value: MembershipRole }>) => this.props.onChangeRole(event.target.value)}>
+                                    <MenuItem value='contributor'>Contributor</MenuItem>
+                                    <MenuItem value='owner'>Owner</MenuItem>
+                                </Select>
+                            </Box>
+                            <Button
+                                variant='outlined'
+                                classes={{ root: this.props.classes.deleteBtn }}
+                                onClick={() => this.props.onRemoveUser()}>
+                                Delete
+                            </Button>
+                        </>
                 }
             </Box>
         </Box>;
     }
 }
 
+function equalUser(user1: UserData | undefined, user2: UserData | undefined) {
+    return user1?.loginName === user2?.loginName && user1?.provider === user2?.provider;
+}
+
 export namespace UserNamespaceMember {
     export interface Props extends WithStyles<typeof memberStyle> {
         namespace: Namespace;
         member: NamespaceMembership;
+        fixSelf: boolean;
         onChangeRole: (role: MembershipRole) => void;
         onRemoveUser: () => void;
     }

--- a/webui/src/pages/user/user-namespace-member-list.tsx
+++ b/webui/src/pages/user/user-namespace-member-list.tsx
@@ -33,13 +33,7 @@ const useStyles = makeStyles((theme) => ({
     }
 }));
 
-interface UserNamespaceMemberListProps {
-    namespace: Namespace;
-    setLoadingState: (loadingState: boolean) => void;
-    filterUsers: (user: UserData) => boolean;
-}
-
-export const UserNamespaceMemberList: FunctionComponent<UserNamespaceMemberListProps> = props => {
+export const UserNamespaceMemberList: FunctionComponent<UserNamespaceMemberList.Props> = props => {
     const classes = useStyles();
     const { service, user, handleError } = useContext(MainContext);
     const [members, setMembers] = useState<NamespaceMembership[]>([]);
@@ -82,36 +76,43 @@ export const UserNamespaceMemberList: FunctionComponent<UserNamespaceMemberListP
         }
     };
 
-    return (<>
-        {
-            user ?
-                <>
-                    <Box className={classes.memberListHeader}>
-                        <Typography variant='h5'>Members in {props.namespace.name}</Typography>
-                        <Button className={classes.addButton} variant='outlined' onClick={handleOpenAddDialog}>
-                            Add Namespace Member
-                        </Button>
-                    </Box>
-                    {members.length ?
-                        <Paper>
-                            {members.map(member =>
-                                <UserNamespaceMember
-                                    key={'nspcmbr-' + member.user.loginName + member.user.provider}
-                                    namespace={props.namespace}
-                                    member={member}
-                                    onChangeRole={role => changeRole(member, role)}
-                                    onRemoveUser={() => changeRole(member, 'remove')} />)}
-                        </Paper> :
-                        <Typography variant='body1'>There are no members assigned yet.</Typography>}
-                    <AddMemberDialog
-                        members={members}
+    if (!user) {
+        return null;
+    }
+    return <>
+        <Box className={classes.memberListHeader}>
+            <Typography variant='h5'>Members in {props.namespace.name}</Typography>
+            <Button className={classes.addButton} variant='outlined' onClick={handleOpenAddDialog}>
+                Add Namespace Member
+            </Button>
+        </Box>
+        {members.length ?
+            <Paper>
+                {members.map(member =>
+                    <UserNamespaceMember
+                        key={'nspcmbr-' + member.user.loginName + member.user.provider}
                         namespace={props.namespace}
-                        onClose={handleCloseAddDialog}
-                        open={addDialogIsOpen}
-                        setLoadingState={props.setLoadingState}
-                        filterUsers={props.filterUsers} />
-                </>
-                : ''
-        }
-    </>);
+                        member={member}
+                        fixSelf={props.fixSelf}
+                        onChangeRole={role => changeRole(member, role)}
+                        onRemoveUser={() => changeRole(member, 'remove')} />)}
+            </Paper> :
+            <Typography variant='body1'>There are no members assigned yet.</Typography>}
+        <AddMemberDialog
+            members={members}
+            namespace={props.namespace}
+            onClose={handleCloseAddDialog}
+            open={addDialogIsOpen}
+            setLoadingState={props.setLoadingState}
+            filterUsers={props.filterUsers} />
+    </>;
 };
+
+export namespace UserNamespaceMemberList {
+    export interface Props {
+        namespace: Namespace;
+        setLoadingState: (loadingState: boolean) => void;
+        filterUsers: (user: UserData) => boolean;
+        fixSelf: boolean;
+    }
+}

--- a/webui/src/pages/user/user-settings-namespace-detail.tsx
+++ b/webui/src/pages/user/user-settings-namespace-detail.tsx
@@ -35,13 +35,7 @@ const useStyles = makeStyles((theme) => ({
     }
 }));
 
-export interface NamespaceProps {
-    namespace: Namespace;
-    filterUsers: (user: UserData) => boolean;
-    setLoadingState: (loading: boolean) => void;
-}
-
-export const NamespaceDetail: FunctionComponent<NamespaceProps> = props => {
+export const NamespaceDetail: FunctionComponent<NamespaceDetail.Props> = props => {
     const classes = useStyles();
 
     return <>
@@ -50,7 +44,8 @@ export const NamespaceDetail: FunctionComponent<NamespaceProps> = props => {
                 <UserNamespaceMemberList
                     setLoadingState={props.setLoadingState}
                     namespace={props.namespace}
-                    filterUsers={props.filterUsers} />
+                    filterUsers={props.filterUsers}
+                    fixSelf={props.fixSelf} />
             </Grid>
             <Grid item>
                 <UserNamespaceExtensionListContainer
@@ -60,3 +55,12 @@ export const NamespaceDetail: FunctionComponent<NamespaceProps> = props => {
         </Grid>
     </>;
 };
+
+export namespace NamespaceDetail {
+    export interface Props {
+        namespace: Namespace;
+        filterUsers: (user: UserData) => boolean;
+        fixSelf: boolean;
+        setLoadingState: (loading: boolean) => void;
+    }
+}

--- a/webui/src/pages/user/user-settings-namespaces.tsx
+++ b/webui/src/pages/user/user-settings-namespaces.tsx
@@ -119,7 +119,8 @@ class UserSettingsNamespacesComponent extends React.Component<UserSettingsNamesp
                             <NamespaceDetail
                                 namespace={namespace}
                                 setLoadingState={loading => this.setState({ loading })}
-                                filterUsers={foundUser => foundUser.provider !== user?.provider || foundUser.loginName !== user?.loginName} />
+                                filterUsers={foundUser => foundUser.provider !== user?.provider || foundUser.loginName !== user?.loginName}
+                                fixSelf={true} />
                         </Box>
                     </React.Fragment>
                     : !this.state.loading ? <Typography variant='body1'>No namespaces available. {


### PR DESCRIPTION
Fixes #217. This changes the handling of namespaces:

 * Removed the concept of public namespaces: only members of a namespace can publish to it.
 * When someone creates a namespace, they automatically become a contributor of that namespace.
 * Extensions are shown as _verified_ in the UI if the publisher is a member of the namespace and the namespace has at least one owner. Otherwise the extensions are shown as _unverified_ with a warning icon and an explanatory banner.

Namespaces with no members are now called _orphaned_. There should be no orphaned namespaces, therefore a migration is executed on startup:
 * All previous publishers to an orphaned namespace are added as contributors.
 * Orphaned namespaces with no published extensions are deleted.