### PR TITLE
don't fail if bundled extension is missing, they are optional

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
@@ -158,10 +158,6 @@ public class ExtensionService {
         if (split.length != 2 || split[0].isEmpty() || split[1].isEmpty()) {
             throw new ErrorResultException("Invalid 'extensionPack' format. Expected: '${namespace}.${name}'");
         }
-        var extensionCount = repositories.countExtensions(split[1], split[0]);
-        if (extensionCount == 0) {
-            throw new ErrorResultException("Cannot resolve bundled extension: " + bundled);
-        }
         var depList = extVersion.getBundledExtensions();
         if (depList == null) {
             depList = new ArrayList<>();


### PR DESCRIPTION
python extensions bundles some proprietrary extensions via extension pack, so we fail to publish it. But bundled extensions are not mandatory, and bundling extension can function without it.

From https://code.visualstudio.com/api/references/extension-manifest#extension-packs: 

> An Extension Pack should not have any functional dependencies with its bundled extensions and the bundled extensions should be manageable independent of the pack. If an extension has a dependency on another extension, that dependency should be declared with the extensionDependencies attribute.

This PR removes a check that bundled extension must be published to Open VSX. And allow publishing of python extension which was broken otherwise for 10 months! 