### PR TITLE
Sort by download count doesn't seem to be working correctly #560

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -611,7 +611,10 @@ public class LocalRegistryService implements IExtensionRegistry {
             }
         }
 
-        return new ArrayList<>(searchEntries.values());
+        return extensions.stream()
+                .map(Extension::getId)
+                .map(searchEntries::get)
+                .collect(Collectors.toList());
     }
 
     private List<SearchEntryJson.VersionReference> getAllVersionReferences(

--- a/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
@@ -24,6 +24,7 @@ import org.eclipse.openvsx.util.ErrorResultException;
 import org.eclipse.openvsx.util.TargetPlatform;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
@@ -304,23 +305,23 @@ public class ElasticSearchService implements ISearchService {
             throw new ErrorResultException("sortOrder parameter must be either 'asc' or 'desc'.");
         }
 
+        var sorts = new ArrayList<SortBuilder<?>>();
         if ("relevance".equals(sortBy)) {
-            queryBuilder.withSort(SortBuilders.scoreSort());
+            sorts.add(SortBuilders.scoreSort());
         }
 
         if ("relevance".equals(sortBy) || "averageRating".equals(sortBy)) {
-            queryBuilder.withSort(
-                    SortBuilders.fieldSort(sortBy).unmappedType("float").order(SortOrder.fromString(sortOrder)));
+            sorts.add(SortBuilders.fieldSort(sortBy).unmappedType("float").order(SortOrder.fromString(sortOrder)));
         } else if ("timestamp".equals(sortBy)) {
-            queryBuilder.withSort(
-                    SortBuilders.fieldSort(sortBy).unmappedType("long").order(SortOrder.fromString(sortOrder)));
+            sorts.add(SortBuilders.fieldSort(sortBy).unmappedType("long").order(SortOrder.fromString(sortOrder)));
         } else if ("downloadCount".equals(sortBy)) {
-            queryBuilder.withSort(
-                    SortBuilders.fieldSort(sortBy).unmappedType("integer").order(SortOrder.fromString(sortOrder)));
+            sorts.add(SortBuilders.fieldSort(sortBy).unmappedType("integer").order(SortOrder.fromString(sortOrder)));
         } else {
             throw new ErrorResultException(
                     "sortBy parameter must be 'relevance', 'timestamp', 'averageRating' or 'downloadCount'");
         }
+
+        queryBuilder.withSorts(sorts);
     }
 
     private long getMaxResultWindow() {


### PR DESCRIPTION
Fixes #560 
Fix search result ordering in LocalRegistryService.java
Remove usage of deprecated withSort method in ElasticSearchService.java

### Testing steps
- Open this PR in Gitpod, let the workspace initialize
- After all test extensions are published, stop the server
- Execute the `psql` command and update the extensions table:
```
UPDATE extension SET download_count = FLOOR(RANDOM() * 1000000 + 1);
```
- Then get extensions by download count:
```
SELECT n.name as namespace, e.name as extension, e.download_count
FROM extension e
JOIN namespace n ON n.id = e.namespace_id
ORDER BY e.download_count DESC;
```
- Restart the server
- Navigate to the Open VSX homepage
- Change the result order from `relevance` to `downloads`
- The result order must be equal to the SQL query