### PR TITLE
server: allow every origin to access api endpoint

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/web/WebConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/WebConfig.java
@@ -44,6 +44,8 @@ public class WebConfig implements WebMvcConfigurer {
             }
             registry.addMapping("/documents/**")
                     .allowedOrigins("*");
+            registry.addMapping("/api/**")
+                    .allowedOrigins("*");
         }
     }
 


### PR DESCRIPTION
**Description**

Fixes: #289 

The following commit allows access to the `api` endpoint for all origins. Previously, the `api` endpoint was not accessible by `cors`
issues. The `"/api/*/*/review/**` remains protected (accessible only through the `webUI`).

I verified the changes (through gitpod) by making requests to the exposed server, and noticed that the headers were correctly set for the endpoint. I also verified that the other endpoints were still restricted to the `webUI`.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>