### PR TITLE
fix docs: only use straight quotes

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -14,12 +14,12 @@ To get started quickly, it is recommended to use Gitpod as default with the deve
 
 - Make sure the firewall is not blocking internet access on WSL2 - need to check every time before running the application or installing new tools.
 
-  - Try to ping a random website, for example, “ping -c 3 [www.google.ca](http://www.google.ca)”, if fails, proceed below
+  - Try to ping a random website, for example, "ping -c 3 [www.google.ca](http://www.google.ca)", if fails, proceed below
   - sudo vi /etc/resolv.conf
   - Change nameserver to 8.8.8.8
   - Ping google again to see if it works this time
   - Related issue: [https://github.com/microsoft/WSL/issues/3669](https://github.com/microsoft/WSL/issues/3669)
-  - Solution that I’m following: [https://stackoverflow.com/questions/60269422/windows10-wsl2-ubuntu-debian-no-network](https://stackoverflow.com/questions/60269422/windows10-wsl2-ubuntu-debian-no-network)
+  - Solution that I'm following: [https://stackoverflow.com/questions/60269422/windows10-wsl2-ubuntu-debian-no-network](https://stackoverflow.com/questions/60269422/windows10-wsl2-ubuntu-debian-no-network)
 
 - clone the repository from github
 - set up vscode on WSL
@@ -33,7 +33,7 @@ To get started quickly, it is recommended to use Gitpod as default with the deve
   - sudo service postgresql start
   - sudo service postgresql status (this is to check if the service is really on)
   - sudo -u postgres psql (connect to the postgres service)
-    - CREATE ROLE gitpod with LOGIN PASSWORD ‘gitpod’;
+    - CREATE ROLE gitpod with LOGIN PASSWORD 'gitpod';
   - [https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-database](https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-database)
 
 - Install node.js using nvm
@@ -52,7 +52,7 @@ To get started quickly, it is recommended to use Gitpod as default with the deve
 - Instal Elasticsearch with Docker
 
   - sudo docker pull elasticsearch:7.9.3
-  - sudo docker run -d -name elasticsearch -p 9200:9200 -p 9300:9300 -e “discovery.type=single-node” elasticsearch:7.9.3
+  - sudo docker run -d -name elasticsearch -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" elasticsearch:7.9.3
 
 - cd cli
 

--- a/server/src/dev/resources/static/documents/publisher-agreement.md
+++ b/server/src/dev/resources/static/documents/publisher-agreement.md
@@ -2,47 +2,47 @@
 
 # Open VSX Publisher Agreement
 
-Thank you for your interest in publishing in the Eclipse Open VSX Registry (“Open VSX”). As used in this Eclipse Open VSX Publisher Agreement (“Agreement”), the term “you”, ”your” or “Publisher” refers to you as an individual, and, to the extent you are the agent or employee of another person or entity that has rights in the Offering (as defined below) (such person or entity, a “Principal”) “you” and “publisher” also includes that Principal.
+Thank you for your interest in publishing in the Eclipse Open VSX Registry ("Open VSX"). As used in this Eclipse Open VSX Publisher Agreement ("Agreement"), the term "you", "your" or "Publisher" refers to you as an individual, and, to the extent you are the agent or employee of another person or entity that has rights in the Offering (as defined below) (such person or entity, a "Principal") "you" and "publisher" also includes that Principal.
 
-This Agreement describes the relationship between you and the Eclipse Foundation, Inc. (“Eclipse”, “us” or “we”) and governs your publication of any Offering (as defined below) within the Registry (as defined below).
+This Agreement describes the relationship between you and the Eclipse Foundation, Inc. ("Eclipse", "us" or "we") and governs your publication of any Offering (as defined below) within the Registry (as defined below).
 
 By clicking where indicated to accept this Agreement, the individual entering into this Agreement represents and warrants to Eclipse that such individual has the authority to enter into this Agreement (including on behalf of his or her Principal), and you (including such individual and any Principal) agree to be bound by its terms.
 
 ## SECTION 1 Definitions.
 
-a. **“Code Content”** shall have the meaning set forth in the [Eclipse Intellectual Property Policy](https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf).
+a. **"Code Content"** shall have the meaning set forth in the [Eclipse Intellectual Property Policy](https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf).
 
-b. **“Content”** shall have the meaning set forth in the [Eclipse Intellectual Property Policy](https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf).
+b. **"Content"** shall have the meaning set forth in the [Eclipse Intellectual Property Policy](https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf).
 
-c. **“Listing Information”** means: (i) the information and images accompanying an Offering that identifies the original source of the Offering, as well as the nature and other features of the Offering, as specified by you in connection with your request to publish the Offering; and (ii) to the extent applicable, Data Information (as defined herein).
+c. **"Listing Information"** means: (i) the information and images accompanying an Offering that identifies the original source of the Offering, as well as the nature and other features of the Offering, as specified by you in connection with your request to publish the Offering; and (ii) to the extent applicable, Data Information (as defined herein).
 
-d. **“Non-Code Content”** shall have the meaning set forth in the [Eclipse Intellectual Property Policy](https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf).
+d. **"Non-Code Content"** shall have the meaning set forth in the [Eclipse Intellectual Property Policy](https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf).
 
-e. **“Offering”** means any software, data, media, documentation, etc. published or proposed to be published in the Registry under this Agreement.
+e. **"Offering"** means any software, data, media, documentation, etc. published or proposed to be published in the Registry under this Agreement.
 
-f. **“Offering Contents”** means all data and software included within, installable by, or otherwise associated with an Offering. Offering Contents include, without limitation, all operating system and application software associated with an Offering.
+f. **"Offering Contents"** means all data and software included within, installable by, or otherwise associated with an Offering. Offering Contents include, without limitation, all operating system and application software associated with an Offering.
 
-g. **“Publisher Account”** means a publisher account for Open VSX, which includes a username and password.
+g. **"Publisher Account"** means a publisher account for Open VSX, which includes a username and password.
 
-h. **“Registry”** means a limited, Eclipse Hosted repository of Offerings published to [Open VSX](https://open-vsx.org/).
+h. **"Registry"** means a limited, Eclipse Hosted repository of Offerings published to [Open VSX](https://open-vsx.org/).
 
-i. **“Terms of Use”** means the [Eclipse.org Terms of Use](https://www.eclipse.org/legal/termsofuse.php), the legal terms under which you grant others the right to use or access your Offering, as well as all Offering Contents associated therewith, as specified in the Listing Information associated with your Offering.
+i. **"Terms of Use"** means the [Eclipse.org Terms of Use](https://www.eclipse.org/legal/termsofuse.php), the legal terms under which you grant others the right to use or access your Offering, as well as all Offering Contents associated therewith, as specified in the Listing Information associated with your Offering.
 
 j. All other capitalized terms that are not defined in this Section 1 shall have the meanings assigned in the text of this Agreement.
 
 ## SECTION 2 Publisher Account.
 
-Your Publisher Account is only for your use, and you are responsible for all activity that takes place within your Publisher Account. If you fail to keep your Publisher Account in good standing (for example by providing incorrect or outdated information, by engaging in dishonest or fraudulent activity, or by repeatedly submitting Offerings that violate this Agreement, abuse the Registry or interfere with any other party’s use of the Registry), we may revoke your Publisher Account, remove your Offerings from the Registry, delete Offering ratings and reviews, and pursue any other remedies available to us.
+Your Publisher Account is only for your use, and you are responsible for all activity that takes place within your Publisher Account. If you fail to keep your Publisher Account in good standing (for example by providing incorrect or outdated information, by engaging in dishonest or fraudulent activity, or by repeatedly submitting Offerings that violate this Agreement, abuse the Registry or interfere with any other party's use of the Registry), we may revoke your Publisher Account, remove your Offerings from the Registry, delete Offering ratings and reviews, and pursue any other remedies available to us.
 
 ## SECTION 3 Submission, Approval, and Publication of Offerings.
 
-a. **Submission Process.** You must submit a request for each Offering that you wish to publish in the Registry. We may approve or reject any proposed Offering in our sole discretion, and may condition our approval on your making modifications to the Offering or its Listing Information. You are responsible for ensuring that the Listing Information associated with your Offering is accurate and not misleading and does not violate third parties’ intellectual property rights, including third-party trademarks or icons. We may require you to provide us with one or more Offering prototypes. Following our approval of an Offering, you may publish the Offering in the Registry, subject to the terms and conditions of this Agreement and the Listing Information provided with your request. Publications of any Offering in the Registry is subject to this agreement being executed and being in effect at the time of publication.
+a. **Submission Process.** You must submit a request for each Offering that you wish to publish in the Registry. We may approve or reject any proposed Offering in our sole discretion, and may condition our approval on your making modifications to the Offering or its Listing Information. You are responsible for ensuring that the Listing Information associated with your Offering is accurate and not misleading and does not violate third parties' intellectual property rights, including third-party trademarks or icons. We may require you to provide us with one or more Offering prototypes. Following our approval of an Offering, you may publish the Offering in the Registry, subject to the terms and conditions of this Agreement and the Listing Information provided with your request. Publications of any Offering in the Registry is subject to this agreement being executed and being in effect at the time of publication.
 
 b. **Presentation of Offerings.** We reserve the right to determine the manner in which all Offerings, whether published by you or others, are presented and promoted in the Registry. We may display your Listing Information in connection with your Offering, as well as other information designed to inform that the Offering is provided by you, including what content is included within the Offering. Notwithstanding our approval of an Offering as described in Section 3(a) above, we, in our sole discretion may determine not to make an Offering available in the Registry.
 
-c. **Ratings and Reviews.** You understand that as part of the Registry, we may make available a facility for third parties to post ratings and reviews on your Offering (“Reviews”). You understand that while we may (but are not obligated to) exercise traditional editorial functions associated with such Reviews, we have no obligation to, and shall not be, reviewing, vetting, or otherwise examining such Reviews and have no obligation to remove Reviews that may be unfavorable to your Offering.
+c. **Ratings and Reviews.** You understand that as part of the Registry, we may make available a facility for third parties to post ratings and reviews on your Offering ("Reviews"). You understand that while we may (but are not obligated to) exercise traditional editorial functions associated with such Reviews, we have no obligation to, and shall not be, reviewing, vetting, or otherwise examining such Reviews and have no obligation to remove Reviews that may be unfavorable to your Offering.
 
-d. **Terms for Publisher Marks.** You hereby grant us a non-exclusive, royalty-free, personal license to display the trademarks and logos associated with the Offering (“Publisher Marks”), as provided to us in connection with the marketing and promotion of your Offerings in the Registry. You represent and warrant that you are the owner and/or authorized licensor of the Publisher Marks. As between the parties, all goodwill associated with the Publisher Marks shall inure to your benefit. We may reformat or resize Publisher Marks as necessary and without altering the overall appearance of the Publisher Marks.
+d. **Terms for Publisher Marks.** You hereby grant us a non-exclusive, royalty-free, personal license to display the trademarks and logos associated with the Offering ("Publisher Marks"), as provided to us in connection with the marketing and promotion of your Offerings in the Registry. You represent and warrant that you are the owner and/or authorized licensor of the Publisher Marks. As between the parties, all goodwill associated with the Publisher Marks shall inure to your benefit. We may reformat or resize Publisher Marks as necessary and without altering the overall appearance of the Publisher Marks.
 
 e. **No Compensation.** You expressly acknowledge that neither Eclipse nor any licensee or end-user of any of your Offerings published on the Registry shall be required to provide you with any compensation for the distribution or use of your Offering as made available on the Registry.
 
@@ -56,7 +56,7 @@ c. **Enforcement/Monitoring.** We are not responsible for monitoring the use of 
 
 ## SECTION 5 Privacy and Data Protection.
 
-To the extent that you collect any data regarding the use of your Offering, including without limitation any information regarding the licensee or end-user of the Offering, you shall disclose in your Listing Information for the Offering a full and complete description of what data you collect, for what purposes it is used, with whom it is shared and how long it is retained (“Data Information”). Without limitation of the foregoing, you agree to comply with all applicable data protection and privacy laws, regulations and ordinances relevant to the use of your Offering.
+To the extent that you collect any data regarding the use of your Offering, including without limitation any information regarding the licensee or end-user of the Offering, you shall disclose in your Listing Information for the Offering a full and complete description of what data you collect, for what purposes it is used, with whom it is shared and how long it is retained ("Data Information"). Without limitation of the foregoing, you agree to comply with all applicable data protection and privacy laws, regulations and ordinances relevant to the use of your Offering.
 
 ## SECTION 6 Removal of Offerings.
 
@@ -86,11 +86,11 @@ a. **DISCLAIMER OF WARRANTY.** WE PROVIDE THE REGISTRY "AS-IS," "WITH ALL FAULTS
 b. **Limitation of Liability.** TO THE EXTENT PERMITTED BY APPLICABLE LAW, ECLIPSE SHALL NOT HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE OFFERING OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGES.
 
-c. **Duty to Defend.** You agree to defend, indemnify, and hold harmless us, Eclipse members, agents, officers, directors and employees as applicable, from and against any costs, losses, damages, liabilities or expenses and attorneys’ fees arising from any and all third-party claims alleging that your Offering, including any Listing Information, infringes any proprietary or personal right of a third party; or arising from any dispute between you and a licensee or End User of your Offering, relating to your Offering.
+c. **Duty to Defend.** You agree to defend, indemnify, and hold harmless us, Eclipse members, agents, officers, directors and employees as applicable, from and against any costs, losses, damages, liabilities or expenses and attorneys' fees arising from any and all third-party claims alleging that your Offering, including any Listing Information, infringes any proprietary or personal right of a third party; or arising from any dispute between you and a licensee or End User of your Offering, relating to your Offering.
 
 ## SECTION 9 Term and Termination.
 
-a. **General.** This Agreement will remain in effect until terminated. Either party may terminate this Agreement at any time, for any reason or no reason, upon thirty (30) days’ written notice and removal of all of your Offerings from the Registry.
+a. **General.** This Agreement will remain in effect until terminated. Either party may terminate this Agreement at any time, for any reason or no reason, upon thirty (30) days' written notice and removal of all of your Offerings from the Registry.
 
 b. **Effect of Termination.** Sections of this Agreement that, by their terms, require performance or establish rights or protections after the termination or expiration of this Agreement will survive.
 
@@ -104,11 +104,11 @@ c. **Jurisdiction and Governing Law.** This Agreement will be governed by the la
 
 d. **Responding to Claims.** If we receive a claim from a third party requesting that your Offering be changed or removed, we may refer that claim to you. If you believe that your Offering may be in violation of the terms of this Agreement, you must immediately notify us and work with us to cure the violation.
 
-e. **Waiver.** Either party’s delay or failure to exercise any right or remedy will not result in a waiver of that or any other right or remedy
+e. **Waiver.** Either party's delay or failure to exercise any right or remedy will not result in a waiver of that or any other right or remedy
 
 f. **Severability.** If any court of competent jurisdiction determines that any provision of this Agreement is illegal, invalid, or unenforceable, the remaining provisions will remain in full force and effect.
 
-g. **Assignment.** Except as provided for below in this paragraph, neither party may assign this Agreement (or any rights or duties under it) without the other party’s prior written consent, provided that either party may assign this Agreement without the other party’s consent in connection with a merger, acquisition, or sale or transfer of all or substantially all of its assets, excepting that Eclipse may assign this agreement to any entity that serves as a successor steward to the Registry. Either party who assigns this Agreement as permitted in this Section 10(g) shall provide the other party with prompt notice of such assignment. Subject to the foregoing, this Agreement will be binding upon and inure to the benefit of the parties and their permitted successors and assigns.
+g. **Assignment.** Except as provided for below in this paragraph, neither party may assign this Agreement (or any rights or duties under it) without the other party's prior written consent, provided that either party may assign this Agreement without the other party's consent in connection with a merger, acquisition, or sale or transfer of all or substantially all of its assets, excepting that Eclipse may assign this agreement to any entity that serves as a successor steward to the Registry. Either party who assigns this Agreement as permitted in this Section 10(g) shall provide the other party with prompt notice of such assignment. Subject to the foregoing, this Agreement will be binding upon and inure to the benefit of the parties and their permitted successors and assigns.
 
 h. **English Language.** The parties intend for this Agreement to be written and interpreted solely in English. Any notices required or provided under this Agreement will be in English. In the event of any conflict between the English version of this Agreement or any notices and a translation of the same, the English version will prevail.
 


### PR DESCRIPTION
Currently copy-pasting some commands with smart quotes results in errors.
Replace all the smart quotes with straight quotes for consistency.

Signed-off-by: David Xia <david@davidxia.com>

