### PR TITLE
Command to verify PAT

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint",
+        "redhat.java",
+        "vscjava.vscode-java-debug",
+        "vscjava.vscode-java-test",
+        "richardwillis.vscode-gradle"
+    ]
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,5 +12,6 @@ export * from './create-namespace';
 export * from './get';
 export * from './publish';
 export * from './registry';
+export * from './verify-pat';
 export { isLicenseOk } from './check-license';
 export { validateManifest, readManifest } from './util';

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -11,6 +11,7 @@
 import * as commander from 'commander';
 import * as leven from 'leven';
 import { createNamespace } from './create-namespace';
+import { verifyPat } from './verify-pat';
 import { publish } from './publish';
 import { handleError } from './util';
 import { getExtension } from './get';
@@ -30,6 +31,14 @@ module.exports = function (argv: string[]): void {
         .action((name: string) => {
             const { registryUrl, pat } = program.opts();
             createNamespace({ name, registryUrl, pat })
+                .catch(handleError(program.debug));
+        });
+
+    const verifyTokenCmd = program.command('verify-pat [namespace]');
+    verifyTokenCmd.description('Verify that a personal access token can publish to a namespace')
+        .action((namespace?: string) => {
+            const { registryUrl, pat } = program.opts();
+            verifyPat({ namespace, registryUrl, pat })
                 .catch(handleError(program.debug));
         });
 

--- a/cli/src/registry.ts
+++ b/cli/src/registry.ts
@@ -58,6 +58,15 @@ export class Registry {
         }
     }
 
+    verifyPat(namespace: string, pat: string): Promise<Response> {
+      try {
+          const query: { [key: string]: string } = { token: pat };
+          return this.getJson(this.getUrl(`api/${namespace}/verify-pat`, query));
+      } catch (err) {
+          return Promise.reject(err);
+      }
+    }
+
     publish(file: string, pat: string): Promise<Extension> {
         try {
             const query: { [key: string]: string } = { token: pat };

--- a/cli/src/verify-pat.ts
+++ b/cli/src/verify-pat.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 Anibal Solon
+ * Copyright (c) 2022 Anibal Solon and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/cli/src/verify-pat.ts
+++ b/cli/src/verify-pat.ts
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (c) 2022 Anibal Solon
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+import { Registry, RegistryOptions } from './registry';
+import { readManifest, addEnvOptions } from './util';
+
+/**
+ * Validates that a Personal Access Token can publish to a namespace.
+ */
+export async function verifyPat(options: VerifyPatOptions): Promise<void> {
+    addEnvOptions(options);
+    if (!options.pat) {
+        throw new Error("A personal access token must be given with the option '--pat'.");
+    }
+
+    if (!options.namespace) {
+      let error;
+      try {
+        options.namespace = (await readManifest()).publisher;
+      } catch (e) {
+        error = e;
+      }
+
+      if (!options.namespace) {
+        throw new Error(
+          `Unable to read the namespace's name. Please supply it as an argument or run ovsx from the extension folder.` +
+          (error ? `\n\n${error}` : '')
+        );
+      }
+    }
+
+    const registry = new Registry(options);
+    const result = await registry.verifyPat(options.namespace, options.pat);
+    if (result.error) {
+        throw new Error(result.error);
+    }
+    console.log(`\ud83d\ude80  PAT valid to publish at ${options.namespace}`);
+}
+
+export interface VerifyPatOptions extends RegistryOptions {
+    /**
+     * Name of the namespace.
+     */
+    namespace?: string
+}

--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -456,6 +456,25 @@ public class LocalRegistryService implements IExtensionRegistry {
         return ResultJson.success("Created namespace " + namespace.getName());
     }
 
+    public ResultJson verifyToken(String namespaceName, String tokenValue) {
+        var token = users.useAccessToken(tokenValue);
+        if (token == null) {
+            throw new ErrorResultException("Invalid access token.");
+        }
+
+        var namespace = repositories.findNamespace(namespaceName);
+        if (namespace == null) {
+            throw new NotFoundException();
+        }
+
+        var user = token.getUser();
+        if (!users.hasPublishPermission(user, namespace)) {
+            throw new ErrorResultException("Insufficient access rights for namespace: " + namespaceName);
+        }
+
+        return ResultJson.success("Valid token");
+    }
+
     @Retryable(value = { DataIntegrityViolationException.class })
     @Transactional(rollbackOn = ErrorResultException.class)
     public ExtensionJson publish(InputStream content, UserData user) throws ErrorResultException {

--- a/server/src/main/java/org/eclipse/openvsx/json/BadgeJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/BadgeJson.java
@@ -12,7 +12,8 @@ package org.eclipse.openvsx.json;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
-import io.swagger.v3.oas.annotations.media.Schema;;import java.io.Serializable;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
 import java.util.Objects;
 
 @Schema(

--- a/server/src/main/java/org/eclipse/openvsx/json/ExtensionReferenceJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/ExtensionReferenceJson.java
@@ -14,7 +14,8 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
-import io.swagger.v3.oas.annotations.media.Schema;;import java.io.Serializable;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
 import java.util.Objects;
 
 @Schema(


### PR DESCRIPTION
Fixes #313

As https://github.com/eclipse/openvsx/issues/313 I got myself needing to verify the PAT before doing other steps down the road (e.g bumping the extension version) in continuous delivery, that is a pain to rollback etc. 

This PR proposes:
- A command in the ovsx set, called `verify-pat`, in which validates that certain token 1) is valid and 2) has publish access to a namespace
```bash
ovsx verify-pat namespace --pat my_pat
```
- An endpoint to support the `verify-pat` command, checking in the local registry the user's permission. If not conforming, the endpoint waits 2s to reply (but I'm in doubt that this is really necessary and beneficial)- the API also has rate limits, so a brute force to try tokens would not be fruitful anyway.
- Tests to support the endpoint. I could not find tests for the CLI.

I've added the extensions used in Gitpod to the extensions recommendation for the vscode workspace, for local devs.