### PR TITLE
503 on https://open-vsx.org/

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/search/ISearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/ISearchService.java
@@ -10,7 +10,6 @@
 package org.eclipse.openvsx.search;
 
 import java.util.Objects;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.eclipse.openvsx.entities.Extension;
 
@@ -27,7 +26,7 @@ public interface ISearchService {
     /**
      * Search with given options
      */
-    SearchHits<ExtensionSearch> search(Options options, Pageable pageRequest);
+    SearchHits<ExtensionSearch> search(Options options);
 
     /**
      * Updating the search index has two modes:

--- a/server/src/main/java/org/eclipse/openvsx/search/SearchUtilService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/SearchUtilService.java
@@ -12,7 +12,6 @@ package org.eclipse.openvsx.search;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.eclipse.openvsx.entities.Extension;
 
@@ -52,8 +51,8 @@ public class SearchUtilService implements ISearchService {
 
     }
 
-    public SearchHits<ExtensionSearch> search(ElasticSearchService.Options options, Pageable pageRequest) {
-        return getImplementation().search(options, pageRequest);
+    public SearchHits<ExtensionSearch> search(ElasticSearchService.Options options) {
+        return getImplementation().search(options);
     }
 
     @Override

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -68,7 +68,6 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHitsImpl;
 import org.springframework.data.elasticsearch.core.TotalHitsRelation;
@@ -1491,7 +1490,7 @@ public class RegistryAPITest {
         Mockito.when(search.isEnabled())
                 .thenReturn(true);
         var searchOptions = new ISearchService.Options("foo", null, null, 10, 0, "desc", "relevance", false);
-        Mockito.when(search.search(searchOptions, PageRequest.of(0, 10)))
+        Mockito.when(search.search(searchOptions))
                 .thenReturn(searchHits);
         Mockito.when(entityManager.find(Extension.class, 1l))
                 .thenReturn(extension);

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAdapterTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAdapterTest.java
@@ -26,7 +26,6 @@ import javax.persistence.EntityManager;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.io.CharStreams;
 
@@ -50,7 +49,6 @@ import org.eclipse.openvsx.storage.AzureDownloadCountService;
 import org.eclipse.openvsx.storage.GoogleCloudStorageService;
 import org.eclipse.openvsx.storage.StorageUtilService;
 import org.eclipse.openvsx.util.TargetPlatform;
-import org.eclipse.openvsx.util.VersionUtil;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -60,7 +58,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHitsImpl;
 import org.springframework.data.elasticsearch.core.TotalHitsRelation;
@@ -404,7 +401,7 @@ public class VSCodeAdapterTest {
         Mockito.when(search.isEnabled())
                 .thenReturn(true);
         var searchOptions = new ISearchService.Options("yaml", null, targetPlatform, 50, 0, "desc", "relevance", false);
-        Mockito.when(search.search(searchOptions, PageRequest.of(0, 50)))
+        Mockito.when(search.search(searchOptions))
                 .thenReturn(searchHits);
 
         var extension = mockExtensionDTO();

--- a/server/src/test/java/org/eclipse/openvsx/search/DatabaseSearchServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/search/DatabaseSearchServiceTest.java
@@ -28,7 +28,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.util.Streamable;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -55,7 +54,7 @@ public class DatabaseSearchServiceTest {
         Mockito.when(repositories.findAllActiveExtensions()).thenReturn(Streamable.of(List.of(ext1, ext2, ext3)));
 
         var searchOptions = new ISearchService.Options(null, "Programming Languages", TargetPlatform.NAME_UNIVERSAL, 50, 0, null, null, false);
-        var result = search.search(searchOptions, PageRequest.of(0, 50));
+        var result = search.search(searchOptions);
         // should find two extensions
         assertThat(result.getTotalHits()).isEqualTo(2);
     }
@@ -68,7 +67,7 @@ public class DatabaseSearchServiceTest {
         Mockito.when(repositories.findAllActiveExtensions()).thenReturn(Streamable.of(List.of(ext1, ext2, ext3)));
 
         var searchOptions = new ISearchService.Options(null, null, TargetPlatform.NAME_UNIVERSAL, 50, 0, null, "relevance", false);
-        var result = search.search(searchOptions, PageRequest.of(0, 50));
+        var result = search.search(searchOptions);
         // should find all extensions but order should be different
         assertThat(result.getTotalHits()).isEqualTo(3);
 
@@ -86,7 +85,7 @@ public class DatabaseSearchServiceTest {
         Mockito.when(repositories.findAllActiveExtensions()).thenReturn(Streamable.of(List.of(ext1, ext2)));
 
         var searchOptions = new ISearchService.Options(null, "Programming Languages", TargetPlatform.NAME_UNIVERSAL, 50, 0, "desc", null, false);
-        var result = search.search(searchOptions, PageRequest.of(0, 50));
+        var result = search.search(searchOptions);
         // should find two extensions
         assertThat(result.getTotalHits()).isEqualTo(2);
 
@@ -106,10 +105,10 @@ public class DatabaseSearchServiceTest {
         var ext7 = mockExtension("ext7", 3.0, 100, 0, "redhat", Arrays.asList("Snippets", "Programming Languages"));
         Mockito.when(repositories.findAllActiveExtensions()).thenReturn(Streamable.of(List.of(ext1, ext2, ext3, ext4, ext5, ext6, ext7)));
 
-        var searchOptions = new ISearchService.Options(null, null, TargetPlatform.NAME_UNIVERSAL, 50, 0, null, null, false);
-
         var pageSizeItems = 5;
-        var result = search.search(searchOptions, PageRequest.of(0, pageSizeItems));
+        var searchOptions = new ISearchService.Options(null, null, TargetPlatform.NAME_UNIVERSAL, pageSizeItems, 0, null, null, false);
+
+        var result = search.search(searchOptions);
         // 7 total hits
         assertThat(result.getTotalHits()).isEqualTo(7);
         // but as we limit the page size it should only contains 5
@@ -134,14 +133,12 @@ public class DatabaseSearchServiceTest {
         var ext7 = mockExtension("ext7", 3.0, 100, 0, "redhat", Arrays.asList("Snippets", "Programming Languages"));
         Mockito.when(repositories.findAllActiveExtensions()).thenReturn(Streamable.of(List.of(ext1, ext2, ext3, ext4, ext5, ext6, ext7)));
 
-        var searchOptions = new ISearchService.Options(null, null, TargetPlatform.NAME_UNIVERSAL, 50, 0, null, null, false);
-
-        var pageNumber = 2;
         var pageSizeItems = 2;
-        var result = search.search(searchOptions, PageRequest.of(pageNumber, pageSizeItems));
+        var searchOptions = new ISearchService.Options(null, null, TargetPlatform.NAME_UNIVERSAL, pageSizeItems, 4, null, null, false);
+        var result = search.search(searchOptions);
+
         // 7 total hits
         assertThat(result.getTotalHits()).isEqualTo(7);
-
         // But it should only contains 2 search items as specified by the pageSize
         var hits = result.getSearchHits();
         assertThat(hits.size()).isEqualTo(pageSizeItems);
@@ -159,7 +156,7 @@ public class DatabaseSearchServiceTest {
         Mockito.when(repositories.findAllActiveExtensions()).thenReturn(Streamable.of(List.of(ext1, ext2, ext3, ext4)));
 
         var searchOptions = new ISearchService.Options("redhat", null, TargetPlatform.NAME_UNIVERSAL, 50, 0, null, null, false);
-        var result = search.search(searchOptions, PageRequest.of(0, 50));
+        var result = search.search(searchOptions);
         // namespace finding
         assertThat(result.getTotalHits()).isEqualTo(3);
 
@@ -179,7 +176,7 @@ public class DatabaseSearchServiceTest {
         Mockito.when(repositories.findAllActiveExtensions()).thenReturn(Streamable.of(List.of(ext1, ext2, ext3, ext4)));
 
         var searchOptions = new ISearchService.Options("openshift", null, TargetPlatform.NAME_UNIVERSAL, 50, 0, null, null, false);
-        var result = search.search(searchOptions, PageRequest.of(0, 50));
+        var result = search.search(searchOptions);
         // extension name finding
         assertThat(result.getTotalHits()).isEqualTo(1);
 
@@ -199,7 +196,7 @@ public class DatabaseSearchServiceTest {
         Mockito.when(repositories.findAllActiveExtensions()).thenReturn(Streamable.of(List.of(ext1, ext2, ext3, ext4)));
 
         var searchOptions = new ISearchService.Options("my custom desc", null, TargetPlatform.NAME_UNIVERSAL, 50, 0, null, null, false);
-        var result = search.search(searchOptions, PageRequest.of(0, 50));
+        var result = search.search(searchOptions);
         // custom description
         assertThat(result.getTotalHits()).isEqualTo(1);
 
@@ -219,7 +216,7 @@ public class DatabaseSearchServiceTest {
         Mockito.when(repositories.findAllActiveExtensions()).thenReturn(Streamable.of(List.of(ext1, ext2, ext3, ext4)));
 
         var searchOptions = new ISearchService.Options("Red Hat", null, TargetPlatform.NAME_UNIVERSAL, 50, 0, null, null, false);
-        var result = search.search(searchOptions, PageRequest.of(0, 50));
+        var result = search.search(searchOptions);
 
         // custom displayname
         assertThat(result.getTotalHits()).isEqualTo(1);
@@ -242,7 +239,7 @@ public class DatabaseSearchServiceTest {
         Mockito.when(repositories.findAllActiveExtensions()).thenReturn(Streamable.of(List.of(ext1, ext2, ext3, ext4)));
 
         var searchOptions = new ISearchService.Options(null, null, TargetPlatform.NAME_UNIVERSAL, 50, 0, null, "timestamp", false);
-        var result = search.search(searchOptions, PageRequest.of(0, 50));
+        var result = search.search(searchOptions);
         // all extensions should be there
         assertThat(result.getTotalHits()).isEqualTo(4);
 
@@ -263,7 +260,7 @@ public class DatabaseSearchServiceTest {
         Mockito.when(repositories.findAllActiveExtensions()).thenReturn(Streamable.of(List.of(ext1, ext2, ext3, ext4)));
 
         var searchOptions = new ISearchService.Options(null, null, TargetPlatform.NAME_UNIVERSAL, 50, 0, null, "downloadCount", false);
-        var result = search.search(searchOptions, PageRequest.of(0, 50));
+        var result = search.search(searchOptions);
         // all extensions should be there
         assertThat(result.getTotalHits()).isEqualTo(4);
 
@@ -284,7 +281,7 @@ public class DatabaseSearchServiceTest {
         Mockito.when(repositories.findAllActiveExtensions()).thenReturn(Streamable.of(List.of(ext1, ext2, ext3, ext4)));
 
         var searchOptions = new ISearchService.Options(null, null, TargetPlatform.NAME_UNIVERSAL, 50, 0, null, "averageRating", false);
-        var result = search.search(searchOptions, PageRequest.of(0, 50));
+        var result = search.search(searchOptions);
         // all extensions should be there
         assertThat(result.getTotalHits()).isEqualTo(4);
 


### PR DESCRIPTION
Fixes #473
Throw exception when ElasticSearch result window is too large
Removed paging logic from LocalRegistryService.java
Added paging logic to ElasticSearchService.java
Only use PageRequest in ElasticSearchService.java