### PR TITLE
Do file resource processing via background job

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionJobRequest.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionJobRequest.java
@@ -1,0 +1,67 @@
+/** ******************************************************************************
+ * Copyright (c) 2022 Precies. Software and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.publish;
+
+import org.jobrunr.jobs.lambdas.JobRequest;
+import org.jobrunr.jobs.lambdas.JobRequestHandler;
+
+public class PublishExtensionVersionJobRequest implements JobRequest {
+
+    private String namespaceName;
+    private String extensionName;
+    private String targetPlatform;
+    private String version;
+
+    public PublishExtensionVersionJobRequest() { }
+
+    public PublishExtensionVersionJobRequest(String namespaceName, String extensionName, String targetPlatform, String version) {
+        this.namespaceName = namespaceName;
+        this.extensionName = extensionName;
+        this.targetPlatform = targetPlatform;
+        this.version = version;
+    }
+
+    @Override
+    public Class<? extends JobRequestHandler> getJobRequestHandler() {
+        return PublishExtensionVersionJobRequestHandler.class;
+    }
+
+    public String getNamespaceName() {
+        return namespaceName;
+    }
+
+    public void setNamespaceName(String namespaceName) {
+        this.namespaceName = namespaceName;
+    }
+
+    public String getExtensionName() {
+        return extensionName;
+    }
+
+    public void setExtensionName(String extensionName) {
+        this.extensionName = extensionName;
+    }
+
+    public String getTargetPlatform() {
+        return targetPlatform;
+    }
+
+    public void setTargetPlatform(String targetPlatform) {
+        this.targetPlatform = targetPlatform;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionJobRequestHandler.java
@@ -1,0 +1,79 @@
+/** ******************************************************************************
+ * Copyright (c) 2022 Precies. Software and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.publish;
+
+import org.eclipse.openvsx.ExtensionProcessor;
+import org.eclipse.openvsx.ExtensionService;
+import org.eclipse.openvsx.entities.ExtensionVersion;
+import org.eclipse.openvsx.entities.FileResource;
+import org.eclipse.openvsx.repositories.RepositoryService;
+import org.eclipse.openvsx.storage.StorageUtilService;
+import org.eclipse.openvsx.util.TargetPlatform;
+import org.jobrunr.jobs.lambdas.JobRequestHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.util.Streamable;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+
+import static org.eclipse.openvsx.entities.FileResource.DOWNLOAD;
+import static org.eclipse.openvsx.entities.FileResource.LICENSE;
+
+@Component
+public class PublishExtensionVersionJobRequestHandler implements JobRequestHandler<PublishExtensionVersionJobRequest> {
+
+    @Autowired
+    ExtensionService extensions;
+
+    @Autowired
+    RepositoryService repositories;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Autowired
+    StorageUtilService storageUtil;
+
+    @Override
+    @Transactional
+    public void run(PublishExtensionVersionJobRequest jobRequest) throws Exception {
+        var extVersion = repositories.findVersion(jobRequest.getVersion(), jobRequest.getTargetPlatform(),
+                jobRequest.getExtensionName(), jobRequest.getNamespaceName());
+
+        var resources = repositories.findFiles(extVersion);
+        var download = resources.stream().filter(r -> r.getType().equals(DOWNLOAD)).findFirst().get();
+        try(
+                var input = new ByteArrayInputStream(download.getContent());
+                var processor = new ExtensionProcessor(input)
+        ) {
+            var otherResources = processor.getResources(extVersion, List.of(DOWNLOAD, LICENSE));
+            otherResources.forEach(fr -> entityManager.persist(fr));
+            resources = resources.and(otherResources);
+        }
+
+        // Store file resources in the DB or external storage
+        for(var resource : resources) {
+            if (storageUtil.shouldStoreExternally(resource)) {
+                storageUtil.uploadFile(resource);
+                // Don't store the binary content in the DB - it's now stored externally
+                resource.setContent(null);
+            } else {
+                resource.setStorageType(FileResource.STORAGE_DB);
+            }
+        }
+
+        // Update whether extension is active, the search index and evict cache
+        extVersion.setActive(true);
+        extensions.updateExtension(extVersion.getExtension());
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
@@ -53,6 +53,7 @@ import org.eclipse.openvsx.storage.GoogleCloudStorageService;
 import org.eclipse.openvsx.storage.StorageUtilService;
 import org.eclipse.openvsx.util.TargetPlatform;
 import org.eclipse.openvsx.util.VersionService;
+import org.jobrunr.scheduling.JobRequestScheduler;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,7 +75,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 @MockBean({
     ClientRegistrationRepository.class, UpstreamRegistryService.class, GoogleCloudStorageService.class,
     AzureBlobStorageService.class, VSCodeIdService.class, DownloadCountService.class, AzureDownloadCountService.class,
-    LockProvider.class, CacheService.class
+    LockProvider.class, CacheService.class, JobRequestScheduler.class
 })
 public class AdminAPITest {
     

--- a/server/src/test/java/org/eclipse/openvsx/IntegrationTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/IntegrationTest.java
@@ -50,11 +50,13 @@ public class IntegrationTest {
         testService.createUser();
         createNamespace();
         publishExtension();
+
+        // Wait a bit until the publish extension background job has finished
+        Thread.sleep(15000);
         getExtensionMetadata();
 
         // Wait a bit until the new entry has landed in the search index
         Thread.sleep(2000);
-
         searchExtension();
     }
 

--- a/server/src/test/java/org/eclipse/openvsx/JobRunrConfig.java
+++ b/server/src/test/java/org/eclipse/openvsx/JobRunrConfig.java
@@ -9,8 +9,11 @@
  ********************************************************************************/
 package org.eclipse.openvsx;
 
+import org.jobrunr.jobs.mappers.JobMapper;
 import org.jobrunr.storage.InMemoryStorageProvider;
 import org.jobrunr.storage.StorageProvider;
+import org.jobrunr.utils.mapper.JsonMapper;
+import org.jobrunr.utils.mapper.jackson.JacksonJsonMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -20,7 +23,20 @@ import org.springframework.context.annotation.Profile;
 public class JobRunrConfig {
 
     @Bean
-    public StorageProvider jobRunrStorageProvider() {
-        return new InMemoryStorageProvider();
+    public StorageProvider storageProvider(JobMapper jobMapper) {
+        var storageProvider = new InMemoryStorageProvider();
+        storageProvider.setJobMapper(jobMapper);
+
+        return storageProvider;
+    }
+
+    @Bean
+    public JobMapper jobMapper(JsonMapper jsonMapper) {
+        return new JobMapper(jsonMapper);
+    }
+
+    @Bean
+    public JsonMapper jsonMapper() {
+        return new JacksonJsonMapper(true);
     }
 }

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -58,6 +58,7 @@ import org.eclipse.openvsx.security.TokenService;
 import org.eclipse.openvsx.storage.*;
 import org.eclipse.openvsx.util.TargetPlatform;
 import org.eclipse.openvsx.util.VersionService;
+import org.jobrunr.scheduling.JobRequestScheduler;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -84,7 +85,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @MockBean({
     ClientRegistrationRepository.class, UpstreamRegistryService.class, GoogleCloudStorageService.class,
     AzureBlobStorageService.class, VSCodeIdService.class, DownloadCountService.class, AzureDownloadCountService.class,
-    LockProvider.class, CacheService.class, EclipseService.class
+    LockProvider.class, CacheService.class, EclipseService.class, JobRequestScheduler.class
 })
 public class RegistryAPITest {
 

--- a/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
@@ -43,6 +43,7 @@ import org.eclipse.openvsx.storage.StorageUtilService;
 import org.eclipse.openvsx.util.ErrorResultException;
 import org.eclipse.openvsx.util.TargetPlatform;
 import org.eclipse.openvsx.util.VersionService;
+import org.jobrunr.scheduling.JobRequestScheduler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -64,7 +65,7 @@ import org.springframework.web.client.RestTemplate;
 @MockBean({
     EntityManager.class, SearchUtilService.class, GoogleCloudStorageService.class, AzureBlobStorageService.class,
     VSCodeIdService.class, DownloadCountService.class, AzureDownloadCountService.class, LockProvider.class,
-    CacheService.class, UserService.class
+    CacheService.class, UserService.class, JobRequestScheduler.class
 })
 public class EclipseServiceTest {
 

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -23,3 +23,15 @@ spring:
             github:
               client-id: dummy-client-id
               client-secret: dummy-client-secret
+
+org:
+  jobrunr:
+    job-scheduler:
+      enabled: true
+    background-job-server:
+      enabled: true
+      worker-count: 1
+    dashboard:
+      enabled: false
+    miscellaneous:
+      allow-anonymous-data-usage: false


### PR DESCRIPTION
Fixes #471

I did some Gatling testing to check if running `FileResource` processing in the background makes a difference in terms of performance and request throughput. Please note that these tests were done on my local development environment. The Open VSX server and Gatling were running on the same machine (which can cause interference). To confirm these findings it would be a good idea to test against the staging server.

Below are the results when only 1 extension is published at a time. The current (OLD) publishing process performs a bit better in this case.
```
== OLD =========================================================================
---- Global Information --------------------------------------------------------
> request count                                       1137 (OK=661    KO=476   )
> min response time                                      3 (OK=23     KO=3     )
> max response time                                  10549 (OK=10549  KO=10029 )
> mean response time                                   208 (OK=323    KO=49    )
> std deviation                                        664 (OK=753    KO=470   )
> response time 50th percentile                         40 (OK=75     KO=8     )
> response time 75th percentile                         99 (OK=267    KO=15    )
> response time 95th percentile                        970 (OK=1375   KO=51    )
> response time 99th percentile                       3146 (OK=3529   KO=779   )
> mean requests/sec                                  4.075 (OK=2.369  KO=1.706 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                           593 ( 52%)
> 800 ms < t < 1200 ms                                  25 (  2%)
> t > 1200 ms                                           43 (  4%)
> failed                                               476 ( 42%)
---- Errors --------------------------------------------------------------------
> status.find.is(201), but actually found 400                       476 (100,0%)
================================================================================
```

```
== NEW =========================================================================
---- Global Information --------------------------------------------------------
> request count                                       1137 (OK=661    KO=476   )
> min response time                                      3 (OK=16     KO=3     )
> max response time                                  10057 (OK=8724   KO=10057 )
> mean response time                                   234 (OK=353    KO=68    )
> std deviation                                        790 (OK=917    KO=527   )
> response time 50th percentile                         33 (OK=64     KO=10    )
> response time 75th percentile                         90 (OK=180    KO=19    )
> response time 95th percentile                       1074 (OK=1882   KO=72    )
> response time 99th percentile                       3958 (OK=4885   KO=1526  )
> mean requests/sec                                  3.598 (OK=2.092  KO=1.506 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                           588 ( 52%)
> 800 ms < t < 1200 ms                                  27 (  2%)
> t > 1200 ms                                           46 (  4%)
> failed                                               476 ( 42%)
---- Errors --------------------------------------------------------------------
> status.find.is(201), but actually found 400                       476 (100,0%)
================================================================================
```

However, when 2 or more extensions are published at a time, the current (OLD) publishing process starts to throw exceptions and I decided to abort the test because it took forever.
With `ovsx` now supporting target platforms, a single `./ovsx publish` command can perform up to 10 requests (one for each target platform) concurrently. This means the server has to be able to reliably handle multiple publish operations at the same time.

```
== OLD =========================================================================
2022-07-18 22:27:34                                         955s elapsed
---- Requests ------------------------------------------------------------------
> Global                                                   (OK=363    KO=278   )
> publishExtension                                         (OK=363    KO=278   )
---- Errors --------------------------------------------------------------------
> status.find.is(201), but actually found 400                       270 (97,12%)
> i.g.h.c.i.RequestTimeoutException: Request timeout to localhos      8 ( 2,88%)
t/127.0.0.1:8080 after 180000 ms

---- RegistryAPI: Publish Extension --------------------------------------------
[--------------------------------------------------------------------------]  0%
          waiting: 0      / active: 2      / done: 0
================================================================================
```

```
2022-07-18 22:26:08.220  WARN 55744 --- [        Timer-0] o.j.storage.AbstractStorageProvider      : Error notifying JobStorageChangeListeners

org.jobrunr.storage.StorageException: java.sql.SQLTransientConnectionException: HikariPool-1 - Connection is not available, request timed out after 30007ms.
        at org.jobrunr.storage.sql.common.DefaultSqlStorageProvider.getJobStats(DefaultSqlStorageProvider.java:346) ~[jobrunr-5.1.2.jar:5.1.2]
        at org.jobrunr.storage.AbstractStorageProvider.notifyJobStatsOnChangeListeners(AbstractStorageProvider.java:73) ~[jobrunr-5.1.2.jar:5.1.2]
        at org.jobrunr.storage.AbstractStorageProvider$NotifyOnChangeListeners.run(AbstractStorageProvider.java:177) ~[jobrunr-5.1.2.jar:5.1.2]
        at java.base/java.util.TimerThread.mainLoop(Timer.java:556) ~[na:na]
        at java.base/java.util.TimerThread.run(Timer.java:506) ~[na:na]
Caused by: java.sql.SQLTransientConnectionException: HikariPool-1 - Connection is not available, request timed out after 30007ms.
        at com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:695) ~[HikariCP-3.4.5.jar:na]
        at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:197) ~[HikariCP-3.4.5.jar:na]
        at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:162) ~[HikariCP-3.4.5.jar:na]
        at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:128) ~[HikariCP-3.4.5.jar:na]
        at org.jobrunr.storage.sql.common.DefaultSqlStorageProvider.getJobStats(DefaultSqlStorageProvider.java:343) ~[jobrunr-5.1.2.jar:5.1.2]
        ... 4 common frames omitted
```

```
== NEW =========================================================================
---- Global Information --------------------------------------------------------
> request count                                       1136 (OK=660    KO=476   )
> min response time                                      4 (OK=20     KO=4     )
> max response time                                  15753 (OK=15753  KO=3597  )
> mean response time                                   348 (OK=552    KO=65    )
> std deviation                                       1145 (OK=1450   KO=272   )
> response time 50th percentile                         51 (OK=108    KO=16    )
> response time 75th percentile                        159 (OK=343    KO=32    )
> response time 95th percentile                       1606 (OK=2577   KO=158   )
> response time 99th percentile                       5948 (OK=8473   KO=1622  )
> mean requests/sec                                  4.876 (OK=2.833  KO=2.043 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                           572 ( 50%)
> 800 ms < t < 1200 ms                                  19 (  2%)
> t > 1200 ms                                           69 (  6%)
> failed                                               476 ( 42%)
---- Errors --------------------------------------------------------------------
> status.find.is(201), but actually found 400                       476 (100,0%)
================================================================================
```

And it gets even better when publishing 4 extensions at a time:

```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       1136 (OK=660    KO=476   )
> min response time                                      4 (OK=18     KO=4     )
> max response time                                  14156 (OK=14156  KO=3215  )
> mean response time                                   463 (OK=736    KO=83    )
> std deviation                                       1427 (OK=1803   KO=322   )
> response time 50th percentile                         62 (OK=140    KO=17    )
> response time 75th percentile                        238 (OK=521    KO=33    )
> response time 95th percentile                       2042 (OK=3613   KO=230   )
> response time 99th percentile                       8461 (OK=10606  KO=2158  )
> mean requests/sec                                  6.927 (OK=4.024  KO=2.902 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                           536 ( 47%)
> 800 ms < t < 1200 ms                                  43 (  4%)
> t > 1200 ms                                           81 (  7%)
> failed                                               476 ( 42%)
---- Errors --------------------------------------------------------------------
> status.find.is(201), but actually found 400                       476 (100,0%)
================================================================================
```