### PR TITLE
Fix color of extension detail view links

### DIFF
--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -65,7 +65,7 @@ const overviewStyles = (theme: Theme) => createStyles({
     },
     link: {
         textDecoration: 'none',
-        color: theme.palette.primary.contrastText,
+        color: theme.palette.text.primary,
         '&:hover': {
             textDecoration: 'underline'
         }


### PR DESCRIPTION
Fixes #595
Found this bug on http://open-vsx.org, in which in neither dark or light mode the links are visible. This PR fixes that.

| Before | After |
|---|---|
| <img width="257" alt="image" src="https://user-images.githubusercontent.com/29888641/202705663-83cbb700-174b-4e59-a77d-37cf4402dc95.png"> | <img width="312" alt="image" src="https://user-images.githubusercontent.com/29888641/202705602-aea13a98-c83d-4301-a59f-703671f526e0.png"> |