### PR TITLE
Use `gp ports await` instead of `gp await-port` in `.gitpod.yml`

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -37,20 +37,20 @@ tasks:
     if [[ $NPM_TOKEN ]]; then echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc; fi
     # Start Elasticsearch as background process
     $ES_HOME/bin/elasticsearch -d -p $ES_HOME/pid -Ediscovery.type=single-node -Expack.ml.enabled=false
-    gp await-port 9200
+    gp ports await 9200
     # Start the server application
     cd server
     ./scripts/generate-properties.sh
     ./gradlew runServer
 - name: WebUI
   command: |
-    gp await-port 8080
+    gp ports await 8080
     # Start Express for serving frontend resources
     cd webui
     yarn start:default
 - name: Publisher
   command: |
-    gp await-port 8080
+    gp ports await 8080
     # Use the CLI to publish some test extensions to the running server
     export OVSX_REGISTRY_URL=http://localhost:8080
     export OVSX_PAT=super_token


### PR DESCRIPTION
Because `gp await-port` was recently deprecated (https://github.com/gitpod-io/gitpod/pull/10463), this PR replaces it with the new command, `gp ports await`.