### PR TITLE
Some extension resource url return 404 or 500

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
@@ -285,12 +285,8 @@ public class ExtensionProcessor implements AutoCloseable {
         return null;
     }
 
-    private boolean isWebExtensionKind(ExtensionVersion extension) {
-        return extension.getTags().contains(WEB_EXTENSION_TAG);
-    }
-
     public List<FileResource> getResources(ExtensionVersion extension) {
-        var resources = new ArrayList<FileResource>();
+        var resources = new ArrayList<>(getAllResources(extension));
         var binary = getBinary(extension);
         if (binary != null)
             resources.add(binary);
@@ -309,27 +305,24 @@ public class ExtensionProcessor implements AutoCloseable {
         var icon = getIcon(extension);
         if (icon != null)
             resources.add(icon);
-        if (isWebExtensionKind(extension))
-            resources.addAll(getWebResources(extension));
+
         return resources;
     }
 
-    protected List<FileResource> getWebResources(ExtensionVersion extension) {
+    protected List<FileResource> getAllResources(ExtensionVersion extension) {
         readInputStream();
-        var namePrefix = "extension/";
         return zipFile.stream()
-                .filter(zipEntry -> zipEntry.getName().startsWith(namePrefix))
                 .map(zipEntry -> {
                     var bytes = ArchiveUtil.readEntry(zipFile, zipEntry);
                     if (bytes == null) {
                         return null;
                     }
-                    var webResource = new FileResource();
-                    webResource.setExtension(extension);
-                    webResource.setName(zipEntry.getName());
-                    webResource.setType(FileResource.WEB_RESOURCE);
-                    webResource.setContent(bytes);
-                    return webResource;
+                    var resource = new FileResource();
+                    resource.setExtension(extension);
+                    resource.setName(zipEntry.getName());
+                    resource.setType(FileResource.RESOURCE);
+                    resource.setContent(bytes);
+                    return resource;
                 })
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());

--- a/server/src/main/java/org/eclipse/openvsx/db/migration/V1_23__FileResource_Extract_Resources.java
+++ b/server/src/main/java/org/eclipse/openvsx/db/migration/V1_23__FileResource_Extract_Resources.java
@@ -1,0 +1,196 @@
+/** ******************************************************************************
+ * Copyright (c) 2022 Precies. Software and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+
+package org.eclipse.openvsx.db.migration;
+
+import org.eclipse.openvsx.ExtensionProcessor;
+import org.eclipse.openvsx.entities.Extension;
+import org.eclipse.openvsx.entities.ExtensionVersion;
+import org.eclipse.openvsx.entities.FileResource;
+import org.eclipse.openvsx.entities.Namespace;
+import org.eclipse.openvsx.storage.AzureBlobStorageService;
+import org.eclipse.openvsx.storage.GoogleCloudStorageService;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.ByteArrayInputStream;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class V1_23__FileResource_Extract_Resources extends BaseJavaMigration {
+
+    private static final String COL_FR_ID = "fr_id";
+    private static final String COL_FR_NAME = "fr_name";
+    private static final String COL_FR_TYPE = "fr_type";
+    private static final String COL_FR_CONTENT = "fr_content";
+    private static final String COL_FR_STORAGE_TYPE = "fr_storage_type";
+    private static final String COL_EV_ID = "ev_id";
+    private static final String COL_EV_VERSION = "ev_version";
+    private static final String COL_E_NAME = "e_name";
+    private static final String COL_N_NAME = "n_name";
+
+    @Autowired
+    RestTemplate restTemplate;
+
+    @Autowired
+    GoogleCloudStorageService googleStorage;
+
+    @Autowired
+    AzureBlobStorageService azureStorage;
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        var connection = context.getConnection();
+        var downloads = getAllDownloads(connection);
+        var resources = extractResources(downloads);
+        uploadResources(resources);
+        deleteResources(connection);
+        insertResources(resources, connection);
+        deleteWebResources(connection);
+    }
+
+    private List<FileResource> getAllDownloads(Connection connection) throws SQLException {
+        var query = "SELECT " +
+                "fr.id " + COL_FR_ID + ", " +
+                "fr.name " + COL_FR_NAME + ", " +
+                "fr.type " + COL_FR_TYPE + ", " +
+                "fr.content " + COL_FR_CONTENT + ", " +
+                "fr.storage_type " + COL_FR_STORAGE_TYPE + ", " +
+                "ev.id " + COL_EV_ID + ", " +
+                "ev.version " + COL_EV_VERSION + ", " +
+                "e.name " + COL_E_NAME + ", " +
+                "n.name " + COL_N_NAME + " " +
+                "FROM file_resource fr " +
+                "JOIN extension_version ev ON ev.id = fr.extension_id " +
+                "JOIN extension e ON e.id = ev.extension_id " +
+                "JOIN namespace n ON n.id = e.namespace_id " +
+                "WHERE fr.type = 'download'";
+
+        var downloads = new ArrayList<FileResource>();
+        try(var statement = connection.prepareStatement(query)) {
+            try(var result = statement.executeQuery()) {
+                while(result.next()) {
+                    downloads.add(toFileResource(result));
+                }
+            }
+        }
+
+        return downloads;
+    }
+
+    private FileResource toFileResource(ResultSet result) throws SQLException {
+        var namespace = new Namespace();
+        namespace.setName(result.getString(COL_N_NAME));
+
+        var extension = new Extension();
+        extension.setName(result.getString(COL_E_NAME));
+        extension.setNamespace(namespace);
+
+        var extVersion = new ExtensionVersion();
+        extVersion.setId(result.getLong(COL_EV_ID));
+        extVersion.setVersion(result.getString(COL_EV_VERSION));
+        extVersion.setExtension(extension);
+
+        var resource = new FileResource();
+        resource.setId(result.getLong(COL_FR_ID));
+        resource.setName(result.getString(COL_FR_NAME));
+        resource.setType(result.getString(COL_FR_TYPE));
+        resource.setContent(result.getBytes(COL_FR_CONTENT));
+        resource.setStorageType(result.getString(COL_FR_STORAGE_TYPE));
+        resource.setExtension(extVersion);
+
+        return resource;
+    }
+
+    private List<FileResource> extractResources(List<FileResource> downloads) {
+        var storages = Map.of(
+                FileResource.STORAGE_GOOGLE, googleStorage,
+                FileResource.STORAGE_AZURE, azureStorage
+        );
+
+        var resources = new ArrayList<FileResource>();
+        for(var download : downloads) {
+            byte[] content;
+            if(download.getStorageType().equals(FileResource.STORAGE_DB)) {
+                content = download.getContent();
+            } else {
+                var storage = storages.get(download.getStorageType());
+                var uri = storage.getLocation(download);
+                content = restTemplate.getForObject(uri, byte[].class);
+            }
+
+            try(var processor = new ExtensionProcessor(new ByteArrayInputStream(content))) {
+                var processedResources = processor.getResources(download.getExtension()).stream()
+                        .filter(resource -> resource.getType().equals(FileResource.RESOURCE))
+                        .map(resource -> {
+                            resource.setStorageType(download.getStorageType());
+                            return resource;
+                        })
+                        .collect(Collectors.toList());
+
+                resources.addAll(processedResources);
+            }
+        }
+
+        return resources;
+    }
+
+    private void uploadResources(List<FileResource> resources) {
+        var storages = Map.of(
+                FileResource.STORAGE_GOOGLE, googleStorage,
+                FileResource.STORAGE_AZURE, azureStorage
+        );
+
+        for(var resource : resources) {
+            if(!resource.getStorageType().equals(FileResource.STORAGE_DB)) {
+                var storage = storages.get(resource.getStorageType());
+                storage.uploadFile(resource);
+                resource.setContent(null);
+            }
+        }
+    }
+
+    private void insertResources(List<FileResource> resources, Connection connection) throws SQLException {
+        var query = "INSERT INTO file_resource(id, type, content, extension_id, name, storage_type) VALUES(nextval('hibernate_sequence'), ?, ?, ?, ?, ?)";
+        try(var statement = connection.prepareStatement(query)) {
+            for(var resource : resources) {
+                statement.setString(1, resource.getType());
+                statement.setBytes(2, resource.getContent());
+                statement.setLong(3, resource.getExtension().getId());
+                statement.setString(4, resource.getName());
+                statement.setString(5, resource.getStorageType());
+                statement.executeUpdate();
+            }
+        }
+    }
+
+    private void deleteResources(Connection connection) throws SQLException {
+        var query = "DELETE FROM file_resource WHERE type = 'resource'";
+        try(var statement = connection.prepareStatement(query)) {
+            statement.executeUpdate();
+        }
+    }
+
+    private void deleteWebResources(Connection connection) throws SQLException {
+        var query = "DELETE FROM file_resource WHERE type = 'web-resource'";
+        try(var statement = connection.prepareStatement(query)) {
+            statement.executeUpdate();
+        }
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/dto/FileResourceDTO.java
+++ b/server/src/main/java/org/eclipse/openvsx/dto/FileResourceDTO.java
@@ -9,6 +9,8 @@
  * ****************************************************************************** */
 package org.eclipse.openvsx.dto;
 
+import org.eclipse.openvsx.entities.FileResource;
+
 import java.util.Objects;
 
 public class FileResourceDTO {
@@ -19,6 +21,14 @@ public class FileResourceDTO {
     private final long id;
     private final String name;
     private final String type;
+    private String storageType;
+    private byte[] content;
+
+    public FileResourceDTO(long id, long extensionVersionId, String name, String type, String storageType, byte[] content) {
+        this(id, extensionVersionId, name, type);
+        this.storageType = storageType;
+        this.content = content;
+    }
 
     public FileResourceDTO(long id, long extensionVersionId, String name, String type) {
         this.id = id;
@@ -53,5 +63,17 @@ public class FileResourceDTO {
 
     public String getType() {
         return type;
+    }
+
+    public String getStorageType() {
+        return storageType;
+    }
+
+    public byte[] getContent() {
+        return content;
+    }
+
+    public boolean isWebResource() {
+        return type.equals(FileResource.RESOURCE) && name.startsWith("extension/");
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/entities/FileResource.java
+++ b/server/src/main/java/org/eclipse/openvsx/entities/FileResource.java
@@ -27,7 +27,7 @@ public class FileResource {
     public static final String README = "readme";
     public static final String LICENSE = "license";
     public static final String CHANGELOG = "changelog";
-    public static final String WEB_RESOURCE = "web-resource";
+    public static final String RESOURCE = "resource";
 
     // Storage types
     public static final String STORAGE_DB = "database";
@@ -100,5 +100,4 @@ public class FileResource {
     public void setStorageType(String storageType) {
         this.storageType = storageType;
     }
-    
 }

--- a/server/src/main/java/org/eclipse/openvsx/repositories/FileResourceDTORepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/FileResourceDTORepository.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
 import java.util.Collection;
 import java.util.List;
 
-import static org.eclipse.openvsx.jooq.Tables.FILE_RESOURCE;
+import static org.eclipse.openvsx.jooq.Tables.*;
 
 @Component
 public class FileResourceDTORepository {
@@ -29,11 +29,25 @@ public class FileResourceDTORepository {
     @Autowired
     DSLContext dsl;
 
-    public List<FileResourceDTO> findAllByExtensionIdAndType(Collection<Long> extensionIds, Collection<String> types) {
+    public List<FileResourceDTO> findAll(Collection<Long> extensionIds, Collection<String> types) {
         return dsl.select(FILE_RESOURCE.ID, FILE_RESOURCE.EXTENSION_ID, FILE_RESOURCE.NAME, FILE_RESOURCE.TYPE)
                 .from(FILE_RESOURCE)
                 .where(FILE_RESOURCE.EXTENSION_ID.in(extensionIds))
                 .and(FILE_RESOURCE.TYPE.in(types))
+                .fetchInto(FileResourceDTO.class);
+    }
+
+    public List<FileResourceDTO> findAllResources(String namespaceName, String extensionName, String version, String prefix) {
+        return dsl.select(FILE_RESOURCE.ID, FILE_RESOURCE.EXTENSION_ID, FILE_RESOURCE.NAME, FILE_RESOURCE.TYPE, FILE_RESOURCE.STORAGE_TYPE, FILE_RESOURCE.CONTENT)
+                .from(FILE_RESOURCE)
+                .join(EXTENSION_VERSION).on(EXTENSION_VERSION.ID.eq(FILE_RESOURCE.EXTENSION_ID))
+                .join(EXTENSION).on(EXTENSION.ID.eq(EXTENSION_VERSION.EXTENSION_ID))
+                .join(NAMESPACE).on(NAMESPACE.ID.eq(EXTENSION.NAMESPACE_ID))
+                .where(NAMESPACE.NAME.eq(namespaceName))
+                .and(EXTENSION.NAME.eq(extensionName))
+                .and(EXTENSION_VERSION.VERSION.eq(version))
+                .and(FILE_RESOURCE.TYPE.eq(FileResource.RESOURCE))
+                .and(FILE_RESOURCE.NAME.startsWith(prefix))
                 .fetchInto(FileResourceDTO.class);
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -286,7 +286,11 @@ public class RepositoryService {
     }
 
     public List<FileResourceDTO> findAllFileResourceDTOsByExtensionVersionIdAndType(Collection<Long> extensionVersionIds, Collection<String> types) {
-        return fileResourceDTORepo.findAllByExtensionIdAndType(extensionVersionIds, types);
+        return fileResourceDTORepo.findAll(extensionVersionIds, types);
+    }
+
+    public List<FileResourceDTO> findAllResourceFileResourceDTOs(String namespaceName, String extensionName, String version, String prefix) {
+        return fileResourceDTORepo.findAllResources(namespaceName, extensionName, version, prefix);
     }
 
     public Map<Long, Integer> findAllActiveReviewCountsByExtensionId(Collection<Long> extensionIds) {

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageUtil.java
@@ -1,0 +1,38 @@
+/** ******************************************************************************
+ * Copyright (c) 2022 Precies. Software and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+
+package org.eclipse.openvsx.storage;
+
+import org.springframework.http.CacheControl;
+import org.springframework.http.MediaType;
+
+import java.net.URLConnection;
+import java.util.concurrent.TimeUnit;
+
+class StorageUtil {
+
+    private StorageUtil(){}
+
+    static MediaType getFileType(String fileName) {
+        if (fileName.endsWith(".vsix"))
+            return MediaType.APPLICATION_OCTET_STREAM;
+        if (fileName.endsWith(".json"))
+            return MediaType.APPLICATION_JSON;
+        var contentType = URLConnection.guessContentTypeFromName(fileName);
+        if (contentType != null)
+            return MediaType.parseMediaType(contentType);
+        return MediaType.TEXT_PLAIN;
+    }
+
+    static CacheControl getCacheControl(String fileName) {
+        // Files are requested with a version string in the URL, so their content cannot change
+        return CacheControl.maxAge(30, TimeUnit.DAYS).cachePublic();
+    }
+}

--- a/server/src/test/resources/org/eclipse/openvsx/adapter/findid-yaml-response-alpine.json
+++ b/server/src/test/resources/org/eclipse/openvsx/adapter/findid-yaml-response-alpine.json
@@ -6,7 +6,7 @@
                     "publisher": {
                         "publisherId": "test-2",
                         "publisherName": "redhat",
-                        "displayName": null
+                        "displayName": "redhat"
                     },
                     "extensionId": "test-1",
                     "extensionName": "vscode-yaml",
@@ -42,6 +42,14 @@
                                 {
                                     "assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
                                     "source": "http://localhost/api/redhat/vscode-yaml/alpine-arm64/0.5.2/file/CHANGELOG.md"
+                                },
+                                {
+                                    "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/themes/dark.json",
+                                    "source":"http://localhost/api/redhat/vscode-yaml/alpine-arm64/0.5.2/file/extension/themes/dark.json"
+                                },
+                                {
+                                    "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/img/logo.png",
+                                    "source":"http://localhost/api/redhat/vscode-yaml/alpine-arm64/0.5.2/file/extension/img/logo.png"
                                 }
                             ],
                             "properties": [

--- a/server/src/test/resources/org/eclipse/openvsx/adapter/findid-yaml-response.json
+++ b/server/src/test/resources/org/eclipse/openvsx/adapter/findid-yaml-response.json
@@ -6,7 +6,7 @@
                     "publisher": {
                         "publisherId": "test-2",
                         "publisherName": "redhat",
-                        "displayName": null
+                        "displayName": "redhat"
                     },
                     "extensionId": "test-1",
                     "extensionName": "vscode-yaml",
@@ -41,6 +41,14 @@
                                 {
                                     "assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
                                     "source": "http://localhost/api/redhat/vscode-yaml/0.5.2/file/CHANGELOG.md"
+                                },
+                                {
+                                    "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/themes/dark.json",
+                                    "source":"http://localhost/api/redhat/vscode-yaml/0.5.2/file/extension/themes/dark.json"
+                                },
+                                {
+                                    "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/img/logo.png",
+                                    "source":"http://localhost/api/redhat/vscode-yaml/0.5.2/file/extension/img/logo.png"
                                 }
                             ],
                             "properties": [

--- a/server/src/test/resources/org/eclipse/openvsx/adapter/findname-yaml-response-linux.json
+++ b/server/src/test/resources/org/eclipse/openvsx/adapter/findname-yaml-response-linux.json
@@ -6,7 +6,7 @@
                     "publisher": {
                         "publisherId": "test-2",
                         "publisherName": "redhat",
-                        "displayName": null
+                        "displayName": "redhat"
                     },
                     "extensionId": "test-1",
                     "extensionName": "vscode-yaml",
@@ -42,6 +42,14 @@
                                 {
                                     "assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
                                     "source": "http://localhost/api/redhat/vscode-yaml/linux-x64/0.5.2/file/CHANGELOG.md"
+                                },
+                                {
+                                    "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/themes/dark.json",
+                                    "source":"http://localhost/api/redhat/vscode-yaml/linux-x64/0.5.2/file/extension/themes/dark.json"
+                                },
+                                {
+                                    "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/img/logo.png",
+                                    "source":"http://localhost/api/redhat/vscode-yaml/linux-x64/0.5.2/file/extension/img/logo.png"
                                 }
                             ],
                             "properties": [

--- a/server/src/test/resources/org/eclipse/openvsx/adapter/findname-yaml-response.json
+++ b/server/src/test/resources/org/eclipse/openvsx/adapter/findname-yaml-response.json
@@ -6,7 +6,7 @@
                     "publisher": {
                         "publisherId": "test-2",
                         "publisherName": "redhat",
-                        "displayName": null
+                        "displayName": "redhat"
                     },
                     "extensionId": "test-1",
                     "extensionName": "vscode-yaml",
@@ -41,6 +41,14 @@
                                 {
                                     "assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
                                     "source": "http://localhost/api/redhat/vscode-yaml/0.5.2/file/CHANGELOG.md"
+                                },
+                                {
+                                    "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/themes/dark.json",
+                                    "source":"http://localhost/api/redhat/vscode-yaml/0.5.2/file/extension/themes/dark.json"
+                                },
+                                {
+                                    "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/img/logo.png",
+                                    "source":"http://localhost/api/redhat/vscode-yaml/0.5.2/file/extension/img/logo.png"
                                 }
                             ],
                             "properties": [

--- a/server/src/test/resources/org/eclipse/openvsx/adapter/search-yaml-response-darwin.json
+++ b/server/src/test/resources/org/eclipse/openvsx/adapter/search-yaml-response-darwin.json
@@ -6,7 +6,7 @@
                     "publisher": {
                         "publisherId": "test-2",
                         "publisherName": "redhat",
-                        "displayName": null
+                        "displayName": "redhat"
                     },
                     "extensionId": "test-1",
                     "extensionName": "vscode-yaml",
@@ -42,6 +42,14 @@
                                 {
                                     "assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
                                     "source": "http://localhost/api/redhat/vscode-yaml/darwin-x64/0.5.2/file/CHANGELOG.md"
+                                },
+                                {
+                                    "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/themes/dark.json",
+                                    "source":"http://localhost/api/redhat/vscode-yaml/darwin-x64/0.5.2/file/extension/themes/dark.json"
+                                },
+                                {
+                                    "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/img/logo.png",
+                                    "source":"http://localhost/api/redhat/vscode-yaml/darwin-x64/0.5.2/file/extension/img/logo.png"
                                 }
                             ],
                             "properties": [

--- a/server/src/test/resources/org/eclipse/openvsx/adapter/search-yaml-response-targets.json
+++ b/server/src/test/resources/org/eclipse/openvsx/adapter/search-yaml-response-targets.json
@@ -6,7 +6,7 @@
           "publisher": {
             "publisherId": "test-2",
             "publisherName": "redhat",
-            "displayName": null
+            "displayName": "redhat"
           },
           "extensionId": "test-1",
           "extensionName": "vscode-yaml",
@@ -42,6 +42,14 @@
                 {
                   "assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
                   "source": "http://localhost/api/redhat/vscode-yaml/darwin-x64/0.5.2/file/CHANGELOG.md"
+                },
+                {
+                  "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/themes/dark.json",
+                  "source":"http://localhost/api/redhat/vscode-yaml/darwin-x64/0.5.2/file/extension/themes/dark.json"
+                },
+                {
+                  "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/img/logo.png",
+                  "source":"http://localhost/api/redhat/vscode-yaml/darwin-x64/0.5.2/file/extension/img/logo.png"
                 }
               ],
               "properties": [
@@ -97,6 +105,14 @@
                 {
                   "assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
                   "source": "http://localhost/api/redhat/vscode-yaml/linux-x64/0.5.2/file/CHANGELOG.md"
+                },
+                {
+                  "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/themes/dark.json",
+                  "source":"http://localhost/api/redhat/vscode-yaml/linux-x64/0.5.2/file/extension/themes/dark.json"
+                },
+                {
+                  "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/img/logo.png",
+                  "source":"http://localhost/api/redhat/vscode-yaml/linux-x64/0.5.2/file/extension/img/logo.png"
                 }
               ],
               "properties": [
@@ -152,6 +168,14 @@
                 {
                   "assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
                   "source": "http://localhost/api/redhat/vscode-yaml/alpine-arm64/0.5.2/file/CHANGELOG.md"
+                },
+                {
+                  "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/themes/dark.json",
+                  "source":"http://localhost/api/redhat/vscode-yaml/alpine-arm64/0.5.2/file/extension/themes/dark.json"
+                },
+                {
+                  "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/img/logo.png",
+                  "source":"http://localhost/api/redhat/vscode-yaml/alpine-arm64/0.5.2/file/extension/img/logo.png"
                 }
               ],
               "properties": [

--- a/server/src/test/resources/org/eclipse/openvsx/adapter/search-yaml-response.json
+++ b/server/src/test/resources/org/eclipse/openvsx/adapter/search-yaml-response.json
@@ -6,7 +6,7 @@
                     "publisher": {
                         "publisherId": "test-2",
                         "publisherName": "redhat",
-                        "displayName": null
+                        "displayName": "redhat"
                     },
                     "extensionId": "test-1",
                     "extensionName": "vscode-yaml",
@@ -41,6 +41,14 @@
                                 {
                                     "assetType": "Microsoft.VisualStudio.Services.Content.Changelog",
                                     "source": "http://localhost/api/redhat/vscode-yaml/0.5.2/file/CHANGELOG.md"
+                                },
+                                {
+                                    "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/themes/dark.json",
+                                    "source":"http://localhost/api/redhat/vscode-yaml/0.5.2/file/extension/themes/dark.json"
+                                },
+                                {
+                                    "assetType":"Microsoft.VisualStudio.Code.WebResources/extension/img/logo.png",
+                                    "source":"http://localhost/api/redhat/vscode-yaml/0.5.2/file/extension/img/logo.png"
                                 }
                             ],
                             "properties": [


### PR DESCRIPTION
Fixes #432 

Added publisher displayName
Added `/vscode/unpkg` endpoint to VSCodeAdapter
Removed WEB_RESOURCE, instead use RESOURCE
FileResource java migration
Updated `/vscode/extensionquery` tests to include web resources
Added `/vscode/asset` tests for web resources

### Testing steps
#### Display name and 404 status
- Update VS Code product.json:
```
"extensionsGallery": {
    "serviceUrl": "http://localhost:8080/vscode/gallery",
    "itemUrl": "http://localhost:8080/vscode/item",
    "resourceUrlTemplate": "http://localhost:8080/vscode/unpkg/{publisher}/{name}/{version}/{path}"
},
```
- Restart VS Code if it is running, to apply the changes to product.json
- Publish a couple extensions where the package.json returned 404:
  - `viper-admin.viper 2.4.0`
  - `huacat.office-theme 1.1.3`
  - `PKief.material-product-icons 1.1.2`
- Open developer tools in VS Code (`Help > Toggle Developer Tools`)
- Browse color themes in VS Code by navigating to `Manage > Color Themes > + Browse Additional Color Themes...`
- The color theme quick pick list should now display the publisher name as the last part of each item, e.g. ` ∙ viper-admin` (instead of ` ∙ null`)
- The developer tools should **not** contain 404 statuses for package.json files.
#### 500 status
- Publish `abelfubu.abelfubu-dark 1.3.4`
- Open developer tools in VS Code (`Help > Toggle Developer Tools`)
- Try to get `abelFubu Dark+-color-theme.json` resource
- The developer tools should **not** contain a 500 status for http://localhost:8080/vscode/asset/abelfubu/abelfubu-dark/1.3.4/Microsoft.VisualStudio.Code.WebResources/extension/themes/abelFubu%20Dark+-color-theme.json.

