### PR TITLE
Explicitly state extension icon size

### DIFF
--- a/webui/src/pages/extension-detail/extension-detail.tsx
+++ b/webui/src/pages/extension-detail/extension-detail.tsx
@@ -283,6 +283,8 @@ export class ExtensionDetailComponent extends React.Component<ExtensionDetailCom
                         {this.renderBanner(extension, headerTheme)}
                         <Box className={classes.iconAndInfo}>
                             <img src={icon || this.context.pageSettings.urls.extensionDefaultIcon }
+                                width={72}
+                                height={72}
                                 className={`${classes.extensionLogo} ${classes.badgePadding}`}
                                 alt={extension.displayName || extension.name} />
                             {this.renderHeaderInfo(extension, headerTheme)}


### PR DESCRIPTION
We just add `width` and `height` to icons in order to reduce [CLS](https://web.dev/optimize-cls/#images-without-dimensions-%F0%9F%8C%86).