### PR TITLE
Reverted max-duration to 10m for resources with variable version.

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
@@ -98,7 +98,7 @@ public class RegistryAPI {
         for (var registry : getRegistries()) {
             try {
                 return ResponseEntity.ok()
-                        .cacheControl(CacheControl.maxAge(7, TimeUnit.DAYS).cachePublic())
+                        .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic())
                         .body(registry.getNamespace(namespace));
             } catch (NotFoundException exc) {
                 // Try the next registry
@@ -133,7 +133,7 @@ public class RegistryAPI {
         for (var registry : getRegistries()) {
             try {
                 return ResponseEntity.ok()
-                        .cacheControl(CacheControl.maxAge(7, TimeUnit.DAYS).cachePublic())
+                        .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic())
                         .body(registry.getExtension(namespace, extension));
             } catch (NotFoundException exc) {
                 // Try the next registry


### PR DESCRIPTION
Towards #266, see [this comment](https://github.com/eclipse/openvsx/pull/271#pullrequestreview-617543160)

Signed-off-by: Daniel Dietrich <daniel.dietrich@typefox.io>