### PR TITLE
Updated vsce version

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This change log covers only the command line interface (CLI) of Open VSX.
 
-### v0.1.0 (Apr. 2020)
+### v0.2.0 (Apr. 2021)
+
+New features:
+ * Added CLI parameter `--web` for web extensions ([#262](https://github.com/eclipse/openvsx/pull/262))
+ * Updated the `vsce` dependency from 1.84.0 to 1.87.1 ([#288](https://github.com/eclipse/openvsx/pull/288))
+
+-----
+
+### v0.1.0 (Apr. 2021)
 
 First release of Open VSX with the Eclipse Foundation.

--- a/cli/package.json
+++ b/cli/package.json
@@ -40,7 +40,7 @@
         "follow-redirects": "^1.13.2",
         "is-ci": "^2.0.0",
         "leven": "^3.1.0",
-        "vsce": "~1.84.0"
+        "vsce": "~1.87.1"
     },
     "devDependencies": {
         "@types/follow-redirects": "^1.13.0",

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -1131,10 +1131,10 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
   integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
 
-vsce@~1.84.0:
-  version "1.84.0"
-  resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.84.0.tgz#1c489212bfde2f37e20dbeb17954e56903f38bee"
-  integrity sha512-mRJDTMC/1GO7byz6dleY28CZo97cM1p0nU3EEMT5bGMpi5Yga3dKdgTvmwgSQF5BYWozNSNSqN1zih5SYzMZjA==
+vsce@~1.87.1:
+  version "1.87.1"
+  resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.87.1.tgz#22b1dae5412b200aa3c43455e4c798a04d631ddd"
+  integrity sha512-3tSUWZl9AmhZrqy/UVUpdPODSzBiCGjIr/AMSSgF2PuFLSdrh+6kiOr2Ath7bpQEXOxf55hNgz3qdO5MuEJmww==
   dependencies:
     azure-devops-node-api "^7.2.0"
     chalk "^2.4.2"


### PR DESCRIPTION
After the version update, the `ovsx` cli tool works fine. I tested the following scenarios:

* [x] publishing different pre-packaged non-web extensions and extension packs
* [x] publishing a pre-packaged web extension using the `--web` parameter
* [x] publishing a web extension from source using the `--web` and `--yarn` parameters

I will merge this PR and publish the latest version to the staging area.