### PR TITLE
Follows redirects on HEAD and GET requests to proxy upstream requests

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/UpstreamProxyService.java
+++ b/server/src/main/java/org/eclipse/openvsx/UpstreamProxyService.java
@@ -1,0 +1,117 @@
+/********************************************************************************
+ * Copyright (c) 2022 Precies. Software and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx;
+
+import org.eclipse.openvsx.json.*;
+import org.eclipse.openvsx.util.UrlUtil;
+import org.elasticsearch.common.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@ConditionalOnProperty(value="ovsx.upstream.proxy.enabled", havingValue = "true")
+public class UpstreamProxyService {
+
+    protected final Logger logger = LoggerFactory.getLogger(UpstreamProxyService.class);
+
+    public NamespaceJson rewriteUrls(NamespaceJson json) {
+        rewriteUrlMap(json.extensions);
+        if(!Strings.isNullOrEmpty(json.membersUrl)) {
+            json.membersUrl = rewriteUrl(json.membersUrl);
+        }
+        if(!Strings.isNullOrEmpty(json.roleUrl)) {
+            json.roleUrl = rewriteUrl(json.roleUrl);
+        }
+
+        return json;
+    }
+
+    public ExtensionJson rewriteUrls(ExtensionJson json) {
+        json.namespaceUrl = rewriteUrl(json.namespaceUrl);
+        json.reviewsUrl = rewriteUrl(json.reviewsUrl);
+        rewriteUrlMap(json.files);
+        rewriteUrlMap(json.allVersions);
+        json.dependencies = rewriteUrlList(json.dependencies, this::rewriteUrls);
+        json.bundledExtensions = rewriteUrlList(json.bundledExtensions, this::rewriteUrls);
+        rewriteUrlMap(json.downloads);
+        return json;
+    }
+
+    public SearchResultJson rewriteUrls(SearchResultJson json) {
+        json.extensions = rewriteUrlList(json.extensions, this::rewriteUrls);
+        return json;
+    }
+
+    public QueryResultJson rewriteUrls(QueryResultJson json) {
+        json.extensions = rewriteUrlList(json.extensions, this::rewriteUrls);
+        return json;
+    }
+
+    private SearchEntryJson rewriteUrls(SearchEntryJson json) {
+        json.url = rewriteUrl(json.url);
+        rewriteUrlMap(json.files);
+        json.allVersions = rewriteUrlList(json.allVersions, this::rewriteUrls);
+
+        return json;
+    }
+
+    private SearchEntryJson.VersionReference rewriteUrls(SearchEntryJson.VersionReference json) {
+        json.url = rewriteUrl(json.url);
+        rewriteUrlMap(json.files);
+
+        return json;
+    }
+
+    private ExtensionReferenceJson rewriteUrls(ExtensionReferenceJson json) {
+        json.url = rewriteUrl(json.url);
+        return json;
+    }
+
+    private <T> List<T> rewriteUrlList(List<T> jsonList, Function<T,T> mapper) {
+        return jsonList != null ? jsonList.stream().map(mapper).collect(Collectors.toList()) : jsonList;
+    }
+
+    private void rewriteUrlMap(Map<String, String> map) {
+        if(map != null) {
+            for (var key : map.keySet()) {
+                map.put(key, rewriteUrl(map.get(key)));
+            }
+        }
+    }
+
+    private String rewriteUrl(String url) {
+        var baseUri = URI.create(UrlUtil.getBaseUrl());
+        var uri = URI.create(url);
+
+        var scheme = baseUri.getScheme();
+        var userInfo = baseUri.getUserInfo();
+        var host = baseUri.getHost();
+        var port = baseUri.getPort();
+        var path = uri.getPath();
+        var query = uri.getQuery();
+        var fragment = uri.getFragment();
+
+        try {
+            return new URI(scheme, userInfo, host, port, path, query, fragment).toString();
+        } catch (URISyntaxException e) {
+            logger.error("failed to rewrite URI: {}", uri);
+            return null;
+        }
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/adapter/UpstreamVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/UpstreamVSCodeService.java
@@ -205,7 +205,7 @@ public class UpstreamVSCodeService implements IVSCodeService {
         return new RestTemplate(new SimpleClientHttpRequestFactory() {
             @Override
             protected void prepareConnection(HttpURLConnection connection, String httpMethod ) {
-                connection.setInstanceFollowRedirects(false);
+                connection.setInstanceFollowRedirects(proxy != null);
             }
         });
     }


### PR DESCRIPTION
Fixes #452
Requires/Includes #460 
Modified `UpstreamRegistryService` und `UpstreamVSCodeService` ([diff to PR #460](https://github.com/eclipse/openvsx/commit/b85c0e129fc3715ed3beb9a9d707ef79e5341afe))

Testing steps
- Add to dev/application.properties:
```
ovsx:
  upstream:
    proxy:
      enabled: true
    url: https://open-vsx.org/
```
- Run the server
- Test the upstream endpoints
- Expected result: all redirects provided by open-vsx.org are followed
```
$ curl -I http://localhost:8080/api/GitLab/gitlab-workflow/3.56.0/file/GitLab.gitlab-workflow-3.56.0.vsix
HTTP/1.1 200 
X-Rate-Limit-Remaining: 14
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
Last-Modified: Tue, 08 Nov 2022 13:34:56 GMT
ETag: "0x8DAC18E0676CF5A"
Server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
x-ms-request-id: e7bd86f7-d01e-0043-2365-fea2ad000000
x-ms-version: 2009-09-19
x-ms-lease-status: unlocked
x-ms-blob-type: BlockBlob
Access-Control-Allow-Origin: *
Date: Tue, 22 Nov 2022 11:30:46 GMT
Content-Disposition: inline;filename=f.txt
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: application/octet-stream
Content-Length: 1389598
```