### PR TITLE
Download count update partition ElasticSearch search entries update

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/migration/OrphanNamespaceMigration.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/OrphanNamespaceMigration.java
@@ -9,20 +9,17 @@
  ********************************************************************************/
 package org.eclipse.openvsx.migration;
 
-import java.util.LinkedHashSet;
-
-import javax.persistence.EntityManager;
-import javax.transaction.Transactional;
-
 import org.eclipse.openvsx.entities.NamespaceMembership;
 import org.eclipse.openvsx.entities.UserData;
 import org.eclipse.openvsx.repositories.RepositoryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.event.ApplicationStartedEvent;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import java.util.LinkedHashSet;
 
 @Component
 public class OrphanNamespaceMigration {
@@ -35,6 +32,7 @@ public class OrphanNamespaceMigration {
     @Autowired
     RepositoryService repositories;
 
+    @Transactional
     public void fixOrphanNamespaces() {
         int[] count = new int[3];
         repositories.findOrphanNamespaces().forEach(namespace -> {

--- a/server/src/main/java/org/eclipse/openvsx/search/DatabaseSearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/DatabaseSearchService.java
@@ -19,6 +19,7 @@ import org.eclipse.openvsx.util.VersionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.elasticsearch.core.*;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.repositories.RepositoryService;
@@ -157,6 +158,13 @@ public class DatabaseSearchService implements ISearchService {
     @Override
     @CacheEvict(value = CACHE_DATABASE_SEARCH, allEntries = true)
     public void updateSearchIndex(boolean clear) {
+
+    }
+
+    @Override
+    @Async
+    @CacheEvict(value = CACHE_DATABASE_SEARCH, allEntries = true)
+    public void updateSearchEntriesAsync(List<Extension> extensions) {
 
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/search/ISearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/ISearchService.java
@@ -44,6 +44,8 @@ public interface ISearchService {
      */
     void updateSearchEntries(List<Extension> extensions);
 
+    void updateSearchEntriesAsync(List<Extension> extensions);
+
     /**
      * The given extension has been added to the registry, we need to refresh the search index.
      */

--- a/server/src/main/java/org/eclipse/openvsx/search/SearchUtilService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/SearchUtilService.java
@@ -68,6 +68,11 @@ public class SearchUtilService implements ISearchService {
     }
 
     @Override
+    public void updateSearchEntriesAsync(List<Extension> extensions) {
+        getImplementation().updateSearchEntriesAsync(extensions);
+    }
+
+    @Override
     public void updateSearchEntry(Extension extension) {
         getImplementation().updateSearchEntry(extension);
     }


### PR DESCRIPTION
Fixes #707 
Decreased transaction scope by creating `RelevanceService.toSearchEntryTrxn`
Added `updateSearchEntriesAsync` to do multiple concurrent index queries.