### PR TITLE
Add upstream for VSCodeAPI endpoints

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/adapter/IVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/IVSCodeService.java
@@ -1,0 +1,26 @@
+/** ******************************************************************************
+ * Copyright (c) 2022 Precies. Software and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.adapter;
+
+import org.springframework.http.ResponseEntity;
+
+public interface IVSCodeService {
+
+    ExtensionQueryResult extensionQuery(ExtensionQueryParam param, int defaultPageSize);
+
+    ResponseEntity<byte[]> browse(String namespaceName, String extensionName, String version, String path);
+
+    String download(String namespace, String extension, String version, String targetPlatform);
+
+    String getItemUrl(String namespace, String extension);
+
+    ResponseEntity<byte[]> getAsset(String namespace, String extensionName, String version, String assetType,
+                                    String targetPlatform, String restOfTheUrl);
+}

--- a/server/src/main/java/org/eclipse/openvsx/adapter/UpstreamVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/UpstreamVSCodeService.java
@@ -1,0 +1,137 @@
+/** ******************************************************************************
+ * Copyright (c) 2022 Precies. Software and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.adapter;
+
+import com.google.common.base.Strings;
+import org.eclipse.openvsx.util.NotFoundException;
+import org.eclipse.openvsx.util.UrlUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+@Component
+public class UpstreamVSCodeService implements IVSCodeService {
+
+    protected final Logger logger = LoggerFactory.getLogger(UpstreamVSCodeService.class);
+
+    @Autowired
+    RestTemplate restTemplate;
+
+    @Value("${ovsx.upstream.url:}")
+    String upstreamUrl;
+
+    public boolean isValid() {
+        return !Strings.isNullOrEmpty(upstreamUrl);
+    }
+
+    @Override
+    public ExtensionQueryResult extensionQuery(ExtensionQueryParam param, int defaultPageSize) {
+        var apiUrl = UrlUtil.createApiUrl(upstreamUrl, "vscode", "gallery", "extensionquery");
+        var request = new RequestEntity<>(param, HttpMethod.POST, URI.create(apiUrl));
+        var response = restTemplate.exchange(request, ExtensionQueryResult.class);
+        var statusCode = response.getStatusCode();
+        if(statusCode.is2xxSuccessful()) {
+            return response.getBody();
+        }
+        if(statusCode.isError() && statusCode != HttpStatus.NOT_FOUND) {
+            logger.error("POST {}: {}", apiUrl, response);
+        }
+
+        throw new NotFoundException();
+    }
+
+    @Override
+    public ResponseEntity<byte[]> browse(String namespaceName, String extensionName, String version, String path) {
+        var segments = new String[]{ "vscode", "unpkg", namespaceName, extensionName, version, path };
+        var apiUrl = UrlUtil.createApiUrl(upstreamUrl, segments);
+        var request = new RequestEntity<Void>(HttpMethod.GET, URI.create(apiUrl));
+        var response = restTemplate.exchange(request, byte[].class);
+        var statusCode = response.getStatusCode();
+        if(statusCode.is2xxSuccessful() || statusCode.is3xxRedirection()) {
+            return response;
+        }
+        if(statusCode.isError() && statusCode != HttpStatus.NOT_FOUND) {
+            logger.error("GET {}: {}", apiUrl, response);
+        }
+
+        throw new NotFoundException();
+    }
+
+    @Override
+    public String download(String namespace, String extension, String version, String targetPlatform) {
+        var segments = new String[]{ "vscode", "gallery", "publishers", namespace, "vsextensions", extension, version, "vspackage" };
+        var apiUrl = UrlUtil.createApiUrl(upstreamUrl, segments);
+        var request = new RequestEntity<Void>(HttpMethod.GET, URI.create(apiUrl));
+        var response = nonRedirectingRestTemplate().exchange(request, Void.class);
+        var statusCode = response.getStatusCode();
+        if(statusCode.is3xxRedirection()) {
+            return response.getHeaders().getLocation().toString();
+        }
+        if(statusCode.isError() && statusCode != HttpStatus.NOT_FOUND) {
+            logger.error("GET {}: {}", apiUrl, response);
+        }
+
+        throw new NotFoundException();
+    }
+
+    @Override
+    public String getItemUrl(String namespace, String extension) {
+        var apiUrl = UrlUtil.createApiUrl(upstreamUrl, "vscode", "item");
+        apiUrl = UrlUtil.addQuery(apiUrl, "itemName", String.join(".", namespace, extension));
+        var request = new RequestEntity<Void>(HttpMethod.GET, URI.create(apiUrl));
+        var response = nonRedirectingRestTemplate().exchange(request, Void.class);
+        var statusCode = response.getStatusCode();
+        if(statusCode.is3xxRedirection()) {
+            return response.getHeaders().getLocation().toString();
+        }
+        if(statusCode.isError() && statusCode != HttpStatus.NOT_FOUND) {
+            logger.error("GET {}: {}", apiUrl, response);
+        }
+
+        throw new NotFoundException();
+    }
+
+    @Override
+    public ResponseEntity<byte[]> getAsset(String namespace, String extensionName, String version, String assetType, String targetPlatform, String restOfTheUrl) {
+        var segments = new String[]{ "vscode", "asset", namespace, extensionName, version, assetType, restOfTheUrl };
+        var apiUrl = UrlUtil.createApiUrl(upstreamUrl, segments);
+        var request = new RequestEntity<Void>(HttpMethod.GET, URI.create(apiUrl));
+        var response = restTemplate.exchange(request, byte[].class);
+        var statusCode = response.getStatusCode();
+        if(statusCode.is2xxSuccessful() || statusCode.is3xxRedirection()) {
+            return response;
+        }
+        if(statusCode.isError() && statusCode != HttpStatus.NOT_FOUND) {
+            logger.error("GET {}: {}", apiUrl, response);
+        }
+
+        throw new NotFoundException();
+    }
+
+    private RestTemplate nonRedirectingRestTemplate() {
+        return new RestTemplate(new SimpleClientHttpRequestFactory() {
+            @Override
+            protected void prepareConnection(HttpURLConnection connection, String httpMethod ) {
+                connection.setInstanceFollowRedirects(false);
+            }
+        });
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
@@ -1,0 +1,212 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.adapter;
+
+import org.eclipse.openvsx.util.NotFoundException;
+import org.eclipse.openvsx.util.TargetPlatform;
+import org.eclipse.openvsx.util.UrlUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@RestController
+public class VSCodeAPI {
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+
+    @Autowired
+    LocalVSCodeService local;
+
+    @Autowired
+    UpstreamVSCodeService upstream;
+
+    private Iterable<IVSCodeService> getVSCodeServices() {
+        var registries = new ArrayList<IVSCodeService>();
+        registries.add(local);
+        if (upstream.isValid())
+            registries.add(upstream);
+        return registries;
+    }
+
+    @PostMapping(
+        path = "/vscode/gallery/extensionquery",
+        consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @CrossOrigin
+    public ExtensionQueryResult extensionQuery(@RequestBody ExtensionQueryParam param) {
+        var size = 0;
+        if(param.filters != null && !param.filters.isEmpty()) {
+            size = param.filters.get(0).pageSize;
+        }
+        if(size <= 0) {
+            size = DEFAULT_PAGE_SIZE;
+        }
+
+        var totalCount = 0L;
+        var resultItem = new ExtensionQueryResult.ResultItem();
+        resultItem.extensions = new ArrayList<>(size);
+
+        var services = getVSCodeServices().iterator();
+        while(resultItem.extensions.size() < size && services.hasNext()) {
+            try {
+                var service = services.next();
+                var subResult = service.extensionQuery(param, DEFAULT_PAGE_SIZE);
+                var subExtensions = subResult.results.get(0).extensions;
+                if (subExtensions != null && subExtensions.size() > 0) {
+                    int limit = size - resultItem.extensions.size();
+                    mergeExtensionQueryResults(resultItem, subExtensions, limit);
+                }
+
+                totalCount += getTotalCount(subResult);
+            } catch (NotFoundException | ResponseStatusException exc) {
+                // Try the next registry
+            }
+        }
+
+        return toExtensionQueryResult(resultItem, totalCount);
+    }
+
+    private void mergeExtensionQueryResults(ExtensionQueryResult.ResultItem resultItem, List<ExtensionQueryResult.Extension> extensions, int limit) {
+        var previous = new ArrayList<>(resultItem.extensions);
+        var extensionsIter = extensions.iterator();
+        while (extensionsIter.hasNext() && resultItem.extensions.size() < limit) {
+            var next = extensionsIter.next();
+            var noneMatch = previous.stream()
+                    .noneMatch(prev -> {
+                        var prevPublisher = prev.publisher.publisherName;
+                        var nextPublisher = next.publisher.publisherName;
+                        return prevPublisher.equals(nextPublisher) && prev.extensionName.equals(next.extensionName);
+                    });
+
+            if (noneMatch) {
+                resultItem.extensions.add(next);
+            }
+        }
+    }
+
+    private long getTotalCount(ExtensionQueryResult subResult) {
+        return subResult.results.get(0).resultMetadata.stream()
+                .filter(metadata -> metadata.metadataType.equals("ResultCount"))
+                .findFirst()
+                .map(metadata -> metadata.metadataItems)
+                .orElseGet(Collections::emptyList)
+                .stream()
+                .filter(item -> item.name.equals("TotalCount"))
+                .findFirst()
+                .map(item -> item.count)
+                .orElse(0L);
+    }
+
+    private ExtensionQueryResult toExtensionQueryResult(ExtensionQueryResult.ResultItem resultItem, long totalCount) {
+        var countMetadataItem = new ExtensionQueryResult.ResultMetadataItem();
+        countMetadataItem.name = "TotalCount";
+        countMetadataItem.count = totalCount;
+
+        var countMetadata = new ExtensionQueryResult.ResultMetadata();
+        countMetadata.metadataType = "ResultCount";
+        countMetadata.metadataItems = List.of(countMetadataItem);
+
+        resultItem.resultMetadata = List.of(countMetadata);
+
+        var result = new ExtensionQueryResult();
+        result.results = List.of(resultItem);
+        return result;
+    }
+
+    @GetMapping("/vscode/asset/{namespace}/{extensionName}/{version}/{assetType}/**")
+    @CrossOrigin
+    public ResponseEntity<byte[]> getAsset(
+            HttpServletRequest request, @PathVariable String namespace, @PathVariable String extensionName,
+            @PathVariable String version, @PathVariable String assetType,
+            @RequestParam(defaultValue = TargetPlatform.NAME_UNIVERSAL) String targetPlatform
+    ) {
+        var restOfTheUrl = UrlUtil.extractWildcardPath(request);
+        for (var service : getVSCodeServices()) {
+            try {
+                return service.getAsset(namespace, extensionName, version, assetType, targetPlatform, restOfTheUrl);
+            } catch (NotFoundException exc) {
+                // Try the next registry
+            }
+        }
+
+        return ResponseEntity.notFound().build();
+    }
+
+    @GetMapping("/vscode/item")
+    @CrossOrigin
+    public ModelAndView getItemUrl(@RequestParam String itemName, ModelMap model) {
+        var dotIndex = itemName.indexOf('.');
+        if (dotIndex < 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Expecting an item of the form `{publisher}.{name}`");
+        }
+
+        var namespace = itemName.substring(0, dotIndex);
+        var extension = itemName.substring(dotIndex + 1);
+        for (var service : getVSCodeServices()) {
+            try {
+                var itemUrl = service.getItemUrl(namespace, extension);
+                return new ModelAndView("redirect:" + itemUrl, model);
+            } catch (NotFoundException exc) {
+                // Try the next registry
+            }
+        }
+
+        return new ModelAndView(null, HttpStatus.NOT_FOUND);
+    }
+
+    @GetMapping("/vscode/gallery/publishers/{namespace}/vsextensions/{extension}/{version}/vspackage")
+    @CrossOrigin
+    public ModelAndView download(
+            @PathVariable String namespace, @PathVariable String extension, @PathVariable String version,
+            @RequestParam(defaultValue = TargetPlatform.NAME_UNIVERSAL) String targetPlatform, ModelMap model
+    ) {
+        for (var service : getVSCodeServices()) {
+            try {
+                var downloadUrl = service.download(namespace, extension, version, targetPlatform);
+                return new ModelAndView("redirect:" + downloadUrl, model);
+            } catch (NotFoundException exc) {
+                // Try the next registry
+            }
+        }
+
+        return new ModelAndView(null, HttpStatus.NOT_FOUND);
+    }
+
+    @GetMapping("/vscode/unpkg/{namespaceName}/{extensionName}/{version}/**")
+    @CrossOrigin
+    public ResponseEntity<byte[]> browse(
+            HttpServletRequest request,
+            @PathVariable String namespaceName,
+            @PathVariable String extensionName,
+            @PathVariable String version
+    ) {
+        var path = UrlUtil.extractWildcardPath(request);
+        for (var service : getVSCodeServices()) {
+            try {
+                return service.browse(namespaceName, extensionName, version, path);
+            } catch (NotFoundException exc) {
+                // Try the next registry
+            }
+        }
+
+        return ResponseEntity.notFound().build();
+    }
+}

--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -178,12 +178,16 @@ class ExtensionDetailOverviewComponent extends React.Component<ExtensionDetailOv
                             : null
                         }
                     </Box>
-                    <Box className={classes.resourcesGroup}>
-                        <Box>
-                            <Typography variant='h6'>Works With</Typography>
-                            {this.renderWorksWithList(extension.downloads)}
+                    {
+                        extension.downloads ?
+                        <Box className={classes.resourcesGroup}>
+                            <Box>
+                                <Typography variant='h6'>Works With</Typography>
+                                {this.renderWorksWithList(extension.downloads)}
+                            </Box>
                         </Box>
-                    </Box>
+                        : null
+                    }
                     <Box className={classes.resourcesGroup}>
                         <Box>
                             <Typography variant='h6'>Resources</Typography>
@@ -192,11 +196,11 @@ class ExtensionDetailOverviewComponent extends React.Component<ExtensionDetailOv
                             {this.renderResourceLink('Bugs', extension.bugs)}
                             {this.renderResourceLink('Q\'n\'A', extension.qna)}
                             {
-                                Object.keys(extension.downloads).length > 1 ?
+                                extension.downloads && Object.keys(extension.downloads).length > 1 ?
                                 <ExtensionDetailDownloadsMenu downloads={extension.downloads}/>
-                                : Object.keys(extension.downloads).length == 1 ?
+                                : extension.downloads && Object.keys(extension.downloads).length == 1 ?
                                 <Button variant='contained' color='secondary'
-                                    href={extension.files.download}
+                                    href={extension.downloads[Object.keys(extension.downloads)[0]]}
                                     className={classes.downloadButton}>
                                     Download
                                 </Button>


### PR DESCRIPTION
Fixes #417 

### Testing Steps

#### Setup
- Open this branch in Gitpod.
- Wait until the publisher process has published all test extensions.
- Stop the  server.
- Configure ovsx.upstream.url in dev/application.properties.
- Run the server: `./gradlew runServer`.
- Publish an extension that the upstream server also has.
- Publish an extension that the upstream server doesn't have.

#### All Endpoints
Endpoints:
- `POST /vscode/gallery/extensionquery`
- `GET /vscode/asset/{namespace}/{extensionName}/{version}/{assetType}/**`
- `GET /vscode/item?itemName={itemName}`
- `GET /vscode/gallery/publishers/{namespace}/vsextensions/{extension}/{version}/vspackage`
- `GET /vscode/unpkg/{namespaceName}/{extensionName}/{version}/**`

Steps:
- Get a local item.
- Get an upstream item.
- Get a non-existent item.

#### /extensionquery
- Test result merging by querying for an extension that both local and upstream have.
  Make sure to use a page size greater than the expected result size, so that merging actually takes place.