### PR TITLE
Update test extensions

### DIFF
--- a/server/test-extensions.gradle
+++ b/server/test-extensions.gradle
@@ -29,20 +29,24 @@ task downloadTestExtensions {
             dest "${buildDir}/test-extensions/ms-python.python-2019.10.44104.vsix"
         }
         download {
-            src "https://github.com/microsoft/vscode-cpptools/releases/download/0.26.0/cpptools-linux.vsix"
-            dest "${buildDir}/test-extensions/ms-vscode.cpptools-0.26.0.vsix"
+            src "https://github.com/redhat-developer/vscode-java/releases/download/v1.11.0/redhat.java@darwin-arm64-1.11.0.vsix"
+            dest "${buildDir}/test-extensions/redhat.java@darwin-arm64-1.11.0.vsix"
         }
         download {
-            src "https://github.com/microsoft/vscode-cpptools/releases/download/0.26.1/cpptools-linux.vsix"
-            dest "${buildDir}/test-extensions/ms-vscode.cpptools-0.26.1.vsix"
+            src "https://github.com/redhat-developer/vscode-java/releases/download/v1.11.0/redhat.java@darwin-x64-1.11.0.vsix"
+            dest "${buildDir}/test-extensions/redhat.java@darwin-x64-1.11.0.vsix"
         }
         download {
-            src "https://github.com/OmniSharp/omnisharp-vscode/releases/download/v1.21.6/csharp-1.21.6.vsix"
-            dest "${buildDir}/test-extensions/ms-vscode.csharp-1.21.6.vsix"
+            src "https://github.com/redhat-developer/vscode-java/releases/download/v1.11.0/redhat.java@linux-arm64-1.11.0.vsix"
+            dest "${buildDir}/test-extensions/redhat.java@linux-arm64-1.11.0.vsix"
         }
         download {
-            src "https://github.com/redhat-developer/vscode-java/releases/download/v0.47.0/redhat.java-0.47.0.vsix"
-            dest "${buildDir}/test-extensions/redhat.java-0.47.0.vsix"
+            src "https://github.com/redhat-developer/vscode-java/releases/download/v1.11.0/redhat.java@linux-x64-1.11.0.vsix"
+            dest "${buildDir}/test-extensions/redhat.java@linux-x64-1.11.0.vsix"
+        }
+        download {
+            src "https://github.com/redhat-developer/vscode-java/releases/download/v1.11.0/redhat.java@win32-x64-1.11.0.vsix"
+            dest "${buildDir}/test-extensions/redhat.java@win32-x64-1.11.0.vsix"
         }
         download {
             src "https://github.com/HookyQR/VSCodeBeautify/releases/download/v0.1.3/beautify-0.1.3.vsix"


### PR DESCRIPTION
Update test extensions to remove problematic Microsoft ones (due to licensing) and add the [Java extension by Redhat](https://open-vsx.org/extension/redhat/java) for testing platform-specific extensions.