### PR TITLE
Handle entity deletes for admin statistics.

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/entities/Download.java
+++ b/server/src/main/java/org/eclipse/openvsx/entities/Download.java
@@ -9,10 +9,7 @@
  * ****************************************************************************** */
 package org.eclipse.openvsx.entities;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
@@ -22,8 +19,8 @@ public class Download {
     @GeneratedValue
     long id;
 
-    @ManyToOne
-    FileResource fileResource;
+    @Column(name = "file_resource_id_not_fk")
+    long fileResourceId;
 
     LocalDateTime timestamp;
 
@@ -37,12 +34,12 @@ public class Download {
         this.id = id;
     }
 
-    public FileResource getFileResource() {
-        return fileResource;
+    public long getFileResourceId() {
+        return fileResourceId;
     }
 
-    public void setFileResource(FileResource fileResource) {
-        this.fileResource = fileResource;
+    public void setFileResourceId(long fileResourceId) {
+        this.fileResourceId = fileResourceId;
     }
 
     public LocalDateTime getTimestamp() {

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
@@ -198,7 +198,7 @@ public class StorageUtilService implements IStorageService {
             var download = new Download();
             download.setAmount(1);
             download.setTimestamp(time);
-            download.setFileResource(resource);
+            download.setFileResourceId(resource.getId());
             entityManager.persist(download);
         }
 

--- a/server/src/main/resources/db/migration/V1_17__Admin_Statistics_Handle_Delete.sql
+++ b/server/src/main/resources/db/migration/V1_17__Admin_Statistics_Handle_Delete.sql
@@ -1,0 +1,80 @@
+-- also insert row into entity_active_state when entity is deleted
+CREATE OR REPLACE FUNCTION public.insert_entity_active_state() RETURNS TRIGGER AS $entity_active_state_trigger$
+    DECLARE
+		id BIGINT;
+		active BOOLEAN;
+    BEGIN
+        IF TG_OP = 'DELETE' THEN
+			id := OLD.id;
+			active := FALSE;
+        ELSE
+			id := NEW.id;
+			active := NEW.active;
+        END IF;
+        INSERT INTO entity_active_state(id, entity_id, entity_type, active, "timestamp")
+        VALUES(nextval('entity_active_state_id_seq'), id, TG_TABLE_NAME, active, CURRENT_TIMESTAMP);
+        RETURN NULL;
+    END;
+$entity_active_state_trigger$ LANGUAGE plpgsql;
+
+CREATE TRIGGER extension_delete_entity_active_state
+AFTER DELETE ON extension
+FOR EACH ROW
+EXECUTE PROCEDURE insert_entity_active_state();
+
+CREATE TRIGGER extension_review_delete_entity_active_state
+AFTER DELETE ON extension_review
+FOR EACH ROW
+EXECUTE PROCEDURE insert_entity_active_state();
+
+CREATE TRIGGER extension_version_delete_entity_active_state
+AFTER DELETE ON extension_version
+FOR EACH ROW
+EXECUTE PROCEDURE insert_entity_active_state();
+
+CREATE TRIGGER personal_access_token_delete_entity_active_state
+AFTER DELETE ON personal_access_token
+FOR EACH ROW
+EXECUTE PROCEDURE insert_entity_active_state();
+
+-- insert rows into entity_active_state for deleted entities
+-- that are still marked as active in the entity_active_state table
+INSERT INTO public.entity_active_state
+SELECT nextval('entity_active_state_id_seq'), d.entity_id, 'extension', FALSE, CURRENT_TIMESTAMP
+FROM (
+    SELECT DISTINCT s.entity_id
+    FROM entity_active_state s
+    LEFT JOIN extension e ON e.id = s.entity_id
+    WHERE e.id IS NULL AND s.entity_type = 'extension' AND s.active = TRUE
+) d;
+
+INSERT INTO public.entity_active_state
+SELECT nextval('entity_active_state_id_seq'), d.entity_id, 'extension_review', FALSE, CURRENT_TIMESTAMP
+FROM (
+    SELECT DISTINCT s.entity_id
+    FROM entity_active_state s
+    LEFT JOIN extension_review r ON r.id = s.entity_id
+    WHERE r.id IS NULL AND s.entity_type = 'extension_review' AND s.active = TRUE
+) d;
+
+INSERT INTO public.entity_active_state
+SELECT nextval('entity_active_state_id_seq'), d.entity_id, 'extension_version', FALSE, CURRENT_TIMESTAMP
+FROM (
+    SELECT DISTINCT s.entity_id
+    FROM entity_active_state s
+    LEFT JOIN extension_version v ON v.id = s.entity_id
+    WHERE v.id IS NULL AND s.entity_type = 'extension_version' AND s.active = TRUE
+) d;
+
+INSERT INTO public.entity_active_state
+SELECT nextval('entity_active_state_id_seq'), d.entity_id, 'personal_access_token', FALSE, CURRENT_TIMESTAMP
+FROM (
+    SELECT DISTINCT s.entity_id
+    FROM entity_active_state s
+    LEFT JOIN personal_access_token t ON t.id = s.entity_id
+    WHERE t.id IS NULL AND s.entity_type = 'personal_access_token' AND s.active = TRUE
+) d;
+
+-- keep downloads that refer to deleted file resource
+ALTER TABLE ONLY public.download DROP CONSTRAINT download_file_resource_fkey;
+ALTER TABLE ONLY public.download RENAME COLUMN file_resource_id TO file_resource_id_not_fk;


### PR DESCRIPTION
Fixes #369 

Set `entity_active_state.active` to false when entity is deleted.
Decouple FileResource from Download.
Renamed table `download` column `file_resource_id` to `file_resource_id_not_fk` to make it clear it isn't a foreign key for future reference.