### PR TITLE
Mention target in publish info message

### DIFF
--- a/cli/src/publish.ts
+++ b/cli/src/publish.ts
@@ -55,8 +55,8 @@ async function doPublish(options: InternalPublishOptions = {}): Promise<void> {
 
     const name = `${extension.namespace}.${extension.name}`;
     let description = `${name} v${extension.version}`;
-    if (options.target) {
-        description += `@${options.target}`;
+    if (extension.targetPlatform !== 'universal') {
+        description += `@${extension.targetPlatform}`;
     }
 
     console.log(`\ud83d\ude80  Published ${description}`);


### PR DESCRIPTION
Use `extension.targetPlatform` instead of `options.target`.

The logging format follows the same pattern as other parts of the codebase:
https://github.com/eclipse/openvsx/blob/df28c16c4d919afaf1c8795ab0dfabd842ceb6e6/cli/src/get.ts#L106-L107
https://github.com/eclipse/openvsx/blob/df28c16c4d919afaf1c8795ab0dfabd842ceb6e6/server/src/main/java/org/eclipse/openvsx/ExtensionService.java#L190-L193

cc @radeksimko