### PR TITLE
Log query string too

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/web/LongRunningRequestFilter.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/LongRunningRequestFilter.java
@@ -61,8 +61,13 @@ public class LongRunningRequestFilter extends OncePerRequestFilter {
         builder.append("\n\t")
                 .append(request.getMethod())
                 .append(" | ")
-                .append(request.getRequestURI())
-                .append(" took ")
+                .append(request.getRequestURI());
+
+        if(request.getQueryString() != null) {
+            builder.append('?').append(request.getQueryString());
+        }
+
+        builder.append(" took ")
                 .append(millis)
                 .append(" ms.\n\t");
 


### PR DESCRIPTION
Log query string too for long running requests