### PR TITLE
Delete all versions at once to prevent race condition

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -26,7 +26,6 @@ def versions = [
     gcloud: '1.113.4',
     azure: '12.9.0',
     guava: '28.2-jre',
-    caffeine: '3.0.5',
     junit: '5.7.1',
     testcontainers: '1.15.2',
     jackson: '2.12.5',
@@ -73,7 +72,6 @@ dependencies {
     implementation "net.javacrumbs.shedlock:shedlock-spring:${versions.shedlock}"
     implementation "net.javacrumbs.shedlock:shedlock-provider-jdbc-template:${versions.shedlock}"
     implementation "com.google.guava:guava:${versions.guava}"
-    implementation "com.github.ben-manes.caffeine:caffeine:${versions.caffeine}"
     implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"

--- a/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
@@ -281,7 +281,9 @@ public class AdminAPITest {
     public void testDeleteExtensionVersion() throws Exception {
         mockAdminUser();
         mockExtension(2, 0, 0);
-        mockMvc.perform(post("/admin/extension/{namespace}/{extension}/delete?version={version}", "foobar", "baz", "2")
+        mockMvc.perform(post("/admin/extension/{namespace}/{extension}/delete", "foobar", "baz")
+                .content("[\"2\"]")
+                .contentType(MediaType.APPLICATION_JSON)
                 .with(user("admin_user").authorities(new SimpleGrantedAuthority(("ROLE_ADMIN"))))
                 .with(csrf().asHeader()))
                 .andExpect(status().isOk())

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openvsx-webui",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "User interface for Eclipse Open VSX",
     "keywords": [
         "react",
@@ -39,10 +39,10 @@
         "@material-ui/core": "~4.9.14",
         "@material-ui/icons": "~4.9.1",
         "clipboard-copy": "^4.0.1",
+        "clsx": "^1.1.1",
         "dompurify": "^2.2.2",
         "markdown-it": "^12.0.2",
         "markdown-it-anchor": "^6.0.1",
-        "clsx": "^1.1.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-infinite-scroller": "^1.2.4",

--- a/webui/src/extension-registry-service.ts
+++ b/webui/src/extension-registry-service.ts
@@ -279,18 +279,20 @@ export class AdminService {
         });
     }
 
-    async deleteExtension(req: { namespace: string, extension: string, version?: string }): Promise<Readonly<SuccessResult | ErrorResult>> {
+    async deleteExtensions(req: { namespace: string, extension: string, versions?: string[] }): Promise<Readonly<SuccessResult | ErrorResult>> {
         const csrfToken = await this.registry.getCsrfToken();
-        const headers: Record<string, string> = {};
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json;charset=UTF-8'
+        };
         if (!isError(csrfToken)) {
             headers[csrfToken.header] = csrfToken.value;
         }
         return sendRequest({
             method: 'POST',
             credentials: true,
-            endpoint: createAbsoluteURL([this.registry.serverUrl, 'admin', 'extension', req.namespace, req.extension, 'delete'],
-                [{ key: 'version', value: req.version }]),
-            headers
+            endpoint: createAbsoluteURL([this.registry.serverUrl, 'admin', 'extension', req.namespace, req.extension, 'delete']),
+            headers,
+            payload: req.versions
         });
     }
 

--- a/webui/src/pages/admin-dashboard/extension-remove-dialog.tsx
+++ b/webui/src/pages/admin-dashboard/extension-remove-dialog.tsx
@@ -24,12 +24,9 @@ export const ExtensionRemoveDialog: FunctionComponent<ExtensionRemoveDialog.Prop
         try {
             setWorking(true);
             if (props.removeAll) {
-                await service.admin.deleteExtension({ namespace: props.extension.namespace, extension: props.extension.name });
+                await service.admin.deleteExtensions({ namespace: props.extension.namespace, extension: props.extension.name });
             } else {
-                const prms = props.versions.map(version =>
-                    service.admin.deleteExtension({ namespace: props.extension.namespace, extension: props.extension.name, version })
-                );
-                await Promise.all(prms);
+                await service.admin.deleteExtensions({ namespace: props.extension.namespace, extension: props.extension.name, versions: props.versions });
             }
             props.onUpdate();
             setDialogOpen(false);


### PR DESCRIPTION
PR #396 tried to fix https://github.com/EclipseFdn/open-vsx.org/issues/816 by using a synchronized block. This approach doesn't work on the staging server.

I've changed the endpoint to delete all versions in one request, so that the versions are deleted one after another instead of deleted by multiple parallel requests. This does work on the staging server.

You can test this by publishing 3+ versions of the same extension and then deleting 2+ versions (keep 1 version) in the admin dashboard.