### PR TITLE
Download Count Broken #380

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/storage/AzureDownloadCountService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AzureDownloadCountService.java
@@ -33,6 +33,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StopWatch;
 
 import javax.persistence.EntityManager;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
@@ -153,9 +154,11 @@ public class AzureDownloadCountService {
     }
 
     private void processBlobItem(String blobName) {
-        try {
+        try (var outputStream = new ByteArrayOutputStream()) {
+            getContainerClient().getBlobClient(blobName).download(outputStream);
+            var bytes = outputStream.toByteArray();
+
             var files = new HashMap<String, List<LocalDateTime>>();
-            var bytes = getContainerClient().getBlobClient(blobName).openInputStream().readAllBytes();
             var jsonObjects = new String(bytes).split("\n");
             for (var jsonObject : jsonObjects) {
                 var node = getObjectMapper().readTree(jsonObject);


### PR DESCRIPTION
Fixes #380 

I've changed `blobClient.openInputStream()` to `blobClient.download`

I found this solution on StackOverflow relating to the Azure Blob Storage C# client SDK.
The AzureDownloadCountService uses similar method calls.
> Well, when you do a CloudBlob.OpenRead(), the client library is doing two operations.
> Attention to the ETag in the response.
> What happen if another WebRole do something in the blob between call? YES a race condition.
> Solution: Use CloudBlob.DownloadToStream(), that method only issues one call.

source: [https://stackoverflow.com/questions/5094089/azure-blob-the-condition-specified-using-http-conditional-headers-is-not-met](https://stackoverflow.com/questions/5094089/azure-blob-the-condition-specified-using-http-conditional-headers-is-not-met)