### PR TITLE
Error Loading Extension Page because of removed versions #816

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -26,6 +26,7 @@ def versions = [
     gcloud: '1.113.4',
     azure: '12.9.0',
     guava: '28.2-jre',
+    caffeine: '3.0.5',
     junit: '5.7.1',
     testcontainers: '1.15.2',
     jackson: '2.12.5',
@@ -72,6 +73,7 @@ dependencies {
     implementation "net.javacrumbs.shedlock:shedlock-spring:${versions.shedlock}"
     implementation "net.javacrumbs.shedlock:shedlock-provider-jdbc-template:${versions.shedlock}"
     implementation "com.google.guava:guava:${versions.guava}"
+    implementation "com.github.ben-manes.caffeine:caffeine:${versions.caffeine}"
     implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"


### PR DESCRIPTION
Fixes https://github.com/EclipseFdn/open-vsx.org/issues/816

Added synchronization so that `Extension.latest` and `Extension.preview` aren't updated concurrently when deleting multiple extension versions at the same time.