### PR TITLE
Empty response for existing (old) plugin version

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -287,7 +287,7 @@ public class LocalRegistryService implements IExtensionRegistry {
             extensionVersions = extensionVersions.stream()
                     .filter(ev -> ev.getVersion().equals(param.extensionVersion))
                     .filter(ev -> ev.getExtension().getName().equals(param.extensionName))
-                    .filter(ev -> ev.getExtension().getNamespace().equals(param.namespaceName))
+                    .filter(ev -> ev.getExtension().getNamespace().getName().equals(param.namespaceName))
                     .collect(Collectors.toList());
         }
         // Only add latest version of an extension

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -586,6 +586,21 @@ public class RegistryAPITest {
     }
 
     @Test
+    public void testGetQueryExtensionVersion() throws Exception {
+        mockExtensionVersionDTO();
+        mockMvc.perform(get("/api/-/query?extensionId={id}&extensionVersion={version}", "foo.bar", "1.0.0"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(queryResultJson(e -> {
+                    e.namespace = "foo";
+                    e.name = "bar";
+                    e.version = "1.0.0";
+                    e.verified = false;
+                    e.timestamp = "2000-01-01T10:00Z";
+                    e.displayName = "Foo Bar";
+                })));
+    }
+
+    @Test
     public void testGetQueryExtensionUuid() throws Exception {
         mockExtensionVersionDTO();
         mockMvc.perform(get("/api/-/query?extensionUuid={extensionUuid}", "5678"))


### PR DESCRIPTION
Fixes #431

Added RegistryAPITest.testGetQueryExtensionVersion to replicate the issue.

### Manual testing steps
- Download https://open-vsx.org/api/ms-python/python/2022.0.1814523869/file/ms-python.python-2022.0.1814523869.vsix.
- Download https://open-vsx.org/api/ms-python/python/2020.8.105369/file/ms-python.python-2020.8.105369.vsix.
- Create namespace `ms-python`.
- Publish the two downloaded extensions.
- Execute query: `curl --location --request GET 'http://localhost:8080/api/-/query?extensionId=ms-python.python&extensionVersion=2020.8.105369'`
- Expected result: a response containing `ms-python.python` version `2020.8.105369`. 