### PR TITLE
Etag and caching

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -154,6 +154,7 @@ task unitTests(type: Test) {
     classpath = sourceSets.test.runtimeClasspath
     useJUnitPlatform()
     exclude 'org/eclipse/openvsx/IntegrationTest.class'
+    exclude 'org/eclipse/openvsx/cache/CacheServiceTest.class'
 }
 
 apply from: 'dependencies.gradle'

--- a/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
@@ -31,10 +31,7 @@ import org.eclipse.openvsx.search.ISearchService;
 import org.eclipse.openvsx.util.*;
 import org.elasticsearch.common.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.CacheControl;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -125,7 +122,7 @@ public class RegistryAPI {
         for (var registry : getRegistries()) {
             try {
                 return ResponseEntity.ok()
-                        .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic())
+                        .cacheControl(CacheControl.noCache().cachePublic())
                         .body(registry.getExtension(namespace, extension, null));
             } catch (NotFoundException exc) {
                 // Try the next registry
@@ -199,7 +196,7 @@ public class RegistryAPI {
         for (var registry : getRegistries()) {
             try {
                 return ResponseEntity.ok()
-                        .cacheControl(CacheControl.maxAge(7, TimeUnit.DAYS).cachePublic())
+                        .cacheControl(CacheControl.noCache().cachePublic())
                         .body(registry.getExtension(namespace, extension, null, version));
             } catch (NotFoundException exc) {
                 // Try the next registry

--- a/server/src/main/java/org/eclipse/openvsx/RegistryApplication.java
+++ b/server/src/main/java/org/eclipse/openvsx/RegistryApplication.java
@@ -12,9 +12,11 @@ package org.eclipse.openvsx;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.eclipse.openvsx.web.ShallowEtagHeaderFilter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.converter.ByteArrayHttpMessageConverter;
@@ -25,12 +27,11 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.client.RestTemplate;
-
 import javax.sql.DataSource;
 
 @SpringBootApplication
 @EnableScheduling
-@EnableCaching
+@EnableCaching(proxyTargetClass = true)
 @EnableSchedulerLock(defaultLockAtMostFor = "5m")
 public class RegistryApplication {
 
@@ -61,5 +62,15 @@ public class RegistryApplication {
                         .usingDbTime()
                         .build()
         );
+    }
+
+    @Bean
+    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
+        var registrationBean = new FilterRegistrationBean<ShallowEtagHeaderFilter>();
+        registrationBean.setFilter(new ShallowEtagHeaderFilter());
+        registrationBean.addUrlPatterns("/api/*");
+        registrationBean.setOrder(Integer.MAX_VALUE);
+
+        return registrationBean;
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/cache/CacheService.java
+++ b/server/src/main/java/org/eclipse/openvsx/cache/CacheService.java
@@ -1,0 +1,73 @@
+/** ******************************************************************************
+ * Copyright (c) 2022 Precies. Software and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.cache;
+
+import org.eclipse.openvsx.entities.Extension;
+import org.eclipse.openvsx.entities.ExtensionVersion;
+import org.eclipse.openvsx.entities.UserData;
+import org.eclipse.openvsx.repositories.RepositoryService;
+import org.eclipse.openvsx.util.TargetPlatform;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class CacheService {
+
+    public static final String CACHE_DATABASE_SEARCH = "database.search";
+    public static final String CACHE_EXTENSION_JSON = "extension.json";
+    public static final String GENERATOR_EXTENSION_JSON = "extensionJsonCacheKeyGenerator";
+
+    @Autowired
+    CacheManager cacheManager;
+
+    @Autowired
+    RepositoryService repositoryService;
+
+    @Autowired
+    ExtensionJsonCacheKeyGenerator extensionJsonCacheKey;
+
+    public void evictExtensionJsons(String namespaceName, String extensionName) {
+        evictExtensionJsons(repositoryService.findExtension(extensionName, namespaceName));
+    }
+
+    public void evictExtensionJsons(UserData user) {
+        repositoryService.findVersions(user)
+                .map(ExtensionVersion::getExtension)
+                .toSet()
+                .forEach(this::evictExtensionJsons);
+    }
+
+    public void evictExtensionJsons(Extension extension) {
+        var cache = cacheManager.getCache(CACHE_EXTENSION_JSON);
+        if(cache == null) {
+            return; // cache is not created
+        }
+        if(extension.getVersions() == null) {
+            return;
+        }
+
+        var versions = new ArrayList<>(List.of("latest", "pre-release"));
+        extension.getVersions().stream()
+                .map(ExtensionVersion::getVersion)
+                .forEach(versions::add);
+
+        var namespaceName = extension.getNamespace().getName();
+        var extensionName = extension.getName();
+        for(var version : versions) {
+            for(var targetPlatform : TargetPlatform.TARGET_PLATFORM_NAMES) {
+                cache.evictIfPresent(extensionJsonCacheKey.generate(namespaceName, extensionName, targetPlatform, version));
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/cache/ExtensionJsonCacheKeyGenerator.java
+++ b/server/src/main/java/org/eclipse/openvsx/cache/ExtensionJsonCacheKeyGenerator.java
@@ -1,0 +1,27 @@
+/** ******************************************************************************
+ * Copyright (c) 2022 Precies. Software and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.cache;
+
+import org.springframework.cache.interceptor.KeyGenerator;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Component
+public class ExtensionJsonCacheKeyGenerator implements KeyGenerator {
+    @Override
+    public Object generate(Object target, Method method, Object... params) {
+        return generate((String) params[0], (String) params[1], (String) params[2], (String) params[3]);
+    }
+
+    public String generate(String namespaceName, String extensionName, String targetPlatform, String version) {
+        return namespaceName + "." + extensionName + "-" + version + "@" + targetPlatform;
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionRepository.java
@@ -9,6 +9,7 @@
  ********************************************************************************/
 package org.eclipse.openvsx.repositories;
 
+import org.eclipse.openvsx.entities.UserData;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.util.Streamable;
@@ -33,15 +34,17 @@ public interface ExtensionVersionRepository extends Repository<ExtensionVersion,
 
     Streamable<ExtensionVersion> findByVersionAndExtensionNameIgnoreCaseAndExtensionNamespaceNameIgnoreCase(String version, String extensionName, String namespace);
 
+    Streamable<ExtensionVersion> findByPublishedWithUser(UserData user);
+
+    Streamable<ExtensionVersion> findByPublishedWith(PersonalAccessToken publishedWith);
+
+    Streamable<ExtensionVersion> findByPublishedWithAndActive(PersonalAccessToken publishedWith, boolean active);
+
     @Query("select ev from ExtensionVersion ev where concat(',', ev.bundledExtensions, ',') like concat('%,', ?1, ',%')")
     Streamable<ExtensionVersion> findByBundledExtensions(String extensionId);
 
     @Query("select ev from ExtensionVersion ev where concat(',', ev.dependencies, ',') like concat('%,', ?1, ',%')")
     Streamable<ExtensionVersion> findByDependencies(String extensionId);
-
-    Streamable<ExtensionVersion> findByPublishedWith(PersonalAccessToken publishedWith);
-
-    Streamable<ExtensionVersion> findByPublishedWithAndActive(PersonalAccessToken publishedWith, boolean active);
 
     @Query("select min(ev.timestamp) from ExtensionVersion ev")
     LocalDateTime getOldestTimestamp();

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -340,4 +340,8 @@ public class RepositoryService {
     public Streamable<ExtensionVersion> findTargetPlatformVersions(String version, String extensionName, String namespaceName) {
         return extensionVersionRepo.findByVersionAndExtensionNameIgnoreCaseAndExtensionNamespaceNameIgnoreCase(version, extensionName, namespaceName);
     }
+
+    public Streamable<ExtensionVersion> findVersions(UserData user) {
+        return extensionVersionRepo.findByPublishedWithUser(user);
+    }
 }

--- a/server/src/main/java/org/eclipse/openvsx/search/DatabaseSearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/DatabaseSearchService.java
@@ -29,6 +29,8 @@ import org.elasticsearch.search.aggregations.Aggregations;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 
+import static org.eclipse.openvsx.cache.CacheService.CACHE_DATABASE_SEARCH;
+
 /**
  * Alternative to ElasticSearch service using database search.
  */
@@ -48,7 +50,7 @@ public class DatabaseSearchService implements ISearchService {
     @Autowired
     RepositoryService repositories;
 
-    @Cacheable("database.search")
+    @Cacheable(CACHE_DATABASE_SEARCH)
     public SearchHits<ExtensionSearch> search(ISearchService.Options options, Pageable pageRequest) {
         // grab all extensions
         var matchingExtensions = repositories.findAllActiveExtensions();
@@ -160,7 +162,7 @@ public class DatabaseSearchService implements ISearchService {
      * Clear the cache when asked to update the search index. It could be done also
      * through a cron job as well
      */
-    @CacheEvict(value = "database.search")
+    @CacheEvict(value = CACHE_DATABASE_SEARCH)
     @Override
     public void updateSearchIndex(boolean clear) {
 

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
@@ -23,6 +23,7 @@ import javax.transaction.Transactional;
 import com.google.common.base.Strings;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.eclipse.openvsx.cache.CacheService;
 import org.eclipse.openvsx.entities.Download;
 import org.eclipse.openvsx.entities.ExtensionVersion;
 import org.eclipse.openvsx.entities.FileResource;
@@ -49,6 +50,9 @@ public class StorageUtilService implements IStorageService {
 
     @Autowired
     SearchUtilService search;
+
+    @Autowired
+    CacheService cache;
 
     @Autowired
     EntityManager entityManager;
@@ -188,6 +192,7 @@ public class StorageUtilService implements IStorageService {
         }
 
         search.updateSearchEntry(extension);
+        cache.evictExtensionJsons(extension);
     }
 
     public HttpHeaders getFileResponseHeaders(String fileName) {

--- a/server/src/main/java/org/eclipse/openvsx/util/TargetPlatform.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/TargetPlatform.java
@@ -43,7 +43,7 @@ public class TargetPlatform {
                     NAME_DARWIN_X64 + "," + NAME_DARWIN_ARM64 + "," +
                     NAME_WEB + "," + NAME_UNIVERSAL;
 
-    private final static List<String> TARGET_PLATFORM_NAMES = List.of(
+    public static final List<String> TARGET_PLATFORM_NAMES = List.of(
         NAME_WIN32_X64, NAME_WIN32_IA32, NAME_WIN32_ARM64,
         NAME_LINUX_X64, NAME_LINUX_ARM64, NAME_LINUX_ARMHF,
         NAME_ALPINE_X64, NAME_ALPINE_ARM64,

--- a/server/src/main/java/org/eclipse/openvsx/web/ShallowEtagHeaderFilter.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/ShallowEtagHeaderFilter.java
@@ -1,0 +1,30 @@
+/** ******************************************************************************
+ * Copyright (c) 2022 Precies. Software and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.web;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+
+public class ShallowEtagHeaderFilter extends org.springframework.web.filter.ShallowEtagHeaderFilter {
+
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        // limit the filter to /api/{namespace}/{extension} and /api/{namespace}/{extension}/{version} endpoints
+        var path = request.getRequestURI().substring(1).split("/");
+        var applyFilter = path.length == 3 || path.length == 4;
+        if(applyFilter) {
+            applyFilter = path[0].equals("api") && !path[1].equals("-");
+        }
+        if(applyFilter && path.length == 4) {
+            applyFilter = !(path[3].equals("review") || path[3].equals("reviews"));
+        }
+
+        return !applyFilter;
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import net.javacrumbs.shedlock.core.LockProvider;
 import org.eclipse.openvsx.adapter.VSCodeIdService;
+import org.eclipse.openvsx.cache.CacheService;
 import org.eclipse.openvsx.eclipse.EclipseService;
 import org.eclipse.openvsx.entities.*;
 import org.eclipse.openvsx.json.ExtensionJson;
@@ -69,7 +70,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 @AutoConfigureWebClient
 @MockBean({
     ClientRegistrationRepository.class, UpstreamRegistryService.class, GoogleCloudStorageService.class,
-    AzureBlobStorageService.class, VSCodeIdService.class, AzureDownloadCountService.class, LockProvider.class
+    AzureBlobStorageService.class, VSCodeIdService.class, AzureDownloadCountService.class, LockProvider.class,
+    CacheService.class
 })
 public class AdminAPITest {
     
@@ -866,5 +868,4 @@ public class AdminAPITest {
             return new StorageUtilService();
         }
     }
-
 }

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -34,6 +34,8 @@ import javax.persistence.EntityManager;
 
 import net.javacrumbs.shedlock.core.LockProvider;
 import org.eclipse.openvsx.adapter.VSCodeIdService;
+import org.eclipse.openvsx.cache.CacheService;
+import org.eclipse.openvsx.cache.ExtensionJsonCacheKeyGenerator;
 import org.eclipse.openvsx.dto.ExtensionVersionDTO;
 import org.eclipse.openvsx.eclipse.EclipseService;
 import org.eclipse.openvsx.entities.*;
@@ -83,7 +85,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @AutoConfigureWebClient
 @MockBean({
     ClientRegistrationRepository.class, UpstreamRegistryService.class, GoogleCloudStorageService.class,
-    AzureBlobStorageService.class, VSCodeIdService.class, AzureDownloadCountService.class, LockProvider.class
+    AzureBlobStorageService.class, VSCodeIdService.class, AzureDownloadCountService.class, LockProvider.class,
+    CacheService.class
 })
 public class RegistryAPITest {
 
@@ -1716,6 +1719,9 @@ public class RegistryAPITest {
         StorageUtilService storageUtilService() {
             return new StorageUtilService();
         }
+
+        @Bean
+        ExtensionJsonCacheKeyGenerator extensionJsonCacheKeyGenerator() { return new ExtensionJsonCacheKeyGenerator(); }
     }
     
 }

--- a/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import net.javacrumbs.shedlock.core.LockProvider;
+import org.eclipse.openvsx.cache.CacheService;
 import org.eclipse.openvsx.eclipse.EclipseService;
 import org.eclipse.openvsx.entities.Namespace;
 import org.eclipse.openvsx.entities.NamespaceMembership;
@@ -57,7 +58,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 @WebMvcTest(UserAPI.class)
 @AutoConfigureWebClient
-@MockBean({ EntityManager.class, ClientRegistrationRepository.class, LockProvider.class })
+@MockBean({ EntityManager.class, ClientRegistrationRepository.class, LockProvider.class, CacheService.class })
 public class UserAPITest {
 
     @SpyBean

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAdapterTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAdapterTest.java
@@ -33,6 +33,7 @@ import com.google.common.io.CharStreams;
 import net.javacrumbs.shedlock.core.LockProvider;
 import org.eclipse.openvsx.MockTransactionTemplate;
 import org.eclipse.openvsx.UserService;
+import org.eclipse.openvsx.cache.CacheService;
 import org.eclipse.openvsx.dto.ExtensionDTO;
 import org.eclipse.openvsx.dto.ExtensionVersionDTO;
 import org.eclipse.openvsx.dto.FileResourceDTO;
@@ -73,7 +74,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 @AutoConfigureWebClient
 @MockBean({
     ClientRegistrationRepository.class, GoogleCloudStorageService.class, AzureBlobStorageService.class,
-    AzureDownloadCountService.class, LockProvider.class
+    AzureDownloadCountService.class, LockProvider.class, CacheService.class
 })
 public class VSCodeAdapterTest {
 

--- a/server/src/test/java/org/eclipse/openvsx/cache/CacheServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/cache/CacheServiceTest.java
@@ -1,0 +1,392 @@
+/** ******************************************************************************
+ * Copyright (c) 2022 Precies. Software and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.cache;
+
+import org.eclipse.openvsx.AdminService;
+import org.eclipse.openvsx.ExtensionService;
+import org.eclipse.openvsx.LocalRegistryService;
+import org.eclipse.openvsx.UserService;
+import org.eclipse.openvsx.entities.*;
+import org.eclipse.openvsx.json.ExtensionJson;
+import org.eclipse.openvsx.json.ReviewJson;
+import org.eclipse.openvsx.security.IdPrincipal;
+import org.eclipse.openvsx.util.TimeUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.eclipse.openvsx.cache.CacheService.CACHE_EXTENSION_JSON;
+import static org.eclipse.openvsx.entities.FileResource.DOWNLOAD;
+import static org.eclipse.openvsx.entities.FileResource.STORAGE_DB;
+import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class CacheServiceTest {
+
+    @Autowired
+    CacheManager cache;
+
+    @Autowired
+    UserService users;
+
+    @Autowired
+    AdminService admins;
+
+    @Autowired
+    ExtensionService extensions;
+
+    @Autowired
+    LocalRegistryService registry;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Test
+    @Transactional
+    public void testGetExtension() {
+        setRequest();
+        var extVersion = insertExtensionVersion();
+        var extension = extVersion.getExtension();
+        var namespace = extension.getNamespace();
+        var cacheKey = new ExtensionJsonCacheKeyGenerator().generate(namespace.getName(), extension.getName(),
+                extVersion.getTargetPlatform(), extVersion.getVersion());
+
+        var json = registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
+        var cachedJson = cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
+        assertEquals(json, cachedJson);
+    }
+
+    @Test
+    @Transactional
+    public void testUpdateExistingUser() {
+        setRequest();
+        var extVersion = insertExtensionVersion();
+        var extension = extVersion.getExtension();
+        var namespace = extension.getNamespace();
+        var cacheKey = new ExtensionJsonCacheKeyGenerator().generate(namespace.getName(), extension.getName(),
+                extVersion.getTargetPlatform(), extVersion.getVersion());
+
+        registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
+
+        var authority = "github";
+        var authorities = List.of((GrantedAuthority) () -> authority);
+
+        var loginName = "amvanbaren";
+        var fullName = "Aart van Baren";
+        var htmlUrl = "https://amvanbaren.github.io";
+        var avatarUrl = "https://amvanbaren.github.io/avatar.png";
+        var attributes = new HashMap<String, Object>();
+        attributes.put("login", loginName);
+        attributes.put("name", fullName);
+        attributes.put("email", "amvanbaren@hotmail.com");
+        attributes.put("html_url", htmlUrl);
+        attributes.put("avatar_url", avatarUrl);
+
+        var user = extVersion.getPublishedWith().getUser();
+        var oauthUser = new DefaultOAuth2User(authorities, attributes, "name");
+        users.updateExistingUser(user, oauthUser);
+        assertNull(cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
+
+        var json = registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
+        assertEquals(loginName, json.publishedBy.loginName);
+        assertEquals(fullName, json.publishedBy.fullName);
+        assertEquals(htmlUrl, json.publishedBy.homepage);
+        assertEquals(authority, json.publishedBy.provider);
+        assertEquals(avatarUrl, json.publishedBy.avatarUrl);
+
+        var cachedJson = cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
+        assertEquals(json, cachedJson);
+    }
+
+    @Test
+    @Transactional
+    public void testPostReview() {
+        setRequest();
+        var extVersion = insertExtensionVersion();
+        var extension = extVersion.getExtension();
+        var namespace = extension.getNamespace();
+        var cacheKey = new ExtensionJsonCacheKeyGenerator().generate(namespace.getName(), extension.getName(),
+                extVersion.getTargetPlatform(), extVersion.getVersion());
+
+        var json = registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
+        assertEquals(Long.valueOf(0), json.reviewCount);
+        assertNull(json.averageRating);
+
+        var poster = new UserData();
+        poster.setLoginName("user1");
+        entityManager.persist(poster);
+        setLoggedInUser(poster);
+
+        var review = new ReviewJson();
+        review.rating = 3;
+        review.comment = "Somewhat ok";
+        review.timestamp = "2000-01-01T10:00Z";
+
+        registry.postReview(review, namespace.getName(), extension.getName());
+        assertNull(cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
+
+        json = registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
+        assertEquals(Long.valueOf(1), json.reviewCount);
+        assertEquals(Double.valueOf(3), json.averageRating);
+
+        var cachedJson = cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
+        assertEquals(json, cachedJson);
+    }
+
+    @Test
+    @Transactional
+    public void testDeleteReview() {
+        setRequest();
+        var extVersion = insertExtensionVersion();
+        var extension = extVersion.getExtension();
+        var namespace = extension.getNamespace();
+        var cacheKey = new ExtensionJsonCacheKeyGenerator().generate(namespace.getName(), extension.getName(),
+                extVersion.getTargetPlatform(), extVersion.getVersion());
+
+        var poster = new UserData();
+        poster.setLoginName("user1");
+        entityManager.persist(poster);
+        setLoggedInUser(poster);
+
+        var review = new ReviewJson();
+        review.rating = 3;
+        review.comment = "Somewhat ok";
+        review.timestamp = "2000-01-01T10:00Z";
+
+        registry.postReview(review, namespace.getName(), extension.getName());
+        var json = registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
+        assertEquals(Long.valueOf(1), json.reviewCount);
+        assertEquals(Double.valueOf(3), json.averageRating);
+
+        registry.deleteReview(namespace.getName(), extension.getName());
+        assertNull(cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
+
+        json = registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
+        assertEquals(Long.valueOf(0), json.reviewCount);
+        assertNull(json.averageRating);
+
+        var cachedJson = cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
+        assertEquals(json, cachedJson);
+    }
+
+    @Test
+    @Transactional
+    public void testDeleteExtension() {
+        setRequest();
+        var admin = insertAdmin();
+        var extVersion = insertExtensionVersion();
+        var extension = extVersion.getExtension();
+        var namespace = extension.getNamespace();
+        var cacheKey = new ExtensionJsonCacheKeyGenerator().generate(namespace.getName(), extension.getName(),
+                extVersion.getTargetPlatform(), extVersion.getVersion());
+
+        registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
+
+        admins.deleteExtension(namespace.getName(), extension.getName(), admin);
+        assertNull(cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
+    }
+
+    @Test
+    @Transactional
+    public void testDeleteExtensionVersion() {
+        setRequest();
+        var admin = insertAdmin();
+        var extVersion = insertExtensionVersion();
+        var extension = extVersion.getExtension();
+        var namespace = extension.getNamespace();
+        var cacheKey = new ExtensionJsonCacheKeyGenerator().generate(namespace.getName(), extension.getName(),
+                extVersion.getTargetPlatform(), extVersion.getVersion());
+
+        var newVersion = "0.2.0";
+        var oldVersion = extVersion.getVersion();
+        insertNewVersion(extension, extVersion.getPublishedWith(), newVersion);
+
+        var json = registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), newVersion);
+        assertTrue(json.allVersions.containsKey(newVersion));
+        assertTrue(json.allVersions.containsKey(oldVersion));
+
+        admins.deleteExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), newVersion, admin);
+        assertNull(cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
+
+        json = registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
+        assertFalse(json.allVersions.containsKey(newVersion));
+        assertTrue(json.allVersions.containsKey(oldVersion));
+
+        var cachedJson = cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
+        assertEquals(json, cachedJson);
+    }
+
+    @Test
+    @Transactional
+    public void testUpdateExtension() {
+        setRequest();
+        var extVersion = insertExtensionVersion();
+        var extension = extVersion.getExtension();
+        var namespace = extension.getNamespace();
+        var cacheKey = new ExtensionJsonCacheKeyGenerator().generate(namespace.getName(), extension.getName(),
+                extVersion.getTargetPlatform(), extVersion.getVersion());
+
+        registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
+
+        var newVersion = "0.2.0";
+        var oldVersion = extVersion.getVersion();
+        var newExtVersion = insertNewVersion(extension, extVersion.getPublishedWith(), newVersion);
+        newExtVersion.setPreRelease(true);
+        extensions.updateExtension(extension);
+        assertNull(cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
+
+        var json = registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), oldVersion);
+        assertTrue(json.allVersions.containsKey(oldVersion));
+        assertTrue(json.allVersions.containsKey(newVersion));
+        assertTrue(json.allVersions.containsKey("latest"));
+        assertTrue(json.allVersions.containsKey("pre-release"));
+
+        var cachedJson = cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
+        assertEquals(json, cachedJson);
+    }
+
+    private void setLoggedInUser(UserData user) {
+        var principal = new IdPrincipal(user.getId(), user.getLoginName(), List.of((GrantedAuthority) () -> "github"));
+        var authentication = new TestingAuthenticationToken(principal, null);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private void setRequest() {
+        // UrlUtil.getBaseUrl needs request
+        var request = new MockHttpServletRequest();
+        request.setScheme("https");
+        request.setServerName("open-vsx.org");
+        request.setServerPort(8080);
+        request.setContextPath("/openvsx-server");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    }
+
+    private UserData insertAdmin() {
+        var admin = new UserData();
+        admin.setLoginName("super_user");
+        admin.setRole("admin");
+        entityManager.persist(admin);
+
+        return admin;
+    }
+
+    private ExtensionVersion insertNewVersion(Extension extension, PersonalAccessToken token, String newVersion) {
+        var extVersion = new ExtensionVersion();
+        extVersion.setPreview(false);
+        extVersion.setActive(true);
+        extVersion.setVersion(newVersion);
+        extVersion.setTargetPlatform("universal");
+        extVersion.setDisplayName("baz");
+        extVersion.setDescription("foo.bar baz");
+        extVersion.setTimestamp(TimeUtil.getCurrentUTC());
+        extVersion.setCategories(Collections.emptyList());
+        extVersion.setTags(Collections.emptyList());
+        extVersion.setExtension(extension);
+        extVersion.setPublishedWith(token);
+        entityManager.persist(extVersion);
+
+        // populate extension versions list
+        entityManager.flush();
+        entityManager.refresh(extension);
+
+        var download = new FileResource();
+        download.setExtension(extVersion);
+        download.setName("foo.bar-" + newVersion + ".vsix");
+        download.setType(DOWNLOAD);
+        download.setStorageType(STORAGE_DB);
+        download.setContent("VSIX Package".getBytes(StandardCharsets.UTF_8));
+        entityManager.persist(download);
+
+        return extVersion;
+    }
+
+    private ExtensionVersion insertExtensionVersion() {
+        return insertExtensionVersion("0.1.0");
+    }
+
+    private ExtensionVersion insertExtensionVersion(String version) {
+        var namespace = new Namespace();
+        namespace.setName("foo");
+        namespace.setPublicId("12823789-189273189-1721983");
+        entityManager.persist(namespace);
+
+        var extension = new Extension();
+        extension.setActive(true);
+        extension.setName("bar");
+        extension.setDownloadCount(0);
+        extension.setNamespace(namespace);
+        entityManager.persist(extension);
+
+        var user = new UserData();
+        user.setLoginName("user");
+        user.setFullName("User");
+        user.setAvatarUrl("https://github.com/user/avatar");
+        user.setProviderUrl("https://github.com");
+        user.setProvider("github");
+        entityManager.persist(user);
+
+        var token = new PersonalAccessToken();
+        token.setUser(user);
+        token.setValue("lkasdjfdklas-daskjfdaksl-kasdljfaksl");
+        token.setActive(true);
+        token.setDescription("test token");
+        token.setCreatedTimestamp(LocalDateTime.now());
+        token.setAccessedTimestamp(LocalDateTime.now());
+        entityManager.persist(token);
+
+        var extVersion = new ExtensionVersion();
+        extVersion.setPreview(false);
+        extVersion.setActive(true);
+        extVersion.setVersion(version);
+        extVersion.setTargetPlatform("universal");
+        extVersion.setDisplayName("baz");
+        extVersion.setDescription("foo.bar baz");
+        extVersion.setTimestamp(TimeUtil.getCurrentUTC());
+        extVersion.setCategories(Collections.emptyList());
+        extVersion.setTags(Collections.emptyList());
+        extVersion.setExtension(extension);
+        extVersion.setPublishedWith(token);
+        entityManager.persist(extVersion);
+
+        // populate extension versions list
+        entityManager.flush();
+        entityManager.refresh(extension);
+
+        var download = new FileResource();
+        download.setExtension(extVersion);
+        download.setName("foo.bar-" + version + ".vsix");
+        download.setType(DOWNLOAD);
+        download.setStorageType(STORAGE_DB);
+        download.setContent("VSIX Package".getBytes(StandardCharsets.UTF_8));
+        entityManager.persist(download);
+
+        return extVersion;
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
@@ -27,6 +27,7 @@ import org.eclipse.openvsx.ExtensionValidator;
 import org.eclipse.openvsx.MockTransactionTemplate;
 import org.eclipse.openvsx.UserService;
 import org.eclipse.openvsx.adapter.VSCodeIdService;
+import org.eclipse.openvsx.cache.CacheService;
 import org.eclipse.openvsx.entities.*;
 import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.search.SearchUtilService;
@@ -57,7 +58,7 @@ import org.springframework.web.client.RestTemplate;
 @ExtendWith(SpringExtension.class)
 @MockBean({
     EntityManager.class, SearchUtilService.class, GoogleCloudStorageService.class, AzureBlobStorageService.class,
-    VSCodeIdService.class, AzureDownloadCountService.class, LockProvider.class
+    VSCodeIdService.class, AzureDownloadCountService.class, LockProvider.class, CacheService.class
 })
 public class EclipseServiceTest {
 


### PR DESCRIPTION
Fixes #391
Contributes to #379

The server uses a fixed caching strategy. `/api/{namespace}/{extension}` responses are cached for 10 minutes and `/api/{namespace}/{extension}/{version}` responses are cached for 7 days. When changing the version using the dropdown, the browser location changes to `/extension/{namespace}/{extension}/{version}`. If the version page has been visited before, the browser loads JSON from cache, else it sends a request to the API. Data inconsistencies emerge when some versions are loaded from cache while others are newly requested and the extension has been updated in the meantime (download count increase, version was added or removed, user details changed).

Instead of caching responses for a fixed duration, use Etag response header to always return the current extension state and limit bandwidth usage when nothing has changed. Server side JSON response caching is added to limit CPU time.

### Testing steps:
- Open browser devtools and go to http://localhost:3000/extension/redhat/vscode-yaml
- In the devtools you should see `GET | http://localhost:8080/api/redhat/vscode-yaml` returns status 200 and it has a Etag response header.
- Refresh the page. Now `GET | http://localhost:8080/api/redhat/vscode-yaml` has the If-None-Match request header and it returns status 304 (not modified).
- Publish a new version of vscode-yaml. Again refresh the page. `GET | http://localhost:8080/api/redhat/vscode-yaml` returns status 200 again and it has a different Etag value.
- You can repeat the above steps for a specific version too, by using the dropdown to the right.