### PR TITLE
Fix data inconsistency between database and elasticsearch

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
@@ -76,11 +76,11 @@ public class ExtensionService {
             var resources = processor.getResources(extVersion);
             checkLicense(extVersion, resources);
 
-            // Update the 'latest' / 'preview' references and the search index
-            updateExtension(extVersion.getExtension());
-
             // Store file resources in the DB or external storage
             storeResources(extVersion, resources);
+
+            // Update the 'latest' / 'preview' references and the search index
+            updateExtension(extVersion.getExtension());
 
             return extVersion;
         }

--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -488,8 +488,12 @@ public class LocalRegistryService implements IExtensionRegistry {
     private SearchEntryJson toSearchEntry(SearchHit<ExtensionSearch> searchHit, String serverUrl, ISearchService.Options options) {
         var searchItem = searchHit.getContent();
         var extension = entityManager.find(Extension.class, searchItem.id);
-        if (extension == null || !extension.isActive())
+        if (extension == null || !extension.isActive()){
+            extension = new Extension();
+            extension.setId(searchItem.id);
+            search.removeSearchEntry(extension);
             return null;
+        }
         var extVer = extension.getLatest();
         var entry = extVer.toSearchEntryJson();
         entry.url = createApiUrl(serverUrl, "api", entry.namespace, entry.name);


### PR DESCRIPTION
[LocalRegistryService](https://github.com/eclipse/openvsx/blob/master/server/src/main/java/org/eclipse/openvsx/ExtensionService.java)
```java
  @Transactional(TxType.REQUIRED)
    public ExtensionVersion publishVersion(InputStream content, PersonalAccessToken token) {
        try (var processor = new ExtensionProcessor(content)) {
            // Extract extension metadata from its manifest
            var extVersion = createExtensionVersion(processor, token.getUser(), token);
            processor.getExtensionDependencies().forEach(dep -> addDependency(dep, extVersion));
            processor.getBundledExtensions().forEach(dep -> addBundledExtension(dep, extVersion));

            // Check the extension's license
            var resources = processor.getResources(extVersion);
            checkLicense(extVersion, resources);

            // Update the 'latest' / 'preview' references and the search index
            updateExtension(extVersion.getExtension());

            // Store file resources in the DB or external storage
            storeResources(extVersion, resources);

            return extVersion;
        }
    }
```
when  `storeResources`  method   thorw a Exception  and `ovsx.elasticsearch.enabled: true` ,  `createExtensionVersion`and`storeResources` roolback, but `updateExtension` (Use the ElasticSearch) method  doesnt  roolback

## reproduce :

```yaml
ovsx:
  databasesearch:
    enabled: false
  elasticsearch:
    enabled: true
    clear-on-start: true
```
 limit content `column` of `file_resource`  insert sizes to a custom size through constraint

```sql
create domain limited_bytea as bytea
  constraint check_length check (octet_length(value) <= 1024);
```

![image](https://user-images.githubusercontent.com/42602026/148638798-24cb2fbd-e43c-4f37-8562-dbbc1a9f35c8.png)

**execute  .sh file**
```sh
    export OVSX_REGISTRY_URL=http://127.0.0.1:8080
    export OVSX_PAT=super_token
    export PUBLISHERS="DotJoshJohnson eamodio Equinusocio felixfbecker formulahendry HookyQR ms-azuretools ms-mssql ms-python ms-vscode octref redhat ritwickdey sburg vscode vscodevim Wscats"
    for pub in $PUBLISHERS; do cli/lib/ovsx create-namespace $pub; done
    find server/build/test-extensions-builtin -name '*.vsix' -exec cli/lib/ovsx publish '{}' \;
    find server/build/test-extensions -name '*.vsix' -exec cli/lib/ovsx publish '{}' \;

```

**result:**
```tex
  could not execute statement; SQL [n/a]; constraint [null]; nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement
See the documentation for more information:
https://github.com/eclipse/openvsx/wiki/Publishing-Extensions
❌  could not execute statement; SQL [n/a]; constraint [null]; nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement
See the documentation for more information:
https://github.com/eclipse/openvsx/wiki/Publishing-Extensions
❌  could not execute statement; SQL [n/a]; constraint [null]; nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement
See the documentation for more information:
https://github.com/eclipse/openvsx/wiki/Publishing-Extensions

......
```
**excute `GET ​/api​/-​/search`**
![image](https://user-images.githubusercontent.com/42602026/148639032-68470567-2570-4787-be62-177c93c308ba.png)
**result**
```json
{
  "offset": 0,
  "totalSize": 15,
  "extensions": []
}
```
`totalSize` is 15,but extensions has nothing .
why?
Because  elasticsearch  has  data,but database has no  data 

## FIX

1.
when `toSearchEntry` of  [LocalRegistryService](https://github.com/eclipse/openvsx/blob/master/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java)
find diffrent bettween database and elaticSearch  , fix it 

```java 
    if (extension == null || !extension.isActive()){
            extension = new Extension();
            extension.setId(searchItem.id);
            search.removeSearchEntry(extension);
            return null;
        }
```

2. In [LocalRegistryService](https://github.com/eclipse/openvsx/blob/master/server/src/main/java/org/eclipse/openvsx/ExtensionService.java), first execute` storeResources(extVersion, resources)`then execute `updateExtension(extVersion.getExtension());`
```java
            // Store file resources in the DB or external storage
            storeResources(extVersion, resources);

            // Update the 'latest' / 'preview' references and the search index
            updateExtension(extVersion.getExtension());

         
```

