### PR TITLE
Implemented Publisher Agreement compliance check

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/eclipse/PublisherComplianceChecker.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/PublisherComplianceChecker.java
@@ -1,0 +1,115 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.eclipse;
+
+import java.util.LinkedHashSet;
+
+import javax.persistence.EntityManager;
+
+import org.eclipse.openvsx.ExtensionService;
+import org.eclipse.openvsx.entities.Extension;
+import org.eclipse.openvsx.entities.PersonalAccessToken;
+import org.eclipse.openvsx.entities.UserData;
+import org.eclipse.openvsx.repositories.RepositoryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.util.Streamable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Component
+public class PublisherComplianceChecker {
+
+    protected final Logger logger = LoggerFactory.getLogger(PublisherComplianceChecker.class);
+
+    @Autowired
+    TransactionTemplate transactions;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Autowired
+    RepositoryService repositories;
+
+    @Autowired
+    ExtensionService extensions;
+
+    @Autowired
+    EclipseService eclipseService;
+
+    @Value("${ovsx.eclipse.check-compliance-on-start:false}")
+    boolean checkCompliance;
+
+    @EventListener
+    public void checkPublishers(ApplicationStartedEvent event) {
+        if (!checkCompliance || !eclipseService.isActive())
+            return;
+
+        repositories.findAllUsers().forEach(user -> {
+            var accessTokens = repositories.findAccessTokens(user);
+            if (!accessTokens.isEmpty() && !isCompliant(user)) {
+                // Found a non-compliant publisher: deactivate all extension versions
+                transactions.<Void>execute(status -> {
+                    deactivateExtensions(accessTokens);
+                    return null;
+                });
+            }
+        });
+    }
+
+    private boolean isCompliant(UserData user) {
+        // Users without authentication provider have been created directly in the DB,
+        // so we skip the agreement check in this case.
+        if (user.getProvider() == null) {
+            return true;
+        }
+        var eclipseData = user.getEclipseData();
+        if (eclipseData == null || eclipseData.personId == null) {
+            // The user has never logged in with Eclipse
+            return false;
+        }
+        if (eclipseData.publisherAgreement == null || !eclipseData.publisherAgreement.isActive) {
+            // We don't have any active PA in our DB, let's check their Eclipse profile
+            var profile = eclipseService.getPublicProfile(eclipseData.personId);
+            if (profile.publisherAgreements == null || profile.publisherAgreements.openVsx == null
+                    || profile.publisherAgreements.openVsx.version == null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void deactivateExtensions(Streamable<PersonalAccessToken> accessTokens) {
+        var affectedExtensions = new LinkedHashSet<Extension>();
+        for (var accessToken : accessTokens) {
+            var versions = repositories.findVersionsByAccessToken(accessToken, true);
+            for (var version : versions) {
+                version.setActive(false);
+                entityManager.merge(version);
+                affectedExtensions.add(version.getExtension());
+                logger.info("Deactivated: " + accessToken.getUser().getLoginName() + " - "
+                        + version.getExtension().getNamespace().getName()
+                        + "." + version.getExtension().getName()
+                        + " v" + version.getVersion());
+            }
+        }
+        
+        // Update affected extensions
+        for (var extension : affectedExtensions) {
+            extensions.updateExtension(extension);
+            entityManager.merge(extension);
+        }
+    }
+    
+}

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -187,6 +187,10 @@ public class RepositoryService {
         return userDataRepo.findByLoginNameStartingWith(loginNameStart);
     }
 
+    public Streamable<UserData> findAllUsers() {
+        return userDataRepo.findAll();
+    }
+
     public long countUsers() {
         return userDataRepo.count();
     }

--- a/server/src/main/java/org/eclipse/openvsx/repositories/UserDataRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/UserDataRepository.java
@@ -21,6 +21,8 @@ public interface UserDataRepository extends Repository<UserData, Long> {
 
     Streamable<UserData> findByLoginNameStartingWith(String loginNameStart);
 
+    Streamable<UserData> findAll();
+
     long count();
 
 }


### PR DESCRIPTION
This PR adds an application startup task that can be enabled with the property `ovsx.eclipse.check-compliance-on-start`. It checks the Publisher Agreement status of all publishers and disables extension versions for which there is no active Publisher Agreement. This task should be run once after the grace period of the transition of open-vsx.org to the Eclipse Foundation has expired (January 9th, 2021). See [this blog post](https://blogs.eclipse.org/post/brian-king/new-era-open-vsx-registry) for more details.