### PR TITLE
Update development documentation for elastic search

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -55,8 +55,8 @@ To get started quickly, it is recommended to use Gitpod as default with the deve
 
 - Install Elasticsearch with Docker
 
-  - sudo docker pull elasticsearch:7.9.3
-  - sudo docker run -d --name elasticsearch -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" elasticsearch:7.9.3
+  - sudo docker pull elasticsearch:8.7.1
+  - sudo docker run -d --name elasticsearch  -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -e "xpack.ml.enabled=false" -e "xpack.security.enabled=false" elasticsearch:8.7.1
 
 ### Setup locally on macOS
 


### PR DESCRIPTION
Update `doc/development.md` to match the settings of elastic search with the one for `gitpod` settings under `.gitpod.yml`.

Without these settings the `openvsx` server would exit with an exception as credentials for elastic search are missing.