### PR TITLE
Ignore includeAllVersions if extensionVersion is specified.

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -267,7 +267,7 @@ public class LocalRegistryService implements IExtensionRegistry {
                 .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), toVersions(e.getValue())))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-        if(!param.includeAllVersions) {
+        if(Strings.isNullOrEmpty(param.extensionVersion) && !param.includeAllVersions) {
             var latestIds = extensionVersions.stream()
                     .map(ExtensionVersionDTO::getExtension)
                     .map(ExtensionDTO::getLatestId)

--- a/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
@@ -375,7 +375,7 @@ public class RegistryAPI {
             @ApiParam(value = "Universally unique identifier of a namespace", example = "1234")
             String namespaceUuid,
             @RequestParam(required = false)
-            @ApiParam(value = "Whether to include all versions of an extension")
+            @ApiParam(value = "Whether to include all versions of an extension, ignored if extensionVersion is specified")
             boolean includeAllVersions
         ) {
         var param = new QueryParamJson();

--- a/server/src/main/java/org/eclipse/openvsx/json/QueryParamJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/QueryParamJson.java
@@ -40,7 +40,7 @@ public class QueryParamJson {
     @ApiModelProperty("Universally unique identifier of a namespace")
     public String namespaceUuid;
 
-    @ApiModelProperty("Whether to include all versions of an extension")
+    @ApiModelProperty("Whether to include all versions of an extension, ignored if extensionVersion is specified")
     public boolean includeAllVersions;
     
 }


### PR DESCRIPTION
Fixes bug introduced by #357

`param.includeAllVersions` was only used here:
https://github.com/amvanbaren/openvsx/blob/181346853fe636cb171321a69a1a161f286dbd27/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java#L269-L281

when `param.extensionVersion` is specified, then 
https://github.com/amvanbaren/openvsx/blob/181346853fe636cb171321a69a1a161f286dbd27/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java#L242 
is called, skipping the `param.includeAllVersions` logic.

#357 changed this to 
https://github.com/amvanbaren/openvsx/blob/db776443c68abb08f6649ecaaa5c971d561099f8/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java#L270
while it should skip this logic if `param.includeAllVersions` is specified.

Testing steps:
Call `/api/-/query?namespaceName={namespace}&extensionName={extension}&extensionVersion={version}` where `{version}` **isn't** the latest version of the extension. 
Before this change: `response.extensions` is empty array.
After this change: `response.extensions` contains extension version.