### PR TITLE
Search should not be case sensitive

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -10,7 +10,7 @@ RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh \
     && sdk install java 18.0.1.1-open \
     && sdk install java 11.0.2-open"
 
-RUN curl https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.9.3-linux-x86_64.tar.gz --output elasticsearch-linux-x86_64.tar.gz \
+RUN curl https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.11.0-linux-x86_64.tar.gz --output elasticsearch-linux-x86_64.tar.gz \
     && tar -xzf elasticsearch-linux-x86_64.tar.gz \
     && rm elasticsearch-linux-x86_64.tar.gz
-ENV ES_HOME="$HOME/elasticsearch-7.9.3"
+ENV ES_HOME="$HOME/elasticsearch-7.11.0"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'nu.studer.jooq' version '6.0.1'
     id 'de.undercouch.download' version '4.1.1'
     id 'org.springframework.boot' version '2.7.0'
-    id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+    id 'io.spring.dependency-management' version '1.1.0'
     id 'io.gatling.gradle' version '3.6.1'
     id 'java'
 }

--- a/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
@@ -237,7 +237,7 @@ public class ElasticSearchService implements ISearchService {
         var queryBuilder = new NativeSearchQueryBuilder();
         var boolQuery = QueryBuilders.boolQuery();
         if (!Strings.isNullOrEmpty(options.queryString)) {
-            boolQuery.should(QueryBuilders.termQuery("extensionId.keyword", options.queryString)).boost(10);
+            boolQuery.should(QueryBuilders.termQuery("extensionId.keyword", options.queryString).caseInsensitive(true)).boost(10);
 
             // Fuzzy matching of search query in multiple fields
             var multiMatchQuery = QueryBuilders.multiMatchQuery(options.queryString)

--- a/server/src/test/java/org/eclipse/openvsx/TestSearchConfig.java
+++ b/server/src/test/java/org/eclipse/openvsx/TestSearchConfig.java
@@ -24,7 +24,7 @@ public class TestSearchConfig extends AbstractElasticsearchConfiguration {
     @Override
     @SuppressWarnings("resource")
     public RestHighLevelClient elasticsearchClient() {
-        var container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.9.3");
+        var container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.11.0");
         container.start();
         var config = ClientConfiguration.create(container.getHttpHostAddress());
         return RestClients.create(config).rest();


### PR DESCRIPTION
Fixes #651
Make extensionId field case insensitive
Update ElasticSearch to 7.11.0

### Testing steps
- Open this PR in Gitpod
- Search for `REDHAT.vscode-YaMl` using the webui, it should return the same result(s) as `redhat.vscode-yaml`.
- Try out different queries.
- Try out different ways of searching, e.g. using VSCode.