### PR TITLE
Search via UI omits second page of ten search results

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openvsx-webui",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "User interface for Eclipse Open VSX",
     "keywords": [
         "react",

--- a/webui/src/pages/extension-list/extension-list.tsx
+++ b/webui/src/pages/extension-list/extension-list.tsx
@@ -102,11 +102,7 @@ export class ExtensionListComponent extends React.Component<ExtensionListCompone
     }
 
     protected loadMore = async (p: number): Promise<void> => {
-        if (this.state.loading) {
-            return;
-        }
-
-        this.setState({ loading: true });
+        this.setState({ loading: true, hasMore: false });
         this.lastRequestedPage = p;
         const filter = copyFilter(this.state.appliedFilter);
         if (!isSameFilter(this.props.filter, filter)) {


### PR DESCRIPTION
Fixes #650
Fixes #608
Set `hasMore` to `false`, so that `loadMore` function isn't called while loading more results