### PR TITLE
User extensions view lists duplicate extension values in user dashboard

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionRepository.java
@@ -9,6 +9,7 @@
  ********************************************************************************/
 package org.eclipse.openvsx.repositories;
 
+import org.eclipse.openvsx.entities.UserData;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.util.Streamable;
@@ -16,7 +17,6 @@ import org.springframework.data.util.Streamable;
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.Namespace;
 
-import java.time.LocalDateTime;
 import java.util.Collection;
 
 public interface ExtensionRepository extends Repository<Extension, Long> {
@@ -36,6 +36,8 @@ public interface ExtensionRepository extends Repository<Extension, Long> {
     Streamable<Extension> findByActiveTrue();
 
     Streamable<Extension> findByIdIn(Collection<Long> extensionIds);
+
+    Streamable<Extension> findDistinctByVersionsPublishedWithUser(UserData user);
 
     long count();
 

--- a/server/src/main/java/org/eclipse/openvsx/repositories/PersonalAccessTokenRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/PersonalAccessTokenRepository.java
@@ -18,6 +18,8 @@ public interface PersonalAccessTokenRepository extends Repository<PersonalAccess
 
     Streamable<PersonalAccessToken> findByUser(UserData user);
 
+    long countByUserAndActiveTrue(UserData user);
+
     PersonalAccessToken findById(long id);
 
     PersonalAccessToken findByValue(String value);

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -140,12 +140,8 @@ public class RepositoryService {
         return extension.getNamespace().getName() + "." + extension.getName();
     }
 
-    public Streamable<ExtensionVersion> findVersionsByUser(UserData user) {
-        return extensionVersionRepo.findByPublishedWithUser(user);
-    }
-
-    public Streamable<ExtensionVersion> findVersionsByAccessToken(PersonalAccessToken publishedWith) {
-        return extensionVersionRepo.findByPublishedWith(publishedWith);
+    public Streamable<Extension> findExtensions(UserData user) {
+        return extensionRepo.findDistinctByVersionsPublishedWithUser(user);
     }
 
     public Streamable<ExtensionVersion> findVersionsByAccessToken(PersonalAccessToken publishedWith, boolean active) {
@@ -246,6 +242,10 @@ public class RepositoryService {
 
     public Streamable<PersonalAccessToken> findAccessTokens(UserData user) {
         return tokenRepo.findByUser(user);
+    }
+
+    public long countActiveAccessTokens(UserData user) {
+        return tokenRepo.countByUserAndActiveTrue(user);
     }
 
     public PersonalAccessToken findAccessToken(String value) {

--- a/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/AdminAPITest.java
@@ -478,16 +478,16 @@ public class AdminAPITest {
         var user = new UserData();
         user.setLoginName("test");
         user.setProvider("github");
-        Mockito.when(repositories.findUserByLoginName("github", "test"))
-                .thenReturn(user);
+
         var token = new PersonalAccessToken();
         token.setUser(user);
         token.setActive(true);
-        Mockito.when(repositories.findAccessTokens(user))
-                .thenReturn(Streamable.of(token));
         versions.forEach(v -> v.setPublishedWith(token));
-        Mockito.when(repositories.findVersionsByAccessToken(token))
-                .thenReturn(Streamable.of(versions));
+
+        Mockito.when(repositories.findUserByLoginName("github", "test")).thenReturn(user);
+        Mockito.when(repositories.countActiveAccessTokens(user)).thenReturn(1L);
+        Mockito.when(repositories.findExtensions(user))
+                .thenReturn(Streamable.of(versions.get(0).getExtension()));
 
         mockMvc.perform(get("/admin/publisher/{provider}/{loginName}", "github", "test")
                 .with(user("admin_user").authorities(new SimpleGrantedAuthority(("ROLE_ADMIN"))))

--- a/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.eclipse.openvsx.cache.CacheService;
+import org.eclipse.openvsx.cache.LatestExtensionVersionCacheKeyGenerator;
+import org.eclipse.openvsx.cache.LatestExtensionVersionDTOCacheKeyGenerator;
 import org.eclipse.openvsx.eclipse.EclipseService;
 import org.eclipse.openvsx.entities.Namespace;
 import org.eclipse.openvsx.entities.NamespaceMembership;
@@ -42,6 +44,7 @@ import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.security.OAuth2UserServices;
 import org.eclipse.openvsx.security.TokenService;
 import org.eclipse.openvsx.storage.StorageUtilService;
+import org.eclipse.openvsx.util.VersionService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -552,6 +555,21 @@ public class UserAPITest {
         @Bean
         TokenService tokenService() {
             return new TokenService();
+        }
+
+        @Bean
+        VersionService versionService() {
+            return new VersionService();
+        }
+
+        @Bean
+        LatestExtensionVersionCacheKeyGenerator latestExtensionVersionCacheKeyGenerator() {
+            return new LatestExtensionVersionCacheKeyGenerator();
+        }
+
+        @Bean
+        LatestExtensionVersionDTOCacheKeyGenerator latestExtensionVersionDTOCacheKeyGenerator() {
+            return new LatestExtensionVersionDTOCacheKeyGenerator();
         }
     }
     

--- a/webui/src/pages/user/user-extension-list.tsx
+++ b/webui/src/pages/user/user-extension-list.tsx
@@ -35,8 +35,8 @@ export const UserExtensionList: FunctionComponent<UserExtensionListProps> = prop
             <DelayedLoadIndicator loading={props.loading} />
             {
                 props.extensions && props.extensions.length > 0 ?
-                props.extensions.map((extension: Extension, i: number) => <UserNamespaceExtensionListItem
-                    key={`${i}${extension.name}${extension.version}`}
+                props.extensions.map((extension: Extension) => <UserNamespaceExtensionListItem
+                    key={`${extension.namespace}.${extension.name}-${extension.version}`}
                     extension={extension}
                 />)
                 : null


### PR DESCRIPTION
Fixes #599
Fix duplicate extension values in user dashboard
Fix duplicate extension values in admin publisher dashboard

### Testing steps
- Stop the server.
- Assign the admin role to yourself: `UPDATE user_data SET role = 'admin' where login_name = <LOGIN_NAME>`.
- Restart the server.
- Publish multiple versions or multiple target platforms for the same extension.
- Navigate to `/user/extensions` in the webui.
- The extension you just published should only be displayed once.
- Navigate to `/admin-dashboard/publisher` and search for your login/publisher name.
- The extension you just published should only be displayed once.