### PR TITLE
 vscode/unpkg route broken for assets #573 

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
@@ -11,7 +11,6 @@ package org.eclipse.openvsx;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Consumer;
@@ -295,6 +294,7 @@ public class ExtensionProcessor implements AutoCloseable {
     public void processEachResource(ExtensionVersion extVersion, Consumer<FileResource> processor) {
         readInputStream();
         zipFile.stream()
+                .filter(zipEntry -> !zipEntry.isDirectory())
                 .map(zipEntry -> {
                     byte[] bytes;
                     try {

--- a/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
@@ -396,11 +396,16 @@ public class LocalVSCodeService implements IVSCodeService {
         var resources = repositories.findAllResourceFileResourceDTOs(extVersion.getId(), path);
         if(resources.isEmpty()) {
             throw new NotFoundException();
-        } else if(resources.size() == 1 && resources.get(0).getName().equals(path)) {
-            return browseFile(resources.get(0), namespaceName, extensionName, extVersion.getTargetPlatform(), version);
-        } else {
-            return browseDirectory(resources, namespaceName, extensionName, version, path);
         }
+
+        var exactMatch = resources.stream()
+                .filter(r -> r.getName().equals(path))
+                .findFirst()
+                .orElse(null);
+
+        return exactMatch != null
+                ? browseFile(exactMatch, namespaceName, extensionName, extVersion.getTargetPlatform(), version)
+                : browseDirectory(resources, namespaceName, extensionName, version, path);
     }
 
     private ResponseEntity<byte[]> browseFile(


### PR DESCRIPTION
Fixes #573
Return file if exact match is found
Exclude empty directory when processing resources