### PR TITLE
 URI encode FileResource urls

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -616,9 +616,9 @@ public class LocalRegistryService implements IExtensionRegistry {
         }
 
         json.files = Maps.newLinkedHashMapWithExpectedSize(6);
-        var versionUrl = UrlUtil.createApiUrl(versionBaseUrl, json.version);
+        var fileBaseUrl = UrlUtil.createApiUrl(versionBaseUrl, json.version, "file");
         for (var resource : resources) {
-            var fileUrl = UrlUtil.createApiUrl(versionUrl, "file", resource.getName());
+            var fileUrl = UrlUtil.createApiUrl(fileBaseUrl, resource.getName().split("/"));
             json.files.put(resource.getType(), fileUrl);
         }
 

--- a/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
@@ -47,9 +47,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import springfox.documentation.annotations.ApiIgnore;
 
+import javax.servlet.http.HttpServletRequest;
+
 @RestController
 public class RegistryAPI {
-
     private final static int REVIEW_TITLE_SIZE = 255;
     private final static int REVIEW_COMMENT_SIZE = 2048;
 
@@ -172,7 +173,7 @@ public class RegistryAPI {
         return new ResponseEntity<>(json, HttpStatus.NOT_FOUND);
     }
 
-    @GetMapping("/api/{namespace}/{extension}/{version}/file/{fileName:.+}")
+    @GetMapping("/api/{namespace}/{extension}/{version}/file/**")
     @CrossOrigin
     @ApiOperation("Access a file packaged by an extension")
     @ApiResponses({
@@ -195,15 +196,15 @@ public class RegistryAPI {
         )
     })
     public ResponseEntity<byte[]> getFile(
+            HttpServletRequest request,
             @PathVariable @ApiParam(value = "Extension namespace", example = "redhat")
             String namespace,
             @PathVariable @ApiParam(value = "Extension name", example = "java")
             String extension,
             @PathVariable @ApiParam(value = "Extension version", example = "0.65.0")
-            String version,
-            @PathVariable @ApiParam(value = "Name of the file to access", example = "LICENSE.txt")
-            String fileName
+            String version
         ) {
+        var fileName = UrlUtil.extractWildcardPath(request);
         for (var registry : getRegistries()) {
             try {
                 return registry.getFile(namespace, extension, version, fileName);

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAdapter.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAdapter.java
@@ -10,6 +10,7 @@
 package org.eclipse.openvsx.adapter;
 
 import com.google.common.collect.Lists;
+import org.apache.commons.lang3.ArrayUtils;
 import org.eclipse.openvsx.dto.ExtensionDTO;
 import org.eclipse.openvsx.dto.ExtensionVersionDTO;
 import org.eclipse.openvsx.dto.FileResourceDTO;
@@ -224,7 +225,8 @@ public class VSCodeAdapter {
     }
 
     private String createFileUrl(FileResourceDTO resource, String versionUrl) {
-        return resource != null ? UrlUtil.createApiUrl(versionUrl, "file", resource.getName()) : null;
+        var segments = ArrayUtils.addAll(new String[]{"file"}, resource.getName().split("/"));
+        return resource != null ? UrlUtil.createApiUrl(versionUrl, segments) : null;
     }
 
     private ExtensionQueryResult toQueryResult(List<ExtensionQueryResult.Extension> extensions, long totalCount) {

--- a/server/src/main/java/org/eclipse/openvsx/storage/AzureDownloadCountService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AzureDownloadCountService.java
@@ -31,11 +31,13 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StopWatch;
+import org.springframework.web.util.UriUtils;
 
 import javax.persistence.EntityManager;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -177,7 +179,7 @@ public class AzureDownloadCountService {
                     matchesStorageBlobContainer = storageBlobContainer.equals(container);
                 }
                 if(matchesStorageBlobContainer) {
-                    var fileName = pathParams[pathParams.length - 1].toUpperCase();
+                    var fileName = UriUtils.decode(pathParams[pathParams.length - 1], StandardCharsets.UTF_8).toUpperCase();
                     var timestamps = files.getOrDefault(fileName, new ArrayList<>());
                     timestamps.add(LocalDateTime.parse(node.get("time").asText(), DateTimeFormatter.ISO_ZONED_DATE_TIME));
                     files.put(fileName, timestamps);

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
@@ -22,6 +22,7 @@ import javax.transaction.Transactional;
 
 import com.google.common.base.Strings;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.eclipse.openvsx.entities.Download;
 import org.eclipse.openvsx.entities.ExtensionVersion;
 import org.eclipse.openvsx.entities.FileResource;
@@ -145,8 +146,9 @@ public class StorageUtilService implements IStorageService {
     private String getFileUrl(String name, ExtensionVersion extVersion, String serverUrl) {
         var extension = extVersion.getExtension();
         var namespace = extension.getNamespace();
-        return UrlUtil.createApiUrl(serverUrl, "api", namespace.getName(), extension.getName(), extVersion.getVersion(),
-                "file", name);
+        var segments = new String[]{"api", namespace.getName(), extension.getName(), extVersion.getVersion(), "file"};
+        segments = ArrayUtils.addAll(segments, name.split("/"));
+        return UrlUtil.createApiUrl(serverUrl, segments);
     }
 
     /**
@@ -155,10 +157,10 @@ public class StorageUtilService implements IStorageService {
     public void addFileUrls(ExtensionVersion extVersion, String serverUrl, Map<String, String> type2Url, String... types) {
         var extension = extVersion.getExtension();
         var namespace = extension.getNamespace();
-        var versionUrl = UrlUtil.createApiUrl(serverUrl, "api", namespace.getName(), extension.getName(), extVersion.getVersion());
+        var baseUrl = UrlUtil.createApiUrl(serverUrl, "api", namespace.getName(), extension.getName(), extVersion.getVersion(), "file");
         var resources = repositories.findFilesByType(extVersion, Arrays.asList(types));
         for (var resource : resources) {
-            var fileUrl = UrlUtil.createApiUrl(versionUrl, "file", resource.getName());
+            var fileUrl = UrlUtil.createApiUrl(baseUrl, resource.getName().split("/"));
             type2Url.put(resource.getType(), fileUrl);
         }
     }
@@ -167,11 +169,11 @@ public class StorageUtilService implements IStorageService {
         var name2Url = new HashMap<String, String>();
         var extension = extVersion.getExtension();
         var namespace = extension.getNamespace();
-        var versionUrl = UrlUtil.createApiUrl(serverUrl, "api", namespace.getName(), extension.getName(), extVersion.getVersion());
+        var baseUrl = UrlUtil.createApiUrl(serverUrl, "api", namespace.getName(), extension.getName(), extVersion.getVersion(), "file");
         var resources = repositories.findFilesByType(extVersion, Arrays.asList(WEB_RESOURCE));
         if (resources != null) {
             for (var resource : resources) {
-                var fileUrl = UrlUtil.createApiUrl(versionUrl, "file", resource.getName());
+                var fileUrl = UrlUtil.createApiUrl(baseUrl, resource.getName().split("/"));
                 name2Url.put(resource.getName(), fileUrl);
             }
         }

--- a/server/src/main/java/org/eclipse/openvsx/util/UrlUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/UrlUtil.java
@@ -9,9 +9,8 @@
  ********************************************************************************/
 package org.eclipse.openvsx.util;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -19,6 +18,7 @@ import org.springframework.util.AntPathMatcher;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.util.UriUtils;
 
 public final class UrlUtil {
 
@@ -33,7 +33,6 @@ public final class UrlUtil {
         for (var segment : segments) {
             initialCapacity += segment.length() + 1;
         }
-        var charset = Charset.forName("UTF-8");
         var result = new StringBuilder(initialCapacity);
         result.append(baseUrl);
         for (var segment : segments) {
@@ -43,7 +42,7 @@ public final class UrlUtil {
                 continue;
             if (result.length() == 0 || result.charAt(result.length() - 1) != '/')
                 result.append('/');
-            result.append(URLEncoder.encode(segment, charset));
+            result.append(UriUtils.encodePathSegment(segment, StandardCharsets.UTF_8));
         }
         return result.toString();
     }
@@ -55,27 +54,24 @@ public final class UrlUtil {
     public static String addQuery(String url, String... parameters) {
         if (parameters.length % 2 != 0)
             throw new IllegalArgumentException("Expected an even number of parameters.");
-        try {
-            var result = new StringBuilder(url);
-            var printedParams = 0;
-            for (var i = 0; i < parameters.length; i += 2) {
-                var key = parameters[i];
-                var value = parameters[i + 1];
-                if (key == null)
-                    throw new NullPointerException("Parameter key must not be null");
-                if (value != null) {
-                    if (printedParams == 0)
-                        result.append('?');
-                    else
-                        result.append('&');
-                    result.append(key).append('=').append(URLEncoder.encode(value, "UTF-8"));
-                    printedParams++;
-                }
+
+        var result = new StringBuilder(url);
+        var printedParams = 0;
+        for (var i = 0; i < parameters.length; i += 2) {
+            var key = parameters[i];
+            var value = parameters[i + 1];
+            if (key == null)
+                throw new NullPointerException("Parameter key must not be null");
+            if (value != null) {
+                if (printedParams == 0)
+                    result.append('?');
+                else
+                    result.append('&');
+                result.append(key).append('=').append(UriUtils.encodeQueryParam(value, StandardCharsets.UTF_8));
+                printedParams++;
             }
-            return result.toString();
-        } catch (UnsupportedEncodingException exc) {
-            throw new RuntimeException(exc);
         }
+        return result.toString();
     }
 
     /**

--- a/server/src/test/java/org/eclipse/openvsx/storage/AzureBlobStorageServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/storage/AzureBlobStorageServiceTest.java
@@ -1,0 +1,68 @@
+/** ******************************************************************************
+ * Copyright (c) 2022 Precies. Software and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.storage;
+
+import org.eclipse.openvsx.entities.Extension;
+import org.eclipse.openvsx.entities.ExtensionVersion;
+import org.eclipse.openvsx.entities.FileResource;
+import org.eclipse.openvsx.entities.Namespace;
+import org.eclipse.openvsx.search.DatabaseSearchService;
+import org.eclipse.openvsx.search.RelevanceService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(SpringExtension.class)
+@MockBean({ StorageUtilService.class })
+public class AzureBlobStorageServiceTest {
+
+    @Autowired
+    AzureBlobStorageService service;
+
+    @Test
+    public void testGetLocation() {
+        service.serviceEndpoint = "http://azure.blob.storage/";
+        service.blobContainer = "blob-container";
+        var namespace = new Namespace();
+        namespace.setName("abelfubu");
+
+        var extension = new Extension();
+        extension.setName("abelfubu-dark");
+        extension.setNamespace(namespace);
+
+        var extVersion = new ExtensionVersion();
+        extVersion.setVersion("1.3.4");
+        extVersion.setExtension(extension);
+
+        var resource = new FileResource();
+        resource.setName("extension/themes/abelFubu Dark+-color-theme.json");
+        resource.setExtension(extVersion);
+
+        var uri = service.getLocation(resource);
+        var expected = URI.create("http://azure.blob.storage/blob-container/abelfubu/abelfubu-dark/1.3.4/extension/themes/abelFubu%20Dark+-color-theme.json");
+        assertEquals(expected, uri);
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        AzureBlobStorageService azureBlobStorageService() {
+            return new AzureBlobStorageService();
+        }
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/util/UriUtilTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/util/UriUtilTest.java
@@ -48,7 +48,7 @@ public class UriUtilTest {
     public void testQuery() throws Exception {
         var url = "http://localhost/api/foo";
         assertThat(UrlUtil.addQuery(url, "a", "1", "b", null, "c", "b\ta/r"))
-                .isEqualTo("http://localhost/api/foo?a=1&c=b%09a%2Fr");
+                .isEqualTo("http://localhost/api/foo?a=1&c=b%09a/r");
     }
 
     // Check base URL is localhost:8080 if there is no XForwarded headers


### PR DESCRIPTION
Fixes #426
Contributes to #432

Validation steps:
- to reproduce the error, use master branch. to test the fix use this branch
- open the branch in gitpod
- wait until publisher terminal is done executing its task
- use publisher terminal to execute the following commands:
  - create namespace: 
  ```
  curl --location --request POST 'http://localhost:8080/api/-/namespace/create?token=super_token' \
  --header 'Content-Type: application/json' \
  --data-raw '{"name":"abelfubu"}'
  ```
  - download vsix package: 
  ```
  curl --location --request GET 'https://open-vsx.org/api/abelfubu/abelfubu-dark/1.3.4/file/abelfubu.abelfubu-dark-1.3.4.vsix' \
  --output 'abelfubu.abelfubu-dark-1.3.4.vsix'
  ```
  - publish vsix package: 
  ```
  curl --location --request POST 'http://localhost:8080/api/-/publish?token=super_token' \
  --header 'Content-Type: application/octet-stream' \
  --data-binary '@/workspace/openvsx/abelfubu.abelfubu-dark-1.3.4.vsix'
  ```
- switch to server terminal and stop the server
- using `psql`: 
```
UPDATE file_resource SET storage_type = 'azure-blob';
```
- open `/workspace/openvsx/server/src/dev/resources/application-ovsx.properties` and add:
```
ovsx.storage.azure.service-endpoint=https://openvsxorg.blob.core.windows.net/
ovsx.storage.azure.blob-container=resources
```
- in server terminal run:
```
./gradlew runServer
```
- switch back to publisher terminal and get color-theme.json: 
```
curl --location --request GET 'http://localhost:8080/vscode/asset/abelfubu/abelfubu-dark/1.3.4/Microsoft.VisualStudio.Code.WebResources/extension/themes/abelFubu%20Dark+-color-theme.json'
```