### PR TITLE
Lower allVersions and default response size from 200 items to 100 items

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
@@ -1084,8 +1084,8 @@ public class RegistryAPI {
                 })
             )
             String targetPlatform,
-            @RequestParam(defaultValue = "200")
-            @Parameter(description = "Maximal number of entries to return", schema = @Schema(type = "integer", minimum = "0", defaultValue = "200"))
+            @RequestParam(defaultValue = "100")
+            @Parameter(description = "Maximal number of entries to return", schema = @Schema(type = "integer", minimum = "0", defaultValue = "100"))
             int size,
             @RequestParam(defaultValue = "0")
             @Parameter(description = "Number of entries to skip (usually a multiple of the page size)", schema = @Schema(type = "integer", minimum = "0", defaultValue = "0"))
@@ -1214,8 +1214,8 @@ public class RegistryAPI {
                 })
             )
             String targetPlatform,
-            @RequestParam(defaultValue = "200")
-            @Parameter(description = "Maximal number of entries to return", schema = @Schema(type = "integer", minimum = "0", defaultValue = "200"))
+            @RequestParam(defaultValue = "100")
+            @Parameter(description = "Maximal number of entries to return", schema = @Schema(type = "integer", minimum = "0", defaultValue = "100"))
             int size,
             @RequestParam(defaultValue = "0")
             @Parameter(description = "Number of entries to skip (usually a multiple of the page size)", schema = @Schema(type = "integer", minimum = "0", defaultValue = "0"))

--- a/server/src/main/java/org/eclipse/openvsx/json/ExtensionJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/ExtensionJson.java
@@ -86,7 +86,7 @@ public class ExtensionJson extends ResultJson implements Serializable {
     @Deprecated
     public String namespaceAccess;
 
-    @Schema(description = "Map of available versions to their metadata URLs. Deprecated: only returns the last 200 versions. Use allVersionsUrl instead.")
+    @Schema(description = "Map of available versions to their metadata URLs. Deprecated: only returns the last 100 versions. Use allVersionsUrl instead.")
     @Deprecated
     public Map<String, String> allVersions;
 

--- a/server/src/main/java/org/eclipse/openvsx/json/QueryParamJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/QueryParamJson.java
@@ -56,7 +56,7 @@ public class QueryParamJson {
     })
     public String targetPlatform;
 
-    @Schema(description = "Maximal number of entries to return", minimum = "0", defaultValue = "200")
+    @Schema(description = "Maximal number of entries to return", minimum = "0", defaultValue = "100")
     public Integer size;
 
     @Schema(description = "Number of entries to skip (usually a multiple of the page size)", minimum = "0", defaultValue = "0")

--- a/server/src/main/java/org/eclipse/openvsx/json/SearchEntryJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/SearchEntryJson.java
@@ -53,7 +53,7 @@ public class SearchEntryJson implements Serializable {
     @NotNull
     public String timestamp;
 
-    @Schema(description = "Essential metadata of all available versions. Deprecated: only returns the last 200 versions. Use allVersionsUrl instead.")
+    @Schema(description = "Essential metadata of all available versions. Deprecated: only returns the last 100 versions. Use allVersionsUrl instead.")
     @Deprecated
     public List<VersionReferenceJson> allVersions;
 

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -30,7 +30,7 @@ import static org.eclipse.openvsx.entities.FileResource.DOWNLOAD_SIG;
 @Component
 public class RepositoryService {
 
-    private static final int MAX_VERSIONS = 200;
+    private static final int MAX_VERSIONS = 100;
     private static final Sort VERSIONS_SORT = Sort.by(Sort.Direction.DESC, "semver.major", "semver.minor", "semver.patch")
             .and(Sort.by(Sort.Direction.ASC, "semver.isPreRelease"))
             .and(Sort.by(Sort.Direction.DESC, "universalTargetPlatform"))
@@ -138,11 +138,6 @@ public class RepositoryService {
 
     public Streamable<ExtensionVersion> findActiveVersions(Extension extension) {
          return extensionVersionRepo.findByExtensionAndActiveTrue(extension);
-    }
-
-    public List<ExtensionVersion> findActiveVersionsSorted(Extension extension) {
-        var page = PageRequest.ofSize(MAX_VERSIONS).withSort(VERSIONS_SORT);
-        return extensionVersionRepo.findByExtensionAndActiveTrue(extension, page);
     }
 
     public Page<ExtensionVersion> findActiveVersionsSorted(String namespace, String extension, PageRequest page) {

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -662,9 +662,9 @@ public class RegistryAPITest {
         var query = new QueryRequest();
         query.namespaceUuid = "1234";
         query.offset = 0;
-        query.size = 200;
+        query.size = 100;
         Mockito.when(repositories.findActiveVersions(query))
-                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(200), versions.size()));
+                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(100), versions.size()));
 
         mockMvc.perform(get("/api/-/query?namespaceUuid={namespaceUuid}", "1234"))
                 .andExpect(status().isOk())
@@ -772,9 +772,9 @@ public class RegistryAPITest {
         query.extensionName = "bar";
         query.includeAllVersions = true;
         query.offset = 0;
-        query.size = 200;
+        query.size = 100;
         Mockito.when(repositories.findActiveVersions(query))
-                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(200), versions.size()));
+                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(100), versions.size()));
 
         mockMvc.perform(get("/api/v2/-/query?extensionId={extensionId}&includeAllVersions={includeAllVersions}", "foo.bar", "true"))
                 .andExpect(status().isOk())
@@ -832,10 +832,10 @@ public class RegistryAPITest {
         query.extensionName = "bar";
         query.includeAllVersions = false;
         query.offset = 0;
-        query.size = 200;
+        query.size = 100;
         versions = versions.stream().filter(ev -> ev.getVersion().equals("3.0.0")).collect(Collectors.toList());
         Mockito.when(repositories.findActiveVersions(query))
-                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(200), versions.size()));
+                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(100), versions.size()));
 
         mockMvc.perform(get("/api/v2/-/query?extensionId={extensionId}&includeAllVersions={includeAllVersions}", "foo.bar", "false"))
                 .andExpect(status().isOk())
@@ -860,10 +860,10 @@ public class RegistryAPITest {
         query.extensionName = "bar";
         query.includeAllVersions = false;
         query.offset = 0;
-        query.size = 200;
+        query.size = 100;
         versions = versions.stream().filter(ev -> ev.getVersion().equals("3.0.0")).collect(Collectors.toList());
         Mockito.when(repositories.findActiveVersions(query))
-                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(200), versions.size()));
+                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(100), versions.size()));
 
         mockMvc.perform(get("/api/v2/-/query?extensionId={extensionId}&includeAllVersions={includeAllVersions}", "foo.bar", "links"))
                 .andExpect(status().isOk())
@@ -893,10 +893,10 @@ public class RegistryAPITest {
         query.extensionName = "bar";
         query.includeAllVersions = false;
         query.offset = 0;
-        query.size = 200;
+        query.size = 100;
         versions = versions.stream().filter(ev -> ev.getVersion().equals("2.0.0")).collect(Collectors.toList());
         Mockito.when(repositories.findActiveVersions(query))
-                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(200), versions.size()));
+                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(100), versions.size()));
 
         mockMvc.perform(get("/api/v2/-/query?extensionId={extensionId}&includeAllVersions={includeAllVersions}", "foo.bar", "links"))
                 .andExpect(status().isOk())
@@ -943,9 +943,9 @@ public class RegistryAPITest {
         query.targetPlatform = "linux-x64";
         query.includeAllVersions = true;
         query.offset = 0;
-        query.size = 200;
+        query.size = 100;
         Mockito.when(repositories.findActiveVersions(query))
-                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(200), versions.size()));
+                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(100), versions.size()));
 
         mockMvc.perform(get("/api/v2/-/query?extensionId={extensionId}&targetPlatform={targetPlatform}&includeAllVersions={includeAllVersions}", "foo.bar", "linux-x64", "true"))
                 .andExpect(status().isOk())
@@ -982,10 +982,10 @@ public class RegistryAPITest {
         query.extensionVersion = "2.0.0";
         query.includeAllVersions = false;
         query.offset = 0;
-        query.size = 200;
+        query.size = 100;
         versions = versions.stream().filter(ev -> ev.getVersion().equals("2.0.0")).collect(Collectors.toList());
         Mockito.when(repositories.findActiveVersions(query))
-                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(200), versions.size()));
+                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(100), versions.size()));
 
         mockMvc.perform(get("/api/v2/-/query?extensionId={extensionId}&extensionVersion={extensionVersion}&includeAllVersions={includeAllVersions}", "foo.bar", "2.0.0", "true"))
                 .andExpect(status().isOk())
@@ -1022,10 +1022,10 @@ public class RegistryAPITest {
         query.extensionVersion = "2.0.0";
         query.includeAllVersions = false;
         query.offset = 0;
-        query.size = 200;
+        query.size = 100;
         versions = versions.stream().filter(ev -> ev.getVersion().equals("2.0.0")).collect(Collectors.toList());
         Mockito.when(repositories.findActiveVersions(query))
-                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(200), versions.size()));
+                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(100), versions.size()));
 
         mockMvc.perform(get("/api/v2/-/query?extensionId={extensionId}&extensionVersion={extensionVersion}&includeAllVersions={includeAllVersions}", "foo.bar", "2.0.0", "false"))
                 .andExpect(status().isOk())
@@ -1050,10 +1050,10 @@ public class RegistryAPITest {
         query.extensionVersion = "2.0.0";
         query.includeAllVersions = false;
         query.offset = 0;
-        query.size = 200;
+        query.size = 100;
         versions = versions.stream().filter(ev -> ev.getVersion().equals("2.0.0")).collect(Collectors.toList());
         Mockito.when(repositories.findActiveVersions(query))
-                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(200), versions.size()));
+                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(100), versions.size()));
 
         mockMvc.perform(get("/api/v2/-/query?extensionId={extensionId}&extensionVersion={extensionVersion}&includeAllVersions={includeAllVersions}", "foo.bar", "2.0.0", "links"))
                 .andExpect(status().isOk())
@@ -1111,9 +1111,9 @@ public class RegistryAPITest {
         query.namespaceUuid = "1234";
         query.includeAllVersions = false;
         query.offset = 0;
-        query.size = 200;
+        query.size = 100;
         Mockito.when(repositories.findActiveVersions(query))
-                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(200), versions.size()));
+                .thenReturn(new PageImpl<>(versions, Pageable.ofSize(100), versions.size()));
 
         mockMvc.perform(get("/api/v2/-/query?namespaceUuid={namespaceUuid}", "1234"))
                 .andExpect(status().isOk())
@@ -1715,7 +1715,7 @@ public class RegistryAPITest {
         var request = new QueryRequest();
         request.namespaceName = namespaceName;
         request.extensionName = extensionName;
-        request.size = 200;
+        request.size = 100;
 
         Mockito.when(repositories.findActiveVersions(request))
                 .thenReturn(new PageImpl<>(Collections.emptyList(), Pageable.ofSize(request.size), 0));
@@ -1841,7 +1841,7 @@ public class RegistryAPITest {
                             ? List.of(extVersion)
                             : Collections.<ExtensionVersion>emptyList();
 
-                    return new PageImpl<>(versions, Pageable.ofSize(200), versions.size());
+                    return new PageImpl<>(versions, Pageable.ofSize(100), versions.size());
                 });
 
         var fileTypes = List.of(DOWNLOAD, MANIFEST, ICON, README, LICENSE, CHANGELOG);

--- a/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
@@ -176,7 +176,6 @@ class RepositoryServiceSmokeTest {
                 () -> repositories.findVersionsWithout(keyPair),
                 () -> repositories.deleteDownloadSigFiles(),
                 () -> repositories.deleteAllKeyPairs(),
-                () -> repositories.findActiveVersionsSorted(extension),
                 () -> repositories.findActiveVersionsSorted("namespaceName", "extensionName", PageRequest.ofSize(1)),
                 () -> repositories.findActiveVersionsSorted("namespaceName", "extensionName", "targetPlatform", PageRequest.ofSize(1)),
                 () -> repositories.findActiveVersionStringsSorted("namespaceName", "extensionName", PageRequest.ofSize(1)),


### PR DESCRIPTION
Fixes #795 
Lower amount of entries in `allVersions` map to 100. 
Change default size for `/api/-/query` and `/api/v2/-/query` to 100