### PR TITLE
VSCode extensionQuery: reduce database queries and use DTOs

### DIFF
--- a/server/src/gatling/resources/adapter/queries-xl.csv
+++ b/server/src/gatling/resources/adapter/queries-xl.csv
@@ -1,0 +1,15 @@
+query
+s
+a
+t
+vscode
+c
+vs
+m
+cod
+f
+theme
+d
+code
+e
+p

--- a/server/src/gatling/resources/adapter/queries.csv
+++ b/server/src/gatling/resources/adapter/queries.csv
@@ -1,0 +1,6 @@
+query
+json
+yaml
+git
+java
+vscode

--- a/server/src/gatling/resources/application.properties
+++ b/server/src/gatling/resources/application.properties
@@ -1,0 +1,3 @@
+baseUrl=http://localhost:8080
+extensionDir=<EXTENSION_DIR>
+#auth=<AUTHORIZATION HEADER>

--- a/server/src/gatling/scala/org/eclipse/openvsx/RegistryAPICreateNamespaceSimulation.scala
+++ b/server/src/gatling/scala/org/eclipse/openvsx/RegistryAPICreateNamespaceSimulation.scala
@@ -1,26 +1,33 @@
 package org.eclipse.openvsx
 
+import com.typesafe.config.ConfigFactory
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 
 import scala.concurrent.duration.DurationInt
 
 class RegistryAPICreateNamespaceSimulation extends Simulation {
+  val conf = ConfigFactory.load()
 
   val httpProtocol = http
-    .baseUrl("http://localhost:8080")
+    .baseUrl(conf.getString("baseUrl"))
     .disableCaching
+
+  var headers: Map[String,String] = Map()
+  if(conf.hasPath("auth")) {
+    headers += "Authorization" -> conf.getString("auth");
+  }
 
   val users = 5
   val namespacesCount = 780
   val repeatTimes = namespacesCount / users
-
   val scn = scenario("RegistryAPI: Create Namespace")
     .repeat(repeatTimes) {
       feed(csv("namespaces.csv"))
         .feed(csv("access-tokens.csv").circular)
         .exec(http("RegistryAPI.createNamespace")
         .post(s"/api/-/namespace/create")
+        .headers(headers)
         .queryParam("token", """${access_token}""")
         .body(StringBody("""{"name":"${namespace}"}""")).asJson
         .requestTimeout(3.minutes)

--- a/server/src/gatling/scala/org/eclipse/openvsx/RegistryAPIGetExtensionSimulation.scala
+++ b/server/src/gatling/scala/org/eclipse/openvsx/RegistryAPIGetExtensionSimulation.scala
@@ -1,18 +1,27 @@
 package org.eclipse.openvsx
 
+import com.typesafe.config.ConfigFactory
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 
 class RegistryAPIGetExtensionSimulation extends Simulation {
+  val conf = ConfigFactory.load()
+
   val httpProtocol = http
-    .baseUrl("http://localhost:8080")
+    .baseUrl(conf.getString("baseUrl"))
     .disableCaching
+
+  var headers: Map[String,String] = Map()
+  if(conf.hasPath("auth")) {
+    headers += "Authorization" -> conf.getString("auth");
+  }
 
   val scn = scenario("RegistryAPI: Get Extension")
     .repeat(342) {
       feed(csv("extensions.csv"))
         .exec(http("RegistryAPI.getExtension")
-          .get("""/api/${namespace}/${name}"""))
+          .get("""/api/${namespace}/${name}""")
+          .headers(headers))
 //          .check(status.is(200)))
     }
 

--- a/server/src/gatling/scala/org/eclipse/openvsx/RegistryAPIGetExtensionVersionSimulation.scala
+++ b/server/src/gatling/scala/org/eclipse/openvsx/RegistryAPIGetExtensionVersionSimulation.scala
@@ -1,18 +1,27 @@
 package org.eclipse.openvsx
 
+import com.typesafe.config.ConfigFactory
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 
 class RegistryAPIGetExtensionVersionSimulation extends Simulation {
+  val conf = ConfigFactory.load()
+
   val httpProtocol = http
-    .baseUrl("http://localhost:8080")
+    .baseUrl(conf.getString("baseUrl"))
     .disableCaching
+
+  var headers: Map[String,String] = Map()
+  if(conf.hasPath("auth")) {
+    headers += "Authorization" -> conf.getString("auth");
+  }
 
   val scn = scenario("RegistryAPI: Get Extension Version")
     .repeat(744) {
       feed(csv("extension-versions.csv"))
         .exec(http("RegistryAPI.getExtensionVersion")
-          .get("""/api/${namespace}/${name}/${version}"""))
+          .get("""/api/${namespace}/${name}/${version}""")
+          .headers(headers))
 //          .check(status.is(200)))
     }
 

--- a/server/src/gatling/scala/org/eclipse/openvsx/RegistryAPIGetNamespaceSimulation.scala
+++ b/server/src/gatling/scala/org/eclipse/openvsx/RegistryAPIGetNamespaceSimulation.scala
@@ -1,19 +1,27 @@
 package org.eclipse.openvsx
 
+import com.typesafe.config.ConfigFactory
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 
 class RegistryAPIGetNamespaceSimulation extends Simulation {
+	val conf = ConfigFactory.load()
 
 	val httpProtocol = http
-		.baseUrl("http://localhost:8080")
+		.baseUrl(conf.getString("baseUrl"))
 		.disableCaching
+
+	var headers: Map[String,String] = Map()
+	if(conf.hasPath("auth")) {
+		headers += "Authorization" -> conf.getString("auth");
+	}
 
 	val scn = scenario("RegistryAPI: Get Namespace")
 		.repeat(1000) {
 			feed(csv("namespaces.csv").circular)
 				.exec(http("RegistryAPI.getNamespace")
 					.get("""/api/${namespace}""")
+					.headers(headers)
 					.check(status.is(200)))
 		}
 

--- a/server/src/gatling/scala/org/eclipse/openvsx/adapter/VSCodeAdapterExtensionQuerySimulation.scala
+++ b/server/src/gatling/scala/org/eclipse/openvsx/adapter/VSCodeAdapterExtensionQuerySimulation.scala
@@ -1,0 +1,60 @@
+package org.eclipse.openvsx.adapter
+
+import com.typesafe.config.ConfigFactory
+import io.gatling.core.Predef._
+import io.gatling.core.session.Expression
+import io.gatling.http.Predef._
+
+import scala.concurrent.duration.DurationInt
+
+class VSCodeAdapterExtensionQuerySimulation extends Simulation {
+  val conf = ConfigFactory.load()
+
+  val httpProtocol = http
+    .baseUrl(conf.getString("baseUrl"))
+    .disableCaching
+
+  val buildRequestBody: Expression[String] = session => {
+    val query = session("query").as[String]
+    val body =
+      s"""
+        |{
+        |  "filters":[
+        |    {
+        |      "criteria":[
+        |        {"filterType":8,"value":"Microsoft.VisualStudio.Code"},
+        |        {"filterType":10,"value":"${query}"},
+        |        {"filterType":12,"value":"4096"}
+        |      ],
+        |      "pageNumber":1,
+        |      "pageSize":50,
+        |      "sortBy":0,
+        |      "sortOrder":0
+        |    }
+        |  ],
+        |  "assetTypes":[],
+        |  "flags":950
+        |}
+        |""".stripMargin
+
+    body
+  }
+
+  var headers: Map[String,String] = Map()
+  if(conf.hasPath("auth")) {
+    headers += "Authorization" -> conf.getString("auth");
+  }
+
+  val scn = scenario("VSCodeAdapter: Extension Query")
+    .repeat(1000) {
+      feed(csv("adapter/queries-xl.csv").circular)
+        .exec(http("VSCodeAdapter.extensionQuery")
+          .post(s"/vscode/gallery/extensionquery")
+          .headers(headers)
+          .body(StringBody(buildRequestBody)).asJson
+          .requestTimeout(3.minutes)
+          .check(status.is(200)))
+    }
+
+  setUp(scn.inject(atOnceUsers(5))).protocols(httpProtocol)
+}

--- a/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
@@ -21,6 +21,7 @@ import javax.transaction.Transactional.TxType;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 
+import org.eclipse.openvsx.adapter.VSCodeIdService;
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.ExtensionVersion;
 import org.eclipse.openvsx.entities.FileResource;
@@ -44,6 +45,9 @@ public class ExtensionService {
 
     @Autowired
     RepositoryService repositories;
+
+    @Autowired
+    VSCodeIdService vsCodeIdService;
 
     @Autowired
     UserService users;
@@ -111,6 +115,8 @@ public class ExtensionService {
             extension = new Extension();
             extension.setName(extensionName);
             extension.setNamespace(namespace);
+
+            vsCodeIdService.createPublicId(extension);
             entityManager.persist(extension);
         } else {
             var existingVersion = repositories.findVersion(extVersion.getVersion(), extension);

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeIdService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeIdService.java
@@ -43,10 +43,6 @@ public class VSCodeIdService {
     @Value("${ovsx.vscode.upstream.gallery-url:}")
     String upstreamUrl;
 
-    @Autowired
-    EntityManager entityManager;
-
-    @Transactional
     public void createPublicId(Extension extension) {
         var upstreamExtension = getUpstreamData(extension);
         if (upstreamExtension != null) {
@@ -59,9 +55,6 @@ public class VSCodeIdService {
             extension.setPublicId(createRandomId());
         if (extension.getNamespace().getPublicId() == null)
             extension.getNamespace().setPublicId(createRandomId());
-
-        entityManager.merge(extension);
-        entityManager.merge(extension.getNamespace());
     }
 
     private String createRandomId() {

--- a/server/src/main/java/org/eclipse/openvsx/dto/ExtensionDTO.java
+++ b/server/src/main/java/org/eclipse/openvsx/dto/ExtensionDTO.java
@@ -1,0 +1,95 @@
+package org.eclipse.openvsx.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ExtensionDTO {
+
+    private final long id;
+    private final String publicId;
+    private final String name;
+    private final NamespaceDTO namespace;
+    private final ExtensionVersionDTO latest;
+    private final Double averageRating;
+    private final int downloadCount;
+
+    public ExtensionDTO(
+            long id,
+            String publicId,
+            String name,
+            Double averageRating,
+            int downloadCount,
+            long namespaceId,
+            String namespacePublicId,
+            String namespaceName,
+            long latestId,
+            String latestVersion,
+            boolean latestPreview,
+            LocalDateTime latestTimestamp,
+            String latestDisplayName,
+            String latestDescription,
+            List<String> latestEngines,
+            List<String> latestCategories,
+            List<String> latestTags,
+            List<String> latestExtensionKind,
+            String latestRepository,
+            String latestGalleryColor,
+            String latestGalleryTheme,
+            List<String> latestDependencies,
+            List<String> latestBundledExtensions
+    ) {
+        this.id = id;
+        this.publicId = publicId;
+        this.name = name;
+        this.averageRating = averageRating;
+        this.downloadCount = downloadCount;
+
+        this.namespace = new NamespaceDTO(namespaceId, namespacePublicId, namespaceName);
+        this.latest = new ExtensionVersionDTO(
+                latestId,
+                latestVersion,
+                latestPreview,
+                latestTimestamp,
+                latestDisplayName,
+                latestDescription,
+                latestEngines,
+                latestCategories,
+                latestTags,
+                latestExtensionKind,
+                latestRepository,
+                latestGalleryColor,
+                latestGalleryTheme,
+                latestDependencies,
+                latestBundledExtensions
+        );
+        this.latest.setExtension(this);
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getPublicId() {
+        return publicId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public NamespaceDTO getNamespace() {
+        return namespace;
+    }
+
+    public ExtensionVersionDTO getLatest() {
+        return latest;
+    }
+
+    public Double getAverageRating() {
+        return averageRating;
+    }
+
+    public int getDownloadCount() {
+        return downloadCount;
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/dto/ExtensionReviewCountDTO.java
+++ b/server/src/main/java/org/eclipse/openvsx/dto/ExtensionReviewCountDTO.java
@@ -1,0 +1,20 @@
+package org.eclipse.openvsx.dto;
+
+public class ExtensionReviewCountDTO {
+
+    private final long extensiondId;
+    private final long reviewCount;
+
+    public ExtensionReviewCountDTO(long extensiondId, long reviewCount) {
+        this.extensiondId = extensiondId;
+        this.reviewCount = reviewCount;
+    }
+
+    public long getExtensiondId() {
+        return extensiondId;
+    }
+
+    public long getReviewCount() {
+        return reviewCount;
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/dto/ExtensionVersionDTO.java
+++ b/server/src/main/java/org/eclipse/openvsx/dto/ExtensionVersionDTO.java
@@ -1,0 +1,191 @@
+package org.eclipse.openvsx.dto;
+
+import org.eclipse.openvsx.util.SemanticVersion;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ExtensionVersionDTO {
+
+    private Long extensionId;
+    private ExtensionDTO extension;
+
+    private final long id;
+    private final String version;
+    private SemanticVersion semver;
+    private final boolean preview;
+    private final LocalDateTime timestamp;
+    private final String displayName;
+    private final String description;
+    private final List<String> engines;
+    private final List<String> categories;
+    private final List<String> tags;
+    private final List<String> extensionKind;
+    private final String repository;
+    private final String galleryColor;
+    private final String galleryTheme;
+    private final List<String> dependencies;
+    private final List<String> bundledExtensions;
+
+    public ExtensionVersionDTO(
+            long extensionId,
+            long id,
+            String version,
+            boolean preview,
+            LocalDateTime timestamp,
+            String displayName,
+            String description,
+            List<String> engines,
+            List<String> categories,
+            List<String> tags,
+            List<String> extensionKind,
+            String repository,
+            String galleryColor,
+            String galleryTheme,
+            List<String> dependencies,
+            List<String> bundledExtensions
+    ) {
+        this(
+                id,
+                version,
+                preview,
+                timestamp,
+                displayName,
+                description,
+                engines,
+                categories,
+                tags,
+                extensionKind,
+                repository,
+                galleryColor,
+                galleryTheme,
+                dependencies,
+                bundledExtensions
+        );
+
+        this.extensionId = extensionId;
+    }
+
+    public ExtensionVersionDTO(
+            long id,
+            String version,
+            boolean preview,
+            LocalDateTime timestamp,
+            String displayName,
+            String description,
+            List<String> engines,
+            List<String> categories,
+            List<String> tags,
+            List<String> extensionKind,
+            String repository,
+            String galleryColor,
+            String galleryTheme,
+            List<String> dependencies,
+            List<String> bundledExtensions
+    ) {
+        this.id = id;
+        this.version = version;
+        this.preview = preview;
+        this.timestamp = timestamp;
+        this.displayName = displayName;
+        this.description = description;
+        this.engines = engines;
+        this.categories = categories;
+        this.tags = tags;
+        this.extensionKind = extensionKind;
+        this.repository = repository;
+        this.galleryColor = galleryColor;
+        this.galleryTheme = galleryTheme;
+        this.dependencies = dependencies;
+        this.bundledExtensions = bundledExtensions;
+    }
+
+    public long getExtensionId() {
+        return extensionId;
+    }
+
+    public void setExtensionId(long extensionId) {
+        this.extensionId = extensionId;
+    }
+
+    public ExtensionDTO getExtension() {
+        return extension;
+    }
+
+    public void setExtension(ExtensionDTO extension) {
+        if(extensionId == null || extension.getId() == extensionId) {
+            this.extension = extension;
+        } else {
+            throw new IllegalArgumentException("extension must have the same id as extensionId");
+        }
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public SemanticVersion getSemanticVersion() {
+        if (semver == null) {
+            var version = getVersion();
+            if (version != null)
+                semver = new SemanticVersion(version);
+        }
+        return semver;
+    }
+
+    public boolean isPreview() {
+        return preview;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public List<String> getEngines() {
+        return engines;
+    }
+
+    public List<String> getCategories() {
+        return categories;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public List<String> getExtensionKind() {
+        return extensionKind;
+    }
+
+    public String getRepository() {
+        return repository;
+    }
+
+    public String getGalleryColor() {
+        return galleryColor;
+    }
+
+    public String getGalleryTheme() {
+        return galleryTheme;
+    }
+
+    public List<String> getDependencies() {
+        return dependencies;
+    }
+
+    public List<String> getBundledExtensions() {
+        return bundledExtensions;
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/dto/FileResourceDTO.java
+++ b/server/src/main/java/org/eclipse/openvsx/dto/FileResourceDTO.java
@@ -1,0 +1,46 @@
+package org.eclipse.openvsx.dto;
+
+public class FileResourceDTO {
+
+    private final long extensionVersionId;
+    private ExtensionVersionDTO extensionVersion;
+
+    private final long id;
+    private final String name;
+    private final String type;
+
+    public FileResourceDTO(long id, long extensionVersionId, String name, String type) {
+        this.id = id;
+        this.extensionVersionId = extensionVersionId;
+        this.name = name;
+        this.type = type;
+    }
+
+    public long getExtensionVersionId() {
+        return extensionVersionId;
+    }
+
+    public ExtensionVersionDTO getExtensionVersion() {
+        return extensionVersion;
+    }
+
+    public void setExtensionVersion(ExtensionVersionDTO extensionVersion) {
+        if(extensionVersion.getId() == extensionVersionId) {
+            this.extensionVersion = extensionVersion;
+        } else {
+            throw new IllegalArgumentException("extensionVersion must have the same id as extensionVersionId");
+        }
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/dto/NamespaceDTO.java
+++ b/server/src/main/java/org/eclipse/openvsx/dto/NamespaceDTO.java
@@ -1,0 +1,26 @@
+package org.eclipse.openvsx.dto;
+
+public class NamespaceDTO {
+
+    private final long id;
+    private final String publicId;
+    private final String name;
+
+    public NamespaceDTO(long id, String publicId, String name) {
+        this.id = id;
+        this.publicId = publicId;
+        this.name = name;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getPublicId() {
+        return publicId;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionDTORepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionDTORepository.java
@@ -1,0 +1,105 @@
+package org.eclipse.openvsx.repositories;
+
+import org.eclipse.openvsx.dto.ExtensionDTO;
+import org.eclipse.openvsx.dto.ExtensionReviewCountDTO;
+import org.eclipse.openvsx.entities.Extension;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.util.Streamable;
+
+import java.util.Collection;
+
+public interface ExtensionDTORepository extends Repository<Extension, Long> {
+
+    @Query("select new org.eclipse.openvsx.dto.ExtensionDTO(" +
+            "e.id," +
+            "e.publicId," +
+            "e.name," +
+            "e.averageRating," +
+            "e.downloadCount," +
+            "e.namespace.id," +
+            "e.namespace.publicId," +
+            "e.namespace.name," +
+            "e.latest.id," +
+            "e.latest.version," +
+            "e.latest.preview," +
+            "e.latest.timestamp," +
+            "e.latest.displayName," +
+            "e.latest.description," +
+            "e.latest.engines," +
+            "e.latest.categories," +
+            "e.latest.tags," +
+            "e.latest.extensionKind," +
+            "e.latest.repository," +
+            "e.latest.galleryColor," +
+            "e.latest.galleryTheme," +
+            "e.latest.dependencies," +
+            "e.latest.bundledExtensions" +
+            ") " +
+            "from Extension e " +
+            "where e.active = true and e.id in(?1)")
+    Streamable<ExtensionDTO> findAllActiveById(Collection<Long> ids);
+
+    @Query("select new org.eclipse.openvsx.dto.ExtensionDTO(" +
+            "e.id," +
+            "e.publicId," +
+            "e.name," +
+            "e.averageRating," +
+            "e.downloadCount," +
+            "e.namespace.id," +
+            "e.namespace.publicId," +
+            "e.namespace.name," +
+            "e.latest.id," +
+            "e.latest.version," +
+            "e.latest.preview," +
+            "e.latest.timestamp," +
+            "e.latest.displayName," +
+            "e.latest.description," +
+            "e.latest.engines," +
+            "e.latest.categories," +
+            "e.latest.tags," +
+            "e.latest.extensionKind," +
+            "e.latest.repository," +
+            "e.latest.galleryColor," +
+            "e.latest.galleryTheme," +
+            "e.latest.dependencies," +
+            "e.latest.bundledExtensions" +
+            ") " +
+            "from Extension e " +
+            "where e.active = true and e.publicId in(?1)")
+    Streamable<ExtensionDTO> findAllActiveByPublicId(Collection<String> publicIds);
+
+    @Query("select new org.eclipse.openvsx.dto.ExtensionDTO(" +
+            "e.id," +
+            "e.publicId," +
+            "e.name," +
+            "e.averageRating," +
+            "e.downloadCount," +
+            "e.namespace.id," +
+            "e.namespace.publicId," +
+            "e.namespace.name," +
+            "e.latest.id," +
+            "e.latest.version," +
+            "e.latest.preview," +
+            "e.latest.timestamp," +
+            "e.latest.displayName," +
+            "e.latest.description," +
+            "e.latest.engines," +
+            "e.latest.categories," +
+            "e.latest.tags," +
+            "e.latest.extensionKind," +
+            "e.latest.repository," +
+            "e.latest.galleryColor," +
+            "e.latest.galleryTheme," +
+            "e.latest.dependencies," +
+            "e.latest.bundledExtensions" +
+            ") " +
+            "from Extension e " +
+            "where e.active = true and upper(e.name) = upper(?1) and upper(e.namespace.name) = upper(?2)")
+    ExtensionDTO findActiveByNameIgnoreCaseAndNamespaceNameIgnoreCase(String name, String namespaceName);
+
+    @Query("select new org.eclipse.openvsx.dto.ExtensionReviewCountDTO(r.extension.id, count(r.id)) " +
+            "from ExtensionReview r " +
+            "where r.active = true and r.extension.id in(?1) group by r.extension.id")
+    Streamable<ExtensionReviewCountDTO> countAllActiveReviewsById(Collection<Long> ids);
+}

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionRepository.java
@@ -38,5 +38,4 @@ public interface ExtensionRepository extends Repository<Extension, Long> {
 
     @Query("select max(e.downloadCount) from Extension e")
     int getMaxDownloadCount();
-
 }

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionReviewRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionReviewRepository.java
@@ -9,12 +9,11 @@
  ********************************************************************************/
 package org.eclipse.openvsx.repositories;
 
-import org.springframework.data.repository.Repository;
-import org.springframework.data.util.Streamable;
-
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.ExtensionReview;
 import org.eclipse.openvsx.entities.UserData;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.util.Streamable;
 
 public interface ExtensionReviewRepository extends Repository<ExtensionReview, Long> {
 
@@ -25,5 +24,4 @@ public interface ExtensionReviewRepository extends Repository<ExtensionReview, L
     Streamable<ExtensionReview> findByExtensionAndUserAndActiveTrue(Extension extension, UserData user);
 
     long countByExtensionAndActiveTrue(Extension extension);
-
 }

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionDTORepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionDTORepository.java
@@ -1,0 +1,35 @@
+package org.eclipse.openvsx.repositories;
+
+import org.eclipse.openvsx.dto.ExtensionVersionDTO;
+import org.eclipse.openvsx.entities.ExtensionVersion;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.util.Streamable;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface ExtensionVersionDTORepository extends Repository<ExtensionVersion, Long> {
+
+    @Query("select new org.eclipse.openvsx.dto.ExtensionVersionDTO(" +
+            "ev.extension.id," +
+            "ev.id," +
+            "ev.version," +
+            "ev.preview," +
+            "ev.timestamp," +
+            "ev.displayName," +
+            "ev.description," +
+            "ev.engines," +
+            "ev.categories," +
+            "ev.tags," +
+            "ev.extensionKind," +
+            "ev.repository," +
+            "ev.galleryColor," +
+            "ev.galleryTheme," +
+            "ev.dependencies," +
+            "ev.bundledExtensions" +
+            ") " +
+            "from ExtensionVersion ev " +
+            "where ev.active = true and ev.extension.id in(?1)")
+    Streamable<ExtensionVersionDTO> findAllActiveByExtensionId(Collection<Long> extensionIds);
+}

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionRepository.java
@@ -51,5 +51,4 @@ public interface ExtensionVersionRepository extends Repository<ExtensionVersion,
 
     @Query("select min(ev.timestamp) from ExtensionVersion ev")
     LocalDateTime getOldestTimestamp();
-
 }

--- a/server/src/main/java/org/eclipse/openvsx/repositories/FileResourceDTORepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/FileResourceDTORepository.java
@@ -1,0 +1,17 @@
+package org.eclipse.openvsx.repositories;
+
+import org.eclipse.openvsx.dto.FileResourceDTO;
+import org.eclipse.openvsx.entities.FileResource;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.util.Streamable;
+
+import java.util.Collection;
+
+public interface FileResourceDTORepository extends Repository<FileResource, Long> {
+
+    @Query("select new org.eclipse.openvsx.dto.FileResourceDTO(r.id, r.extension.id, r.name, r.type) " +
+            "from FileResource r " +
+            "where r.extension.id in(?1) and r.type in(?2)")
+    Streamable<FileResourceDTO> findAllByExtensionIdAndType(Collection<Long> extensionIds, Collection<String> types);
+}

--- a/server/src/main/java/org/eclipse/openvsx/repositories/FileResourceRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/FileResourceRepository.java
@@ -30,5 +30,4 @@ public interface FileResourceRepository extends Repository<FileResource, Long> {
     FileResource findByExtensionAndTypeAndNameIgnoreCase(ExtensionVersion extVersion, String type, String name);
 
     Streamable<FileResource> findByExtensionAndTypeIn(ExtensionVersion extVersion, Collection<String> types);
-
 }

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -9,6 +9,10 @@
  ********************************************************************************/
 package org.eclipse.openvsx.repositories;
 
+import org.eclipse.openvsx.dto.ExtensionDTO;
+import org.eclipse.openvsx.dto.ExtensionReviewCountDTO;
+import org.eclipse.openvsx.dto.ExtensionVersionDTO;
+import org.eclipse.openvsx.dto.FileResourceDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.util.Streamable;
 import org.springframework.stereotype.Component;
@@ -16,6 +20,8 @@ import org.eclipse.openvsx.entities.PersistedLog;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.ExtensionReview;
@@ -38,6 +44,9 @@ public class RepositoryService {
     @Autowired NamespaceMembershipRepository membershipRepo;
     @Autowired PersonalAccessTokenRepository tokenRepo;
     @Autowired PersistedLogRepository persistedLogRepo;
+    @Autowired ExtensionDTORepository extensionDTORepo;
+    @Autowired ExtensionVersionDTORepository extensionVersionDTORepo;
+    @Autowired FileResourceDTORepository fileResourceDTORepo;
 
     public Namespace findNamespace(String name) {
         return namespaceRepo.findByNameIgnoreCase(name);
@@ -251,4 +260,27 @@ public class RepositoryService {
         return persistedLogRepo.findByTimestampAfterOrderByTimestampAsc(dateTime);
     }
 
+    public Streamable<ExtensionDTO> findAllActiveExtensionDTOsByPublicId(Collection<String> publicIds) {
+        return extensionDTORepo.findAllActiveByPublicId(publicIds);
+    }
+
+    public ExtensionDTO findActiveExtensionDTOByNameAndNamespaceName(String name, String namespaceName) {
+        return extensionDTORepo.findActiveByNameIgnoreCaseAndNamespaceNameIgnoreCase(name, namespaceName);
+    }
+
+    public Streamable<ExtensionDTO> findAllActiveExtensionDTOsById(Collection<Long> ids) {
+        return extensionDTORepo.findAllActiveById(ids);
+    }
+
+    public Streamable<ExtensionVersionDTO> findAllActiveExtensionVersionDTOsByExtensionId(Collection<Long> extensionIds) {
+        return extensionVersionDTORepo.findAllActiveByExtensionId(extensionIds);
+    }
+
+    public Streamable<FileResourceDTO> findAllFileResourceDTOsByExtensionVersionIdAndType(Collection<Long> extensionVersionIds, Collection<String> types) {
+        return fileResourceDTORepo.findAllByExtensionIdAndType(extensionVersionIds, types);
+    }
+
+    public Streamable<ExtensionReviewCountDTO> countAllActiveReviewsByExtensionId(Collection<Long> extensionIds) {
+        return extensionDTORepo.countAllActiveReviewsById(extensionIds);
+    }
 }

--- a/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
@@ -30,6 +30,7 @@ import javax.persistence.EntityManager;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.eclipse.openvsx.adapter.VSCodeIdService;
 import org.eclipse.openvsx.eclipse.EclipseService;
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.ExtensionVersion;
@@ -71,7 +72,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 @AutoConfigureWebClient
 @MockBean({
     ClientRegistrationRepository.class, UpstreamRegistryService.class, GoogleCloudStorageService.class,
-    AzureBlobStorageService.class
+    AzureBlobStorageService.class, VSCodeIdService.class
 })
 public class AdminAPITest {
     

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -33,6 +33,7 @@ import java.util.zip.ZipOutputStream;
 
 import javax.persistence.EntityManager;
 
+import org.eclipse.openvsx.adapter.VSCodeIdService;
 import org.eclipse.openvsx.eclipse.EclipseService;
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.ExtensionReview;
@@ -85,7 +86,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @AutoConfigureWebClient
 @MockBean({
     ClientRegistrationRepository.class, UpstreamRegistryService.class, GoogleCloudStorageService.class,
-    AzureBlobStorageService.class
+    AzureBlobStorageService.class, VSCodeIdService.class
 })
 public class RegistryAPITest {
 

--- a/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
@@ -25,6 +25,7 @@ import org.eclipse.openvsx.ExtensionService;
 import org.eclipse.openvsx.ExtensionValidator;
 import org.eclipse.openvsx.MockTransactionTemplate;
 import org.eclipse.openvsx.UserService;
+import org.eclipse.openvsx.adapter.VSCodeIdService;
 import org.eclipse.openvsx.entities.AuthToken;
 import org.eclipse.openvsx.entities.EclipseData;
 import org.eclipse.openvsx.entities.Extension;
@@ -58,7 +59,8 @@ import org.springframework.web.client.RestTemplate;
 
 @ExtendWith(SpringExtension.class)
 @MockBean({
-    EntityManager.class, SearchService.class, GoogleCloudStorageService.class, AzureBlobStorageService.class
+    EntityManager.class, SearchService.class, GoogleCloudStorageService.class, AzureBlobStorageService.class,
+    VSCodeIdService.class
 })
 public class EclipseServiceTest {
 


### PR DESCRIPTION
To measure performance I created `server/src/gatling/scala/org/eclipse/openvsx/adapter/VSCodeAdapterExtensionQuerySimulation.scala` 
To run it: `./gradlew --rerun-tasks gatlingRun-org.eclipse.openvsx.adapter.VSCodeAdapterExtensionQuerySimulation`

![gatling-extensionquery-results2](https://user-images.githubusercontent.com/14129099/137737874-bd3d487f-f867-49a6-9b31-c6ec5be7fd4f.png)
I saw 4x more requests, try to reproduce and if it works please approve

Changes:
Moved creation of Extension publicId to ExtensionService
Added bulk queries
Added DTO objects
Fixed unittests
Added Gatling simulation for VSCode extensionQuery endpoint