### PR TITLE
fix search icon contrast issues

### DIFF
--- a/webui/src/main.tsx
+++ b/webui/src/main.tsx
@@ -222,9 +222,7 @@ class MainComponent extends React.Component<MainComponent.Props, MainComponent.S
                             <Switch>
                                 <Route exact path={[ExtensionListRoutes.MAIN]}
                                     render={routeProps =>
-                                        <ExtensionListContainer
-                                            {...routeProps}
-                                        />
+                                        <ExtensionListContainer {...routeProps} />
                                     } />
                                 <Route path={UserSettingsRoutes.MAIN}
                                     render={routeProps =>

--- a/webui/src/pages/extension-list/extension-list-searchfield.tsx
+++ b/webui/src/pages/extension-list/extension-list-searchfield.tsx
@@ -8,9 +8,10 @@
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useContext } from 'react';
 import SearchIcon from '@material-ui/icons/Search';
 import { Paper, IconButton, makeStyles, InputBase } from '@material-ui/core';
+import { MainContext } from '../../context';
 
 const useStyles = makeStyles((theme) => ({
     search: {
@@ -35,6 +36,12 @@ const useStyles = makeStyles((theme) => ({
             filter: 'invert(100%)',
         }
     },
+    searchIconLight: {
+        color: '#ffffff',
+    },
+    searchIconDark: {
+        color: '#111111',
+    },
     error: {
         border: `2px solid ${theme.palette.error.main}`
     }
@@ -53,6 +60,8 @@ interface ExtensionListSearchfieldProps {
 export const ExtensionListSearchfield: FunctionComponent<ExtensionListSearchfieldProps> = props => {
     const classes = useStyles();
 
+    const { pageSettings } = useContext(MainContext);
+
     const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         props.onSearchChanged(event.target.value);
     };
@@ -62,6 +71,8 @@ export const ExtensionListSearchfield: FunctionComponent<ExtensionListSearchfiel
             props.onSearchSubmit(props.searchQuery || '');
         }
     };
+
+    const searchIconClass = pageSettings?.themeType === 'dark' ? classes.searchIconDark : classes.searchIconLight;
 
     return (<>
         <Paper className={classes.search} classes={{ root: props.error ? classes.error : '' }}>
@@ -88,7 +99,7 @@ export const ExtensionListSearchfield: FunctionComponent<ExtensionListSearchfiel
             {
                 props.hideIconButton ? '' :
                     <IconButton color='primary' aria-label='Search' classes={{ root: classes.iconButton }} onClick={handleSearchButtonClick}>
-                        <SearchIcon />
+                        <SearchIcon classes={{ root: searchIconClass }} />
                     </IconButton>
             }
         </Paper>


### PR DESCRIPTION
fix #660 
I modified the theme colour of the search icon, now it looks like this:
|          | light mode  | dark mode |
| ------------- | ------------- | ------------- |
unhovered | <img width="859" alt="image" src="https://user-images.githubusercontent.com/108029327/234316510-d039f627-e5ed-4448-88f9-47b291b9527a.png">  | <img width="847" alt="image" src="https://user-images.githubusercontent.com/108029327/234318089-35e24c22-e89e-4c22-9d4e-cab34fcf2ce5.png">  |
hovered | <img width="832" alt="image" src="https://user-images.githubusercontent.com/108029327/234317636-7bbd38c4-48fd-478f-ba04-ffb9ec1531c9.png"> | <img width="837" alt="image" src="https://user-images.githubusercontent.com/108029327/234318265-1a4ac6d5-3985-466d-b879-68db3b74e0ab.png">
  
