### PR TITLE
Corrupted metadata extension in some extensions regarding targetPlatform

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/migration/ExtractResourcesJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/ExtractResourcesJobRequestHandler.java
@@ -19,6 +19,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
+import java.nio.file.Files;
+
 @Component
 @ConditionalOnProperty(value = "ovsx.data.mirror.enabled", havingValue = "false", matchIfMissing = true)
 public class ExtractResourcesJobRequestHandler implements JobRequestHandler<MigrationJobRequest> {
@@ -50,5 +52,6 @@ public class ExtractResourcesJobRequestHandler implements JobRequestHandler<Migr
         }
 
         service.deleteWebResources(extVersion);
+        Files.delete(extensionFile);
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/migration/FixTargetPlatformsService.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/FixTargetPlatformsService.java
@@ -1,0 +1,40 @@
+/** ******************************************************************************
+ * Copyright (c) 2023 Precies. Software Ltd and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.migration;
+
+import org.eclipse.openvsx.entities.UserData;
+import org.eclipse.openvsx.repositories.RepositoryService;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+@Component
+public class FixTargetPlatformsService {
+
+    @Autowired
+    RepositoryService repositories;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Transactional
+    public UserData getUser() {
+        var userName = "FixTargetPlatformMigration";
+        var user = repositories.findUserByLoginName(null, userName);
+        if(user == null) {
+            user = new UserData();
+            user.setLoginName(userName);
+            entityManager.persist(user);
+        }
+        return user;
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationRunner.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationRunner.java
@@ -35,6 +35,7 @@ public class MigrationRunner implements JobRequestHandler<HandlerJobRequest<?>> 
         setPreReleaseMigration();
         renameDownloadsMigration();
         extractVsixManifestMigration();
+        fixTargetPlatformMigration();
     }
 
     private void extractResourcesMigration() {
@@ -59,5 +60,11 @@ public class MigrationRunner implements JobRequestHandler<HandlerJobRequest<?>> 
         var jobName = "ExtractVsixManifestMigration";
         var handler = ExtractVsixManifestsJobRequestHandler.class;
         repositories.findNotMigratedVsixManifests().forEach(item -> migrations.enqueueMigration(jobName, handler, item));
+    }
+
+    private void fixTargetPlatformMigration() {
+        var jobName = "FixTargetPlatformMigration";
+        var handler = FixTargetPlatformsJobRequestHandler.class;
+        repositories.findNotMigratedTargetPlatforms().forEach(item -> migrations.enqueueMigration(jobName, handler, item));
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/migration/RenameDownloadsJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/RenameDownloadsJobRequestHandler.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
+import java.nio.file.Files;
 import java.util.AbstractMap;
 
 @Component
@@ -48,6 +49,7 @@ public class RenameDownloadsJobRequestHandler  implements JobRequestHandler<Migr
 
         download.setName(name);
         service.updateResource(download);
+        Files.delete(extensionFile);
         logger.info("Updated download name to: {}", name);
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/migration/SetPreReleaseJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/SetPreReleaseJobRequestHandler.java
@@ -15,9 +15,13 @@ import org.jobrunr.jobs.lambdas.JobRequestHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
+import java.nio.file.Files;
+
 @Component
+@ConditionalOnProperty(value = "ovsx.data.mirror.enabled", havingValue = "false", matchIfMissing = true)
 public class SetPreReleaseJobRequestHandler implements JobRequestHandler<MigrationJobRequest> {
 
     protected final Logger logger = new JobRunrDashboardLogger(LoggerFactory.getLogger(ExtractResourcesJobRequestHandler.class));
@@ -33,6 +37,7 @@ public class SetPreReleaseJobRequestHandler implements JobRequestHandler<Migrati
             var entry = service.getDownload(extVersion);
             var extensionFile = service.getExtensionFile(entry);
             service.updatePreviewAndPreRelease(extVersion, extensionFile);
+            Files.delete(extensionFile);
         }
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -406,6 +406,10 @@ public class RepositoryService {
         return findNotMigratedItems("V1_32__FileResource_Extract_VsixManifest.sql");
     }
 
+    public Streamable<MigrationItem> findNotMigratedTargetPlatforms() {
+        return findNotMigratedItems("V1_34__ExtensionVersion_Fix_TargetPlatform.sql");
+    }
+
     private Streamable<MigrationItem> findNotMigratedItems(String migrationScript) {
         return migrationItemRepo.findByMigrationScriptAndMigrationScheduledFalseOrderById(migrationScript);
     }

--- a/server/src/main/resources/db/migration/V1_34__ExtensionVersion_Fix_TargetPlatform.sql
+++ b/server/src/main/resources/db/migration/V1_34__ExtensionVersion_Fix_TargetPlatform.sql
@@ -1,0 +1,7 @@
+INSERT INTO migration_item(id, migration_script, entity_id, migration_scheduled)
+SELECT nextval('hibernate_sequence'), 'V1_34__ExtensionVersion_Fix_TargetPlatform.sql', fr.id, FALSE
+FROM file_resource fr
+JOIN extension_version ev ON ev.id = fr.extension_id
+JOIN extension e ON e.id = ev.extension_id
+WHERE fr.type = 'download' AND ev.target_platform = 'universal'
+ORDER BY e.download_count DESC;

--- a/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
@@ -147,6 +147,7 @@ class RepositoryServiceSmokeTest {
                 () -> repositories.findNotMigratedPreReleases(),
                 () -> repositories.findNotMigratedRenamedDownloads(),
                 () -> repositories.findNotMigratedVsixManifests(),
+                () -> repositories.findNotMigratedTargetPlatforms(),
                 () -> repositories.topMostActivePublishingUsers(NOW, 1),
                 () -> repositories.topNamespaceExtensions(NOW, 1),
                 () -> repositories.topNamespaceExtensionVersions(NOW, 1),


### PR DESCRIPTION
Fixes #580 
Added FixTargetPlatformMigration
Remove extensionFile at end of a migration
Don't run migrations in mirror mode

### Testing steps
- Open this PR in Gitpod, let the workspace initialize
- Stop the server
- using the `psql` command, execute:
```
SELECT n.name, e.name, ev.version, ev.target_platform
FROM extension_version ev
JOIN extension e ON e.id = ev.extension_id
JOIN namespace n ON n.id = e.namespace_id
WHERE ev.target_platform <> 'universal';
```
- copy-paste the output to a file
- then set all target platforms to 'universal' using the `psql` command:
```
UPDATE extension_version SET target_platform = 'universal';
```
- and execute the 1.34 migration script:
```
INSERT INTO migration_item(id, migration_script, entity_id, migration_scheduled)
SELECT nextval('hibernate_sequence'), 'V1_34__ExtensionVersion_Fix_TargetPlatform.sql', fr.id, FALSE
FROM file_resource fr
JOIN extension_version ev ON ev.id = fr.extension_id
JOIN extension e ON e.id = ev.extension_id
WHERE fr.type = 'download' AND ev.target_platform = 'universal'
ORDER BY e.download_count DESC;
```
- restart the server
- the extensions migrated by the server should match the copy-pasted output.