### PR TITLE
fix #317: use thread-safe entity manager

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -61,4 +61,7 @@ tasks:
 
 vscode:
   extensions:
-    - dbaeumer.vscode-eslint@2.1.3:1NRvj3UKNTNwmYjptmUmIw==
+    - dbaeumer.vscode-eslint
+    - redhat.java
+    - vscjava.vscode-java-debug
+    - vscjava.vscode-java-test

--- a/server/src/main/java/org/eclipse/openvsx/AdminService.java
+++ b/server/src/main/java/org/eclipse/openvsx/AdminService.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashSet;
 import java.util.stream.Collectors;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
 
 import com.google.common.base.Strings;
@@ -51,7 +52,7 @@ public class AdminService {
     @Autowired
     ExtensionService extensions;
 
-    @Autowired
+    @PersistenceContext
     EntityManager entityManager;
 
     @Autowired

--- a/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
 
@@ -39,7 +40,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ExtensionService {
 
-    @Autowired
+    @PersistenceContext
     EntityManager entityManager;
 
     @Autowired

--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
 
 import com.google.common.base.Strings;
@@ -65,7 +66,7 @@ import org.springframework.web.server.ResponseStatusException;
 @Component
 public class LocalRegistryService implements IExtensionRegistry {
 
-    @Autowired
+    @PersistenceContext
     EntityManager entityManager;
 
     @Autowired

--- a/server/src/main/java/org/eclipse/openvsx/UserAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/UserAPI.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.transaction.Transactional;
 
@@ -55,7 +56,7 @@ public class UserAPI {
 
     private final static int TOKEN_DESCRIPTION_SIZE = 255;
 
-    @Autowired
+    @PersistenceContext
     EntityManager entityManager;
 
     @Autowired

--- a/server/src/main/java/org/eclipse/openvsx/UserService.java
+++ b/server/src/main/java/org/eclipse/openvsx/UserService.java
@@ -12,6 +12,7 @@ package org.eclipse.openvsx;
 import java.util.UUID;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
 
 import org.eclipse.openvsx.entities.Namespace;
@@ -31,7 +32,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class UserService {
 
-    @Autowired
+    @PersistenceContext
     EntityManager entityManager;
 
     @Autowired

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAdapter.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAdapter.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import javax.servlet.http.HttpServletRequest;
 
 import com.google.common.base.Strings;
@@ -62,7 +63,7 @@ import org.springframework.web.servlet.ModelAndView;
 @RestController
 public class VSCodeAdapter {
 
-    @Autowired
+    @PersistenceContext
     EntityManager entityManager;
 
     @Autowired

--- a/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -82,7 +83,7 @@ public class EclipseService {
     @Autowired
     ExtensionService extensions;
 
-    @Autowired
+    @PersistenceContext
     EntityManager entityManager;
 
     @Autowired

--- a/server/src/main/java/org/eclipse/openvsx/eclipse/PublisherComplianceChecker.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/PublisherComplianceChecker.java
@@ -12,6 +12,7 @@ package org.eclipse.openvsx.eclipse;
 import java.util.LinkedHashSet;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 
 import org.eclipse.openvsx.ExtensionService;
 import org.eclipse.openvsx.entities.Extension;
@@ -36,7 +37,7 @@ public class PublisherComplianceChecker {
     @Autowired
     TransactionTemplate transactions;
 
-    @Autowired
+    @PersistenceContext
     EntityManager entityManager;
 
     @Autowired

--- a/server/src/main/java/org/eclipse/openvsx/migration/OrphanNamespaceMigration.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/OrphanNamespaceMigration.java
@@ -12,6 +12,7 @@ package org.eclipse.openvsx.migration;
 import java.util.LinkedHashSet;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
 
 import org.eclipse.openvsx.entities.NamespaceMembership;
@@ -29,7 +30,7 @@ public class OrphanNamespaceMigration {
 
     protected final Logger logger = LoggerFactory.getLogger(OrphanNamespaceMigration.class);
 
-    @Autowired
+    @PersistenceContext
     EntityManager entityManager;
 
     @Autowired

--- a/server/src/main/java/org/eclipse/openvsx/security/OAuth2UserServices.java
+++ b/server/src/main/java/org/eclipse/openvsx/security/OAuth2UserServices.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 
 import com.google.common.base.Strings;
 
@@ -52,7 +53,7 @@ public class OAuth2UserServices {
     @Autowired
     RepositoryService repositories;
 
-    @Autowired
+    @PersistenceContext
     EntityManager entityManager;
 
     @Autowired

--- a/server/src/main/java/org/eclipse/openvsx/security/TokenService.java
+++ b/server/src/main/java/org/eclipse/openvsx/security/TokenService.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 import java.util.Arrays;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,7 +45,7 @@ public class TokenService {
     @Autowired
     TransactionTemplate transactions;
 
-    @Autowired
+    @PersistenceContext
     EntityManager entityManager;
 
     @Autowired

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageMigration.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageMigration.java
@@ -15,6 +15,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ScheduledFuture;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 
 import org.apache.jena.ext.com.google.common.collect.Lists;
 import org.eclipse.openvsx.entities.FileResource;
@@ -41,7 +42,7 @@ public class StorageMigration {
     @Autowired
     TransactionTemplate transactions;
 
-    @Autowired
+    @PersistenceContext
     EntityManager entityManager;
 
     @Autowired

--- a/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -51,6 +52,8 @@ import org.eclipse.openvsx.security.TokenService;
 import org.eclipse.openvsx.storage.AzureBlobStorageService;
 import org.eclipse.openvsx.storage.GoogleCloudStorageService;
 import org.eclipse.openvsx.storage.StorageUtilService;
+import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,13 +88,25 @@ public class AdminAPITest {
     SearchService search;
 
     @MockBean
-    EntityManager entityManager;
-
-    @MockBean
     EclipseService eclipse;
 
     @Autowired
     MockMvc mockMvc;
+
+    @MockBean
+    private EntityManager entityManager;
+
+    @MockBean
+    private EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    AdminService admins;
+
+    @BeforeEach
+    public void setup() {
+        admins.entityManager = entityManager;
+        users.entityManager = entityManager;
+    }
 
     @Test
     public void testGetExtensionNotLoggedIn() throws Exception {

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -32,6 +32,10 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.eclipse.openvsx.eclipse.EclipseService;
 import org.eclipse.openvsx.entities.Extension;
@@ -59,6 +63,7 @@ import org.eclipse.openvsx.storage.AzureBlobStorageService;
 import org.eclipse.openvsx.storage.GoogleCloudStorageService;
 import org.eclipse.openvsx.storage.StorageUtilService;
 import org.elasticsearch.search.aggregations.Aggregations;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,9 +82,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.support.TransactionTemplate;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(RegistryAPI.class)
 @AutoConfigureWebClient
@@ -102,6 +104,9 @@ public class RegistryAPITest {
     EntityManager entityManager;
 
     @MockBean
+    EntityManagerFactory entityManagerFactory;
+
+    @MockBean
     EclipseService eclipse;
 
     @Autowired
@@ -109,6 +114,16 @@ public class RegistryAPITest {
 
     @Autowired
     ExtensionService extensionService;
+
+    @Autowired
+    LocalRegistryService local;
+
+    @BeforeEach
+    public void setup() {
+        users.entityManager = entityManager;
+        local.entityManager = entityManager;
+        extensionService.entityManager = entityManager;
+    }
 
     @Test
     public void testPublicNamespace() throws Exception {

--- a/server/src/test/java/org/eclipse/openvsx/TestService.java
+++ b/server/src/test/java/org/eclipse/openvsx/TestService.java
@@ -12,11 +12,11 @@ package org.eclipse.openvsx;
 import java.time.LocalDateTime;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
 
 import org.eclipse.openvsx.entities.PersonalAccessToken;
 import org.eclipse.openvsx.entities.UserData;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Component;
 @Profile("test")
 public class TestService {
     
-    @Autowired
+    @PersistenceContext
     EntityManager entityManager;
 
     @Transactional

--- a/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,6 +41,7 @@ import org.eclipse.openvsx.json.UserJson;
 import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.security.OAuth2UserServices;
 import org.eclipse.openvsx.security.TokenService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,7 +58,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 @WebMvcTest(UserAPI.class)
 @AutoConfigureWebClient
-@MockBean({ EntityManager.class, ClientRegistrationRepository.class })
+@MockBean({ ClientRegistrationRepository.class })
 public class UserAPITest {
 
     @SpyBean
@@ -70,6 +72,21 @@ public class UserAPITest {
 
     @Autowired
     MockMvc mockMvc;
+
+    @MockBean
+    EntityManager entityManager;
+
+    @MockBean
+    EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    UserAPI userAPI;
+
+    @BeforeEach
+    public void setup() {
+        userAPI.entityManager = entityManager;
+        users.entityManager = entityManager;
+    }
 
     @Test
     public void testLoggedIn() throws Exception {

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAdapterTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAdapterTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 
 import com.google.common.collect.Lists;
 import com.google.common.io.CharStreams;
@@ -44,6 +45,7 @@ import org.eclipse.openvsx.storage.AzureBlobStorageService;
 import org.eclipse.openvsx.storage.GoogleCloudStorageService;
 import org.eclipse.openvsx.storage.StorageUtilService;
 import org.elasticsearch.search.aggregations.Aggregations;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -82,10 +84,21 @@ public class VSCodeAdapterTest {
     EntityManager entityManager;
 
     @MockBean
+    EntityManagerFactory entityManagerFactory;
+
+    @MockBean
     EclipseService eclipse;
 
     @Autowired
     MockMvc mockMvc;
+
+    @Autowired
+    VSCodeAdapter adapter;
+
+    @BeforeEach
+    public void setup() {
+        adapter.entityManager = entityManager;
+    }
 
     @Test
     public void testSearch() throws Exception {

--- a/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 
 import com.google.common.io.CharStreams;
 
@@ -58,7 +59,7 @@ import org.springframework.web.client.RestTemplate;
 
 @ExtendWith(SpringExtension.class)
 @MockBean({
-    EntityManager.class, SearchService.class, GoogleCloudStorageService.class, AzureBlobStorageService.class
+    EntityManagerFactory.class, SearchService.class, GoogleCloudStorageService.class, AzureBlobStorageService.class
 })
 public class EclipseServiceTest {
 
@@ -77,8 +78,12 @@ public class EclipseServiceTest {
     @Autowired
     EclipseService eclipse;
 
+    @MockBean
+    EntityManager entityManager;
+
     @BeforeEach
     public void setup() {
+        eclipse.entityManager = entityManager;
         eclipse.publisherAgreementVersion = "1";
         eclipse.eclipseApiUrl = "https://test.openvsx.eclipse.org/";
     }


### PR DESCRIPTION
fix #317 

The fix is motivated by https://stackoverflow.com/a/58891587/961588 
> I can confirm this when talking about threads. For example, without @PersistenceContext my application runs SQL insert/update in other thread but no changes are made to the database