### PR TITLE
fix: X-Forwarded-Host header can be array or comma separated list

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/util/UrlUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/UrlUtil.java
@@ -12,6 +12,9 @@ package org.eclipse.openvsx.util;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
+import java.util.ArrayList;
+import java.util.Collections;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -159,11 +162,19 @@ public final class UrlUtil {
         // Use the host and port from the X-Forwarded-Host header if present
         String host;
         int port;
-        var forwardedHost = request.getHeader("X-Forwarded-Host");
-        if (forwardedHost == null) {
+        var forwardedHostHeadersEnumeration = request.getHeaders("X-Forwarded-Host");
+        if (forwardedHostHeadersEnumeration == null || !forwardedHostHeadersEnumeration.hasMoreElements()) {
             host = request.getServerName();
             port = request.getServerPort();
         } else {
+            // take the first one
+            var forwardedHost = forwardedHostHeadersEnumeration.nextElement();
+
+            // if it's comma separated, take the first one
+            var forwardedHosts = forwardedHost.split(",");
+            if (forwardedHosts.length > 1) {
+                forwardedHost = forwardedHosts[0];
+            }
             int colonIndex = forwardedHost.lastIndexOf(':');
             if (colonIndex > 0) {
                 host = forwardedHost.substring(0, colonIndex);

--- a/server/src/test/java/org/eclipse/openvsx/util/UrlUtilTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/util/UrlUtilTest.java
@@ -12,6 +12,9 @@ package org.eclipse.openvsx.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 
+import java.util.ArrayList;
+import java.util.Collections;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.junit.jupiter.api.AfterEach;
@@ -100,9 +103,49 @@ public class UrlUtilTest {
 
         // XForwarded content
         doReturn("https").when(request).getHeader("X-Forwarded-Proto");
-        doReturn("open-vsx.org").when(request).getHeader("X-Forwarded-Host");
+        var items = new ArrayList<String>();
+        items.add("open-vsx.org");
+        doReturn(Collections.enumeration(items)).when(request).getHeaders("X-Forwarded-Host");
         doReturn("/openvsx").when(request).getHeader("X-Forwarded-Prefix");
         assertThat(UrlUtil.getBaseUrl(request)).isEqualTo("https://open-vsx.org/openvsx/");
-    }    
+    } 
+
+    // Check base URL is using array X-Forwarded-Host headers
+    @Test
+    public void testWithXForwardedHostArray() throws Exception {
+        // basic request
+        doReturn("http").when(request).getScheme();
+        doReturn("localhost").when(request).getServerName();
+        doReturn(8080).when(request).getServerPort();
+        doReturn("/").when(request).getContextPath();
+
+        // XForwarded content
+        doReturn("https").when(request).getHeader("X-Forwarded-Proto");
+        var items = new ArrayList<String>();
+        items.add("open-vsx.org");
+        items.add("foo.com");
+        items.add("bar.com");
+        doReturn(Collections.enumeration(items)).when(request).getHeaders("X-Forwarded-Host");
+        doReturn("/openvsx").when(request).getHeader("X-Forwarded-Prefix");
+        assertThat(UrlUtil.getBaseUrl(request)).isEqualTo("https://open-vsx.org/openvsx/");
+    }
+
+    // Check base URL is using comma separated X-Forwarded-Host headers
+    @Test
+    public void testWithXForwardedHostCommaSeparated() throws Exception {
+        // basic request
+        doReturn("http").when(request).getScheme();
+        doReturn("localhost").when(request).getServerName();
+        doReturn(8080).when(request).getServerPort();
+        doReturn("/").when(request).getContextPath();
+
+        // XForwarded content
+        doReturn("https").when(request).getHeader("X-Forwarded-Proto");
+        var items = new ArrayList<String>();
+        items.add("open-vsx.org, foo.com, bar.com");
+        doReturn(Collections.enumeration(items)).when(request).getHeaders("X-Forwarded-Host");
+        doReturn("/openvsx").when(request).getHeader("X-Forwarded-Prefix");
+        assertThat(UrlUtil.getBaseUrl(request)).isEqualTo("https://open-vsx.org/openvsx/");
+    }
 
 }


### PR DESCRIPTION
Headers can be array values or be a single string with comma separated value

So when computing the host using `X-Forwarded-Host` it should use the first value and not the 'joined' list concatenate by a comma else it leads to invalid base URL

example:
```
https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#x-headers

Be careful when using these headers on the origin server, since they will contain more than one (comma-separated) value if the original request already contained one of these headers. For example, you can use %{X-Forwarded-For}i in the log format string of the origin server to log the original clients IP address, but you may get more than one address if the request passes through several proxies.
```

Fixes https://github.com/eclipse/openvsx/issues/498

Change-Id: I4407776a5296809e304e3c8b10dafe50e9929035
Signed-off-by: Florent Benoit <fbenoit@redhat.com>