### PR TITLE
#306 Send CORS headers so vscode can use the API

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAdapter.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAdapter.java
@@ -274,6 +274,7 @@ public class VSCodeAdapter {
     }
 
     @GetMapping("/vscode/item")
+    @CrossOrigin
     public ModelAndView getItemUrl(@RequestParam String itemName, ModelMap model) {
         var dotIndex = itemName.indexOf('.');
         if (dotIndex < 0) {
@@ -285,6 +286,7 @@ public class VSCodeAdapter {
     }
 
     @GetMapping("/vscode/gallery/publishers/{namespace}/vsextensions/{extension}/{version}/vspackage")
+    @CrossOrigin
     public ModelAndView download(@PathVariable String namespace, @PathVariable String extension,
                                  @PathVariable String version, ModelMap model) {
         if (googleStorage.isEnabled()) {

--- a/server/src/main/java/org/eclipse/openvsx/web/WebConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/WebConfig.java
@@ -46,6 +46,8 @@ public class WebConfig implements WebMvcConfigurer {
                     .allowedOrigins("*");
             registry.addMapping("/api/**")
                     .allowedOrigins("*");
+            registry.addMapping("/vscode/**")
+                    .allowedOrigins("*");
         }
     }
 


### PR DESCRIPTION
~~Explicitly instructs Spring to send CORS headers allowing any origin.~~

~~I haven't tested this, I'm not really a Java developer and am not set up to test this project. However I believe according to the Spring documentation that this will fix the issue at-hand.~~

Fixes #306 

I went ahead and set up a test environment, and as noted by daiyam below my original fix was insufficient as Spring already defaulted to all origins. On further investigation I found that the extensionquery endpoint was not covered by the pre-existing CORS mappings as defined in WebConfig.java, due to existing outside of the /api/ endpoint root. I've added two lines to add this endpoint to the CORS mappings, which in my quick test solved the issue.