### PR TITLE
Set latest version, whether it's a pre-release or not

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionRepository.java
@@ -25,8 +25,6 @@ public interface ExtensionVersionRepository extends Repository<ExtensionVersion,
 
     Streamable<ExtensionVersion> findByExtensionAndActiveTrue(Extension extension);
 
-    Streamable<ExtensionVersion> findByExtensionAndPreReleaseAndActiveTrue(Extension extension, boolean preRelease);
-
     ExtensionVersion findByVersionAndExtension(String version, Extension extension);
 
     ExtensionVersion findByVersionAndExtensionNameIgnoreCaseAndExtensionNamespaceNameIgnoreCase(String version, String extensionName, String namespace);

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -125,10 +125,6 @@ public class RepositoryService {
         return extensionVersionRepo.getActiveVersionStrings(extension);
     }
 
-    public Streamable<ExtensionVersion> findActiveVersions(Extension extension, boolean preRelease) {
-         return extensionVersionRepo.findByExtensionAndPreReleaseAndActiveTrue(extension, preRelease);
-    }
-
     public Streamable<ExtensionVersion> findBundledExtensionsReference(Extension extension) {
         return extensionVersionRepo.findByBundledExtensions(extensionId(extension));
     }

--- a/server/src/main/java/org/eclipse/openvsx/search/DatabaseSearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/DatabaseSearchService.java
@@ -71,7 +71,6 @@ public class DatabaseSearchService implements ISearchService {
         // filter text
         if (options.queryString != null) {
             matchingExtensions = matchingExtensions.filter(extension ->
-            // var latest = extension.getLatest();
             extension.getName().toLowerCase().contains(options.queryString.toLowerCase())
                     || extension.getNamespace().getName().contains(options.queryString.toLowerCase())
                     || (extension.getLatest().getDescription() != null && extension.getLatest().getDescription()

--- a/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
@@ -758,10 +758,8 @@ public class AdminAPITest {
         extension.setLatest(versions.get(versions.size() - 1));
         Mockito.when(repositories.findVersions(extension))
                 .thenReturn(Streamable.of(versions));
-        Mockito.when(repositories.findActiveVersions(extension, false))
+        Mockito.when(repositories.findActiveVersions(extension))
                 .thenReturn(Streamable.of(versions));
-        Mockito.when(repositories.findActiveVersions(extension, true))
-                .thenReturn(Streamable.empty());
         Mockito.when(repositories.getVersionStrings(extension))
                 .thenReturn(Streamable.of(versions).map(ev -> ev.getVersion()));
         Mockito.when(repositories.getActiveVersionStrings(extension))

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -1192,7 +1192,7 @@ public class RegistryAPITest {
                 .thenReturn(0l);
         Mockito.when(repositories.findVersions(any(Extension.class)))
                 .thenReturn(Streamable.empty());
-        Mockito.when(repositories.findActiveVersions(any(Extension.class), any(boolean.class)))
+        Mockito.when(repositories.findActiveVersions(any(Extension.class)))
                 .thenReturn(Streamable.empty());
         Mockito.when(repositories.getVersionStrings(any(Extension.class)))
                 .thenReturn(Streamable.empty());

--- a/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
@@ -202,10 +202,8 @@ public class EclipseServiceTest {
         extVersion.setExtension(extension);
         Mockito.when(repositories.findVersionsByAccessToken(accessToken, false))
             .thenReturn(Streamable.of(extVersion));
-        Mockito.when(repositories.findActiveVersions(extension, false))
+        Mockito.when(repositories.findActiveVersions(extension))
             .thenReturn(Streamable.of(extVersion));
-        Mockito.when(repositories.findActiveVersions(extension, true))
-            .thenReturn(Streamable.empty());
 
         eclipse.signPublisherAgreement(user);
 


### PR DESCRIPTION
Set `extension.latest`, whether it's a pre-release or not. It fixes https://github.com/eclipse/openvsx/pull/410#issuecomment-1034831850

Testing steps:
- Create namespace
- Publish a pre-release version for a new extension.
- Check that latest_id points to the pre-release: `SELECT e.name, ev.version, ev.pre_release FROM extension e JOIN extension_version ev ON ev.id = e.latest_id`. On gitpod you can use the `psql` CLI tool to execute queries.
- Publish a newer regular version for the same extension, use the same query to verify that `latest` now points to the newer regular version.
- Finally, publish a newer pre-release version and again verify that `latest` points to the pre-release.
- Now you can also delete each version one at a time in reverse order and again check that `latest` is updated.