### PR TITLE
refactor(cli): Update ./cli/check-licence.ts

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,3 +12,5 @@ export * from './create-namespace';
 export * from './get';
 export * from './publish';
 export * from './registry';
+export { isLicenseOk } from './check-license';
+export { validateManifest, readManifest } from './util';

--- a/cli/src/publish.ts
+++ b/cli/src/publish.ts
@@ -10,7 +10,7 @@
 
 import { createVSIX } from 'vsce';
 import { createTempFile, addEnvOptions } from './util';
-import { Registry, DEFAULT_URL, RegistryOptions } from './registry';
+import { Registry, RegistryOptions } from './registry';
 import { checkLicense } from './check-license';
 
 /**
@@ -33,12 +33,6 @@ export async function publish(options: PublishOptions = {}): Promise<void> {
         throw new Error(extension.error);
     }
     console.log(`\ud83d\ude80  Published ${extension.namespace}.${extension.name} v${extension.version}`);
-    if (registry.url === DEFAULT_URL) {
-        console.log('The open-vsx.org website will be transferred to the Eclipse Foundation on December 9. '
-            + 'Please read the blog post referenced below to find out more. '
-            + 'Some action will be required so you can continue publishing.\n'
-            + 'https://blogs.eclipse.org/post/brian-king/open-vsx-registry-under-new-management');
-    }
 }
 
 export interface PublishOptions extends RegistryOptions {
@@ -67,7 +61,7 @@ export interface PublishOptions extends RegistryOptions {
 
 async function packageExtension(options: PublishOptions, registry: Registry): Promise<void> {
     if (registry.requiresLicense) {
-        await checkLicense(options.packagePath);
+        await checkLicense(options.packagePath!);
     }
 
     options.extensionFile = await createTempFile({ postfix: '.vsix' });

--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -114,6 +114,18 @@ export async function readManifest(packagePath?: string): Promise<Manifest> {
     return JSON.parse(content);
 }
 
+export function validateManifest(manifest: Manifest): void {
+    if (!manifest.publisher) {
+        throw new Error("Missing required field 'publisher'.");
+    }
+    if (!manifest.name) {
+        throw new Error("Missing required field 'name'.");
+    }
+    if (!manifest.version) {
+        throw new Error("Missing required field 'version'.");
+    }
+}
+
 export function writeFile(name: string, content: string, packagePath?: string, encoding = 'utf-8'): Promise<void> {
     return new Promise((resolve, reject) => {
         fs.writeFile(


### PR DESCRIPTION
Add **isLicenceOk** function to check the presence of licence, `validateManifest` function is exported as well to remove duplication [here](https://github.com/open-vsx/publish-extensions/blob/master/add-extension.js#L114)

There is described use case https://github.com/eclipse/openvsx/issues/222#issuecomment-759971119

**publish workflow behaviour is the same without any changes.**