### PR TITLE
use Boolean for ExtensionJson.preRelease

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/json/ExtensionJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/ExtensionJson.java
@@ -58,8 +58,7 @@ public class ExtensionJson extends ResultJson {
     public String version;
 
     @ApiModelProperty("Indicates whether this is a pre-release version")
-    @NotNull
-    public boolean preRelease;
+    public Boolean preRelease;
 
     @ApiModelProperty("Data of the user who published this version")
     @NotNull


### PR DESCRIPTION
use Boolean, so that preRelease is only included in the response if it has been set.