### PR TITLE
Ignore case when finding default files

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
@@ -43,18 +43,9 @@ public class ExtensionProcessor implements AutoCloseable {
 
     private static final String PACKAGE_JSON = "extension/package.json";
     private static final String PACKAGE_NLS_JSON = "extension/package.nls.json";
-    private static final String[] README = {
-        "extension/README.md",  "extension/Readme.md",  "extension/readme.md",
-        "extension/README",     "extension/Readme",     "extension/readme",
-        "extension/README.txt", "extension/Readme.txt", "extension/readme.txt" };
-    private static final String[] LICENSE = {
-        "extension/LICENSE.md",  "extension/License.md",  "extension/license.md",
-        "extension/LICENSE",     "extension/License",     "extension/license",
-        "extension/LICENSE.txt", "extension/License.txt", "extension/license.txt" };
-    private static final String[] CHANGELOG = {
-        "extension/CHANGELOG.md",  "extension/Changelog.md",  "extension/changelog.md",
-        "extension/CHANGELOG",     "extension/Changelog",     "extension/changelog",
-        "extension/CHANGELOG.txt", "extension/Changelog.txt", "extension/changelog.txt" };
+    private static final String[] README = { "extension/README.md", "extension/README", "extension/README.txt" };
+    private static final String[] LICENSE = { "extension/LICENSE.md", "extension/LICENSE", "extension/LICENSE.txt" };
+    private static final String[] CHANGELOG = { "extension/CHANGELOG.md", "extension/CHANGELOG", "extension/CHANGELOG.txt" };
 
     private static final int MAX_CONTENT_SIZE = 512 * 1024 * 1024;
     private static final Pattern LICENSE_PATTERN = Pattern.compile("SEE( (?<license>\\S+))? LICENSE IN (?<file>\\S+)");
@@ -347,10 +338,11 @@ public class ExtensionProcessor implements AutoCloseable {
 
     private Pair<byte[], String> readFromAlternateNames(String[] names) {
         for (var name : names) {
-            var bytes = ArchiveUtil.readEntry(zipFile, name);
-            if (bytes != null) {
-                var lastSegmentIndex = name.lastIndexOf('/');
-                var lastSegment = name.substring(lastSegmentIndex + 1);
+            var entry = ArchiveUtil.getEntryIgnoreCase(zipFile, name);
+            if (entry != null) {
+                var bytes = ArchiveUtil.readEntry(zipFile, entry);
+                var lastSegmentIndex = entry.getName().lastIndexOf('/');
+                var lastSegment = entry.getName().substring(lastSegmentIndex + 1);
                 return Pair.of(bytes, lastSegment);
             }
         }

--- a/server/src/test/java/org/eclipse/openvsx/util/ArchiveUtilTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/util/ArchiveUtilTest.java
@@ -11,7 +11,7 @@ package org.eclipse.openvsx.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.io.ByteStreams;
+import java.util.zip.ZipFile;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,13 +19,14 @@ public class ArchiveUtilTest {
 
     @Test
     public void testTodoTree() throws Exception {
+        var packageUrl = getClass().getResource("todo-tree.zip");
+        assertThat(packageUrl.getProtocol()).isEqualTo("file");
         try (
-            var stream = getClass().getResourceAsStream("todo-tree.zip");
+            var archive = new ZipFile(packageUrl.getPath());
         ) {
-            var bytes = ByteStreams.toByteArray(stream);
-            var packageJson = ArchiveUtil.readEntry(bytes, "extension/package.json");
+            var packageJson = ArchiveUtil.readEntry(archive, "extension/package.json");
             assertThat(packageJson.length).isEqualTo(24052);
-            var icon = ArchiveUtil.readEntry(bytes, "extension/resources/todo-tree.png");
+            var icon = ArchiveUtil.readEntry(archive, "extension/resources/todo-tree.png");
             assertThat(icon.length).isEqualTo(8854);
         }
     }


### PR DESCRIPTION
Fixes #200. This is a follow-up of #230 that generalizes retrieval of default files (README, LICENSE, CHANGELOG) by ignoring case in their names.