### PR TITLE
[webui] filter out internal tags

### DIFF
--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -144,6 +144,8 @@ class ExtensionDetailOverviewComponent extends React.Component<ExtensionDetailOv
         const ReportAbuse = this.context.pageSettings.elements.reportAbuse;
         const otherAliases = Object.keys(extension.allVersions)
             .filter(version => extension.versionAlias.indexOf(version) < 0 && VERSION_ALIASES.indexOf(version) >= 0);
+        // filter internal tags
+        const tags = extension.tags?.filter(t => !t.startsWith('__'));
         return <React.Fragment>
             <Box className={classes.overview}>
                 <Box flex={5} overflow='auto'>
@@ -167,9 +169,9 @@ class ExtensionDetailOverviewComponent extends React.Component<ExtensionDetailOv
                             : null
                         }
                         {
-                            extension.tags && extension.tags.length > 0 ?
+                            tags && tags.length > 0 ?
                             <Box mt={2}>
-                                {this.renderButtonList('search', 'Tags', extension.tags)}
+                                {this.renderButtonList('search', 'Tags', tags)}
                             </Box>
                             : null
                         }


### PR DESCRIPTION
We should exclude internal tags from UI, they are used only for internal search by VS Code:
<img width="433" alt="Screenshot 2021-09-10 at 12 37 45 (1)" src="https://user-images.githubusercontent.com/3082655/132842536-0967e9e7-f9be-4bf5-a586-ca1ce47ddcf3.png">
