### PR TITLE
[Admin] Add Ability to Change Namespace

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/AdminAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/AdminAPI.java
@@ -273,6 +273,21 @@ public class AdminAPI {
         }
     }
 
+    @PostMapping(
+            path = "/admin/change-namespace",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<ResultJson> changeNamespace(@RequestBody ChangeNamespaceJson json) {
+        try {
+            admins.checkAdminUser();
+            admins.changeNamespace(json);
+            return ResponseEntity.ok(ResultJson.success("Changed namespace " + json.oldNamespace + " to " + json.newNamespace));
+        } catch (ErrorResultException exc) {
+            return exc.toResponseEntity();
+        }
+    }
+
     @GetMapping(
         path = "/admin/namespace/{namespaceName}/members",
         produces = MediaType.APPLICATION_JSON_VALUE

--- a/server/src/main/java/org/eclipse/openvsx/json/ChangeNamespaceJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/ChangeNamespaceJson.java
@@ -1,0 +1,23 @@
+/** ******************************************************************************
+ * Copyright (c) 2022 Precies. Software and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.json;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Used to change a namespace
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ChangeNamespaceJson {
+    public String oldNamespace;
+    public String newNamespace;
+    public boolean removeOldNamespace;
+    public boolean mergeIfNewNamespaceAlreadyExists;
+}

--- a/webui/src/extension-registry-service.ts
+++ b/webui/src/extension-registry-service.ts
@@ -441,6 +441,24 @@ export class AdminService {
         });
     }
 
+    async changeNamespace(abortController: AbortController, req: {oldNamespace: string, newNamespace: string, removeOldNamespace: boolean, mergeIfNewNamespaceAlreadyExists: boolean}): Promise<Readonly<SuccessResult | ErrorResult>> {
+        const csrfToken = await this.registry.getCsrfToken(abortController);
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json;charset=UTF-8'
+        };
+        if (!isError(csrfToken)) {
+            headers[csrfToken.header] = csrfToken.value;
+        }
+        return sendRequest({
+            abortController,
+            credentials: true,
+            endpoint: createAbsoluteURL([this.registry.serverUrl, 'admin', 'change-namespace']),
+            method: 'POST',
+            payload: req,
+            headers
+        });
+    }
+
     async getPublisherInfo(abortController: AbortController, provider: string, login: string): Promise<Readonly<PublisherInfo>> {
         return sendRequest({
             abortController,

--- a/webui/src/pages/admin-dashboard/namespace-admin.tsx
+++ b/webui/src/pages/admin-dashboard/namespace-admin.tsx
@@ -89,6 +89,7 @@ export const NamespaceAdmin: FunctionComponent = props => {
                             setLoadingState={setLoading}
                             namespace={currentNamespace}
                             filterUsers={() => true}
+                            onNamespaceChange={fetchNamespace}
                             fixSelf={false}
                         />
                     </NamespaceDetailConfigContext.Provider>

--- a/webui/src/pages/admin-dashboard/namespace-change-dialog.tsx
+++ b/webui/src/pages/admin-dashboard/namespace-change-dialog.tsx
@@ -1,0 +1,120 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+ import React, { FunctionComponent, useState, useContext, useEffect } from 'react';
+ import {
+     Button, Checkbox, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, FormControlLabel, TextField
+ } from '@material-ui/core';
+ import { ButtonWithProgress } from '../../components/button-with-progress';
+ import { Namespace, isError } from '../../extension-registry-types';
+ import { MainContext } from '../../context';
+
+ export interface NamespaceChangeDialogProps {
+     open: boolean;
+     onClose: (newNamespaceName?: string) => void;
+     namespace: Namespace;
+     setLoadingState: (loading: boolean) => void;
+ }
+
+ export const NamespaceChangeDialog: FunctionComponent<NamespaceChangeDialogProps> = props => {
+     const { open } = props;
+     const { service, handleError } = useContext(MainContext);
+     const [working, setWorking] = useState(false);
+     const [newNamespace, setNewNamespace] = useState('');
+     const [removeOldNamespace, setRemoveOldNamespace] = useState(false);
+     const [mergeIfNewNamespaceAlreadyExists, setMergeIfNewNamespaceAlreadyExists] = useState(false);
+
+     const abortController = new AbortController();
+     useEffect(() => {
+         return () => {
+             abortController.abort();
+         };
+     }, []);
+
+    useEffect(() => {
+        if (open) {
+            setNewNamespace('');
+            setRemoveOldNamespace(true);
+            setMergeIfNewNamespaceAlreadyExists(false);
+        }
+    }, [open]);
+
+    const onClose = () => {
+        props.onClose();
+    };
+    const onRemoveOldNamespaceChange = (event: React.ChangeEvent, checked: boolean) => {
+        setRemoveOldNamespace(checked);
+    };
+    const onMergeIfNewNamespaceAlreadyExistsChange = (event: React.ChangeEvent, checked: boolean) => {
+        setMergeIfNewNamespaceAlreadyExists(checked);
+    };
+    const handleChangeNamespace = async () => {
+        try {
+            if (!props.namespace) {
+                return;
+            }
+            setWorking(true);
+            props.setLoadingState(true);
+            const oldNamespace = props.namespace.name;
+            const result = await service.admin.changeNamespace(abortController, { oldNamespace, newNamespace, removeOldNamespace, mergeIfNewNamespaceAlreadyExists });
+            if (isError(result)) {
+                throw result;
+            }
+            props.setLoadingState(false);
+            setWorking(false);
+            props.onClose(newNamespace);
+        } catch (err) {
+            props.setLoadingState(false);
+            setWorking(false);
+            handleError(err);
+        }
+    };
+
+     return <>
+        <Dialog onClose={onClose} open={open} aria-labelledby='form-dialog-title'>
+            <DialogTitle id='form-dialog-title'>Change Namespace</DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+                     Enter the new Namespace name.
+                </DialogContentText>
+                <TextField
+                    autoFocus
+                    margin='dense'
+                    id='name'
+                    autoComplete='off'
+                    label='New Open VSX Namespace'
+                    fullWidth
+                    onChange={(event) => {
+                        setNewNamespace(event.target.value);
+                    }}
+                />
+                <FormControlLabel
+                    control={<Checkbox checked={removeOldNamespace} onChange={onRemoveOldNamespaceChange} name='remove-old-namespace' />}
+                    label={`Remove '${props.namespace.name}' namespace after namespace change`} />
+                <FormControlLabel
+                    control={<Checkbox checked={mergeIfNewNamespaceAlreadyExists} onChange={onMergeIfNewNamespaceAlreadyExistsChange} name='merge-change-namespace' />}
+                    label='Merge namespaces if new namespace already exists' />
+             </DialogContent>
+             <DialogActions>
+                 <Button
+                    variant='contained'
+                    color='primary'
+                    onClick={onClose} >
+                    Cancel
+                </Button>
+                <ButtonWithProgress
+                    working={working}
+                    onClick={handleChangeNamespace} >
+                    Change Namespace
+                </ButtonWithProgress>
+             </DialogActions>
+         </Dialog>
+     </>;
+ };

--- a/webui/src/pages/user/user-namespace-member-list.tsx
+++ b/webui/src/pages/user/user-namespace-member-list.tsx
@@ -88,7 +88,7 @@ export const UserNamespaceMemberList: FunctionComponent<UserNamespaceMemberList.
     }
     return <>
         <Box className={classes.memberListHeader}>
-            <Typography variant='h5'>Members in {props.namespace.name}</Typography>
+            <Typography variant='h5'>Members</Typography>
             <Button className={classes.addButton} variant='outlined' onClick={handleOpenAddDialog}>
                 Add Namespace Member
             </Button>

--- a/webui/src/pages/user/user-settings-namespace-detail.tsx
+++ b/webui/src/pages/user/user-settings-namespace-detail.tsx
@@ -8,11 +8,14 @@
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
 
-import React, { FunctionComponent } from 'react';
-import { makeStyles, Grid, Link, Paper, Box } from '@material-ui/core';
+import React, { useState, FunctionComponent } from 'react';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { makeStyles, Box, Button, Link, Paper, Grid, Typography } from '@material-ui/core';
 import WarningIcon from '@material-ui/icons/Warning';
 import { UserNamespaceExtensionListContainer } from './user-namespace-extension-list';
+import { AdminDashboardRoutes } from '../admin-dashboard/admin-dashboard';
 import { Namespace, UserData } from '../../extension-registry-types';
+import { NamespaceChangeDialog } from '../admin-dashboard/namespace-change-dialog';
 import { UserNamespaceMemberList } from './user-namespace-member-list';
 import { UserNamespaceDetails } from './user-namespace-details';
 
@@ -62,11 +65,37 @@ const useStyles = makeStyles((theme) => ({
             color: '#fff',
             textDecoration: 'underline'
         }
+    },
+    changeButton: {
+        [theme.breakpoints.down('md')]: {
+            marginLeft: theme.spacing(2)
+        }
+    },
+    namespaceHeader: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: theme.spacing(1),
+        [theme.breakpoints.down('sm')]: {
+            flexDirection: 'column',
+            alignItems: 'center'
+        }
     }
 }));
 
-export const NamespaceDetail: FunctionComponent<NamespaceDetail.Props> = props => {
+export const NamespaceDetailComponent: FunctionComponent<NamespaceDetailComponent.Props> = props => {
     const classes = useStyles();
+    const [changeDialogIsOpen, setChangeDialogIsOpen] = useState(false);
+    const handleCloseChangeDialog = async (newNamespaceName?: string) => {
+        setChangeDialogIsOpen(false);
+        if (newNamespaceName && props.onNamespaceChange) {
+            props.onNamespaceChange(newNamespaceName);
+        }
+    };
+    const handleOpenChangeDialog = () => {
+        setChangeDialogIsOpen(true);
+    };
+
     return <>
         <Grid container direction='column' spacing={4} className={classes.namespaceDetailContainer}>
             {
@@ -85,6 +114,17 @@ export const NamespaceDetail: FunctionComponent<NamespaceDetail.Props> = props =
                 </Grid>
                 : null
             }
+            <Grid item>
+                <Box className={classes.namespaceHeader}>
+                    <Typography variant='h4'>{props.namespace.name}</Typography>
+                    { props.location.pathname.startsWith(AdminDashboardRoutes.NAMESPACE_ADMIN)
+                        ? <Button className={classes.changeButton} variant='outlined' onClick={handleOpenChangeDialog}>
+                            Change Namespace
+                        </Button>
+                        : null
+                    }
+                </Box>
+            </Grid>
             {
                 props.namespace.membersUrl
                 ? <Grid item>
@@ -105,16 +145,24 @@ export const NamespaceDetail: FunctionComponent<NamespaceDetail.Props> = props =
                 />
             </Grid>
         </Grid>
+        <NamespaceChangeDialog
+            open={changeDialogIsOpen}
+            onClose={handleCloseChangeDialog}
+            namespace={props.namespace}
+            setLoadingState={props.setLoadingState} />
     </>;
 };
 
-export namespace NamespaceDetail {
-    export interface Props {
+export namespace NamespaceDetailComponent {
+    export interface Props extends RouteComponentProps {
         namespace: Namespace;
         filterUsers: (user: UserData) => boolean;
+        onNamespaceChange?: (newNamespaceName: string) => void;
         fixSelf: boolean;
         setLoadingState: (loading: boolean) => void;
         namespaceAccessUrl?: string;
         theme?: string;
     }
 }
+
+export const NamespaceDetail = withRouter(NamespaceDetailComponent);


### PR DESCRIPTION
Fixes #427

Added change namespace dialog to the webui
Added `/admin/change-namespace` endpoint to server

### Testing steps
- Navigate to admin dashboard
- Search for a namespace
- Click the 'Change namespace' button
- A dialog opens up
- Type a new namespace name and check/uncheck the options
- Click the 'Change namespace' button in the dialog to perform the operation