### PR TITLE
Cache `/api/-/search` results

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
@@ -117,6 +117,7 @@ public class ExtensionService {
         cache.evictNamespaceDetails(extension);
         cache.evictLatestExtensionVersion(extension);
         cache.evictExtensionJsons(extension);
+        cache.evictSearchEntryJsons(extension);
 
         if (extension.getVersions().stream().anyMatch(ExtensionVersion::isActive)) {
             // There is at least one active version => activate the extension

--- a/server/src/main/java/org/eclipse/openvsx/cache/SearchEntryJsonCacheKeyGenerator.java
+++ b/server/src/main/java/org/eclipse/openvsx/cache/SearchEntryJsonCacheKeyGenerator.java
@@ -1,0 +1,20 @@
+/** ******************************************************************************
+ * Copyright (c) 2022 Precies. Software Ltd and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.cache;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class SearchEntryJsonCacheKeyGenerator {
+
+    public Object generate(long extensionId, boolean includeAllVersions) {
+        return "extensionId=" + extensionId + ",includeAllVersions=" + includeAllVersions;
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/entities/Extension.java
+++ b/server/src/main/java/org/eclipse/openvsx/entities/Extension.java
@@ -62,6 +62,7 @@ public class Extension implements Serializable {
         search.name = this.getName();
         search.namespace = this.getNamespace().getName();
         search.extensionId = search.namespace + "." + search.name;
+        search.averageRating = this.getAverageRating();
         search.downloadCount = this.getDownloadCount();
         search.targetPlatforms = this.getVersions().stream()
                 .map(ExtensionVersion::getTargetPlatform)

--- a/server/src/main/java/org/eclipse/openvsx/json/SearchEntryJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/SearchEntryJson.java
@@ -78,7 +78,7 @@ public class SearchEntryJson implements Serializable {
         name = "VersionReference",
         description = "Essential metadata of an extension version"
     )
-    public static class VersionReference {
+    public static class VersionReference implements Serializable {
 
         @Schema(description = "URL to get the full metadata of this version")
         public String url;

--- a/server/src/main/java/org/eclipse/openvsx/json/SearchEntryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/SearchEntryService.java
@@ -1,0 +1,118 @@
+/** ******************************************************************************
+ * Copyright (c) 2022 Precies. Software Ltd and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.json;
+
+import org.eclipse.openvsx.cache.CacheService;
+import org.eclipse.openvsx.entities.Extension;
+import org.eclipse.openvsx.entities.ExtensionVersion;
+import org.eclipse.openvsx.repositories.RepositoryService;
+import org.eclipse.openvsx.search.ExtensionSearch;
+import org.eclipse.openvsx.search.SearchUtilService;
+import org.eclipse.openvsx.storage.StorageUtilService;
+import org.eclipse.openvsx.util.UrlUtil;
+import org.eclipse.openvsx.util.VersionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.eclipse.openvsx.entities.FileResource.DOWNLOAD;
+import static org.eclipse.openvsx.entities.FileResource.ICON;
+import static org.eclipse.openvsx.util.UrlUtil.createApiUrl;
+
+@Component
+public class SearchEntryService {
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Autowired
+    VersionService versions;
+
+    @Autowired
+    StorageUtilService storageUtil;
+
+    @Autowired
+    SearchUtilService search;
+
+    @Autowired
+    RepositoryService repositories;
+
+    @Autowired
+    CacheService cache;
+
+    @Transactional
+    public SearchEntryJson toJson(SearchHit<ExtensionSearch> searchHit, boolean includeAllVersions) {
+        var searchEntry = cache.getSearchEntryJson(searchHit, includeAllVersions);
+        if(searchEntry != null) {
+            return searchEntry;
+        }
+
+        var extension = getExtension(searchHit);
+        if(extension == null) {
+            return null;
+        }
+
+        var serverUrl = UrlUtil.getBaseUrl();
+        if(includeAllVersions && cache != null) {
+            searchEntry = cache.getSearchEntryJson(searchHit, false);
+        }
+        if(searchEntry == null) {
+            var latest = versions.getLatest(extension, null, false, true);
+            searchEntry = latest.toSearchEntryJson();
+            searchEntry.url = createApiUrl(serverUrl, "api", searchEntry.namespace, searchEntry.name);
+            searchEntry.files = storageUtil.getFileUrls(latest, serverUrl, DOWNLOAD, ICON);
+            cache.putSearchEntryJson(searchEntry, searchHit, false);
+        }
+        if (includeAllVersions) {
+            var activeVersions = repositories.findActiveVersions(extension).toList();
+            var versionUrls = storageUtil.getFileUrls(activeVersions, serverUrl, DOWNLOAD);
+            searchEntry.allVersions = getAllVersionReferences(activeVersions, versionUrls, serverUrl);
+            cache.putSearchEntryJson(searchEntry, searchHit, true);
+        }
+
+        return searchEntry;
+    }
+
+    private Extension getExtension(SearchHit<ExtensionSearch> searchHit) {
+        var searchItem = searchHit.getContent();
+        var extension = entityManager.find(Extension.class, searchItem.id);
+        if (extension == null || !extension.isActive()) {
+            extension = new Extension();
+            extension.setId(searchItem.id);
+            search.removeSearchEntry(extension);
+            return null;
+        }
+
+        return extension;
+    }
+
+    private List<SearchEntryJson.VersionReference> getAllVersionReferences(
+            List<ExtensionVersion> extVersions,
+            Map<Long, Map<String, String>> versionUrls,
+            String serverUrl
+    ) {
+        return extVersions.stream()
+                .sorted(ExtensionVersion.SORT_COMPARATOR)
+                .map(extVersion -> {
+                    var ref = new SearchEntryJson.VersionReference();
+                    ref.version = extVersion.getVersion();
+                    ref.engines = extVersion.getEnginesMap();
+                    ref.url = UrlUtil.createApiVersionUrl(serverUrl, extVersion);
+                    ref.files = versionUrls.get(extVersion.getId());
+                    return ref;
+                }).collect(Collectors.toList());
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/search/ExtensionSearch.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/ExtensionSearch.java
@@ -46,6 +46,14 @@ public class ExtensionSearch implements Serializable {
 
     @Nullable
     @Field(index = false, type = FieldType.Float)
+    public Double averageRating;
+
+    @Nullable
+    @Field(index = false, type = FieldType.Float)
+    public Long reviewCount;
+
+    @Nullable
+    @Field(index = false, type = FieldType.Float)
     public Double rating;
 
     @Field(index = false)

--- a/server/src/main/resources/ehcache.xml
+++ b/server/src/main/resources/ehcache.xml
@@ -30,6 +30,16 @@
             <heap unit="entries">1024</heap>
         </resources>
     </cache>
+    <cache alias="search.entry.json">
+        <expiry>
+            <ttl unit="seconds">3600</ttl>
+        </expiry>
+        <resources>
+            <heap unit="entries">1024</heap>
+            <offheap unit="MB">32</offheap>
+            <disk unit="MB">128</disk>
+        </resources>
+    </cache>
     <cache alias="extension.json">
         <expiry>
             <ttl unit="seconds">3600</ttl>

--- a/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
@@ -68,7 +68,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     ClientRegistrationRepository.class, UpstreamRegistryService.class, GoogleCloudStorageService.class,
     AzureBlobStorageService.class, VSCodeIdService.class, AzureDownloadCountService.class,
     CacheService.class, PublishExtensionVersionHandler.class, SearchUtilService.class,
-    EclipseService.class, SimpleMeterRegistry.class
+    EclipseService.class, SimpleMeterRegistry.class, SearchEntryService.class
 })
 public class AdminAPITest {
     

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -36,6 +36,7 @@ import org.eclipse.openvsx.adapter.VSCodeIdService;
 import org.eclipse.openvsx.cache.CacheService;
 import org.eclipse.openvsx.cache.ExtensionJsonCacheKeyGenerator;
 import org.eclipse.openvsx.cache.LatestExtensionVersionCacheKeyGenerator;
+import org.eclipse.openvsx.cache.SearchEntryJsonCacheKeyGenerator;
 import org.eclipse.openvsx.eclipse.EclipseService;
 import org.eclipse.openvsx.entities.*;
 import org.eclipse.openvsx.json.*;
@@ -2171,6 +2172,16 @@ public class RegistryAPITest {
         @Bean
         PublishExtensionVersionHandler publishExtensionVersionHandler() {
             return new PublishExtensionVersionHandler();
+        }
+
+        @Bean
+        SearchEntryService searchEntryService() {
+            return new SearchEntryService();
+        }
+
+        @Bean
+        SearchEntryJsonCacheKeyGenerator searchEntryJsonCacheKeyGenerator() {
+            return new SearchEntryJsonCacheKeyGenerator();
         }
     }
 }


### PR DESCRIPTION
### Testing steps
- Check out [master ](https://github.com/eclipse/openvsx/commit/f9561102728657fc301c274ec0c4b00b57f09f08)
- Download a bunch of extensions in a directory (the more  the better)
- Configure `extensionDir` in `src/gatling/resources/application.properties`
- Add `super_token` to `access-tokens.csv`
- Start the server: `./gradlew runServer`
- Run `src/gatling/scripts/fill-database.sh`
- Wait for the server to process all publish background jobs
- Run `./gradlew --rerun-tasks gatlingRun-org.eclipse.openvsx.RegistryAPISearchSimulation`
- Checkout this PR
- Again run `./gradlew --rerun-tasks gatlingRun-org.eclipse.openvsx.RegistryAPISearchSimulation`

### Performance Comparison

<pre>
== MASTER <a href="https://github.com/eclipse/openvsx/commit/f9561102728657fc301c274ec0c4b00b57f09f08">f956110</a> 3 RUNS ===============================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                      4 (OK=4      KO=-     )
> max response time                                   2193 (OK=2193   KO=-     )
> mean response time                                    57 (OK=57     KO=-     )
> std deviation                                        106 (OK=106    KO=-     )
> response time 50th percentile                         20 (OK=20     KO=-     )
> response time 75th percentile                         39 (OK=39     KO=-     )
> response time 95th percentile                        342 (OK=342    KO=-     )
> response time 99th percentile                        446 (OK=446    KO=-     )
> mean requests/sec                                 <b>83.333</b> (OK=83.333 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4997 (100%)
> 800 ms < t < 1200 ms                                   1 (  0%)
> t > 1200 ms                                            2 (  0%)
> failed                                                 0 (  0%)
================================================================================
</pre>

<pre>
== NEW 1 RUN ===================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                      4 (OK=4      KO=-     )
> max response time                                   6210 (OK=6210   KO=-     )
> mean response time                                    44 (OK=44     KO=-     )
> std deviation                                        178 (OK=178    KO=-     )
> response time 50th percentile                         20 (OK=20     KO=-     )
> response time 75th percentile                         39 (OK=39     KO=-     )
> response time 95th percentile                        114 (OK=114    KO=-     )
> response time 99th percentile                        350 (OK=350    KO=-     )
> mean requests/sec                                <b>104.167</b> (OK=104.167 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4983 (100%)
> 800 ms < t < 1200 ms                                   3 (  0%)
> t > 1200 ms                                           14 (  0%)
> failed                                                 0 (  0%)
================================================================================
</pre>

<pre>
== NEW 3 RUNS ==================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                      3 (OK=3      KO=-     )
> max response time                                    407 (OK=407    KO=-     )
> mean response time                                    18 (OK=18     KO=-     )
> std deviation                                         25 (OK=25     KO=-     )
> response time 50th percentile                         11 (OK=11     KO=-     )
> response time 75th percentile                         17 (OK=17     KO=-     )
> response time 95th percentile                         53 (OK=53     KO=-     )
> response time 99th percentile                        139 (OK=139    KO=-     )
> mean requests/sec                                    <b>250</b> (OK=250    KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          5000 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
</pre>