### PR TITLE
Web extension support fix

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/adapter/ExtensionQueryResult.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/ExtensionQueryResult.java
@@ -87,6 +87,7 @@ public class ExtensionQueryResult {
         public static final String PROP_LOCALIZED_LANGUAGES = "Microsoft.VisualStudio.Code.LocalizedLanguages";
         public static final String PROP_BRANDING_COLOR = "Microsoft.VisualStudio.Services.Branding.Color";
         public static final String PROP_BRANDING_THEME = "Microsoft.VisualStudio.Services.Branding.Theme";
+        public static final String PROP_WEB_EXTENSION = "Microsoft.VisualStudio.Code.WebExtension";
 
         public String key;
         public String value;

--- a/server/src/main/java/org/eclipse/openvsx/util/UrlUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/UrlUtil.java
@@ -15,8 +15,10 @@ import java.nio.charset.Charset;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerMapping;
 
 public final class UrlUtil {
 
@@ -132,6 +134,22 @@ public final class UrlUtil {
 
         url.append(request.getContextPath());
         return url.toString();
+    }
+
+    /**
+     * Extract the rest ** of a wildcard path /<segments>/**
+     * @param request incoming request
+     * @return rest of the path
+     */
+    public static String extractWildcardPath(HttpServletRequest request){
+        String path = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+        String bestMatchPattern = (String ) request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        if (path == null || bestMatchPattern == null) {
+            return "";
+        } else {
+            String restOfPath = new AntPathMatcher().extractPathWithinPattern(bestMatchPattern, path);
+            return restOfPath;
+        }
     }
 
 }


### PR DESCRIPTION
Added web extension property to vscode adapter query result.
Fixes assetType spanning multiple path segments.

Signed-off-by: Daniel Dietrich <daniel.dietrich@typefox.io>