### PR TITLE
Set Content-Type application/xml for /sitemap.xml endpoint

### DIFF
--- a/server/src/dev/resources/application.yml
+++ b/server/src/dev/resources/application.yml
@@ -1,9 +1,5 @@
 server:
   port: 8080
-  compression:
-    enabled: true
-    min-response-size: 1024
-    mime-types: text/csv,text/plain,application/json,application/xml
 
 spring:
   profiles:

--- a/server/src/dev/resources/application.yml
+++ b/server/src/dev/resources/application.yml
@@ -1,5 +1,9 @@
 server:
   port: 8080
+  compression:
+    enabled: true
+    min-response-size: 1024
+    mime-types: text/csv,text/plain,application/json,application/xml
 
 spring:
   profiles:

--- a/server/src/main/java/org/eclipse/openvsx/web/SitemapController.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/SitemapController.java
@@ -34,9 +34,7 @@ import org.eclipse.openvsx.util.UrlUtil;
 import org.eclipse.openvsx.util.VersionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.CacheControl;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
@@ -92,6 +90,7 @@ public class SitemapController {
         };
         return ResponseEntity.ok()
                 .cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS).cachePublic())
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML_VALUE)
                 .body(stream);
     }
 


### PR DESCRIPTION
Added `Content-Type` response header to SitemapController, so that the response is recognized as XML.