### PR TITLE
fix #317: make sure that public id gets persisted

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeIdService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeIdService.java
@@ -11,6 +11,7 @@ package org.eclipse.openvsx.adapter;
 
 import java.util.UUID;
 
+import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 
 import com.google.common.base.Strings;
@@ -42,6 +43,9 @@ public class VSCodeIdService {
     @Value("${ovsx.vscode.upstream.gallery-url:}")
     String upstreamUrl;
 
+    @Autowired
+    EntityManager entityManager;
+
     @Transactional
     public void createPublicId(Extension extension) {
         var upstreamExtension = getUpstreamData(extension);
@@ -55,6 +59,9 @@ public class VSCodeIdService {
             extension.setPublicId(createRandomId());
         if (extension.getNamespace().getPublicId() == null)
             extension.getNamespace().setPublicId(createRandomId());
+
+        entityManager.merge(extension);
+        entityManager.merge(extension.getNamespace());
     }
 
     private String createRandomId() {


### PR DESCRIPTION
We seen that in production public ides are not always persisted, leading to new ids on each query and breaking clients:  https://github.com/eclipse/openvsx/issues/317#issuecomment-900104912

This PR makes sure that the given entity state is merged in the current persistent context to be committed on the transaction end.