### PR TITLE
Add `semver` dependency to the `ovsx` package

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -41,6 +41,7 @@
         "follow-redirects": "^1.14.6",
         "is-ci": "^2.0.0",
         "leven": "^3.1.0",
+        "semver": "^5.1.0",
         "tmp": "^0.2.1"
     },
     "devDependencies": {


### PR DESCRIPTION
When trying to publish a package to open-vsx after installing `ovsx` via the command `npm i -g @vscode/vsce ovsx`, the package cannot seem to find the `semver` dependency. It's a transitive dependency from `@vscode/vsce` but explicitly used in the ovsx code.

This led to a failure in our deployment pipeline, see [here](https://github.com/langium/langium/actions/runs/4861701176/jobs/8667062213#step:7:45).

This PR adds the `semver` package explicitly, so that this issue doesn't occur anymore.