### PR TITLE
server: refactor: introduce `AuthUser` interface

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/RegistryApplication.java
+++ b/server/src/main/java/org/eclipse/openvsx/RegistryApplication.java
@@ -12,11 +12,13 @@ package org.eclipse.openvsx;
 import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.eclipse.openvsx.mirror.ReadOnlyRequestFilter;
+import org.eclipse.openvsx.security.OAuth2AttributesConfig;
 import org.eclipse.openvsx.web.ShallowEtagHeaderFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -34,6 +36,7 @@ import org.springframework.security.web.firewall.RequestRejectedHandler;
 @EnableRetry
 @EnableAsync
 @EnableCaching(proxyTargetClass = true)
+@EnableConfigurationProperties(OAuth2AttributesConfig.class)
 public class RegistryApplication {
 
     public static void main(String[] args) {

--- a/server/src/main/java/org/eclipse/openvsx/json/LoginProvidersJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/LoginProvidersJson.java
@@ -1,0 +1,27 @@
+/** ******************************************************************************
+ * Copyright (c) 2025 Precies. Software OU and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.json;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LoginProvidersJson extends ResultJson {
+    private Map<String,String> loginProviders;
+
+    public Map<String, String> getLoginProviders() {
+        return loginProviders;
+    }
+
+    public void setLoginProviders(Map<String, String> loginProviders) {
+        this.loginProviders = loginProviders;
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/security/CodedAuthException.java
+++ b/server/src/main/java/org/eclipse/openvsx/security/CodedAuthException.java
@@ -21,22 +21,27 @@ public class CodedAuthException extends AuthenticationException {
 
     public static final String UNSUPPORTED_REGISTRATION = "unsupported-registration";
     public static final String INVALID_GITHUB_USER = "invalid-github-user";
+    public static final String INVALID_USER = "invalid-user";
     public static final String NEED_MAIN_LOGIN = "need-main-login";
     public static final String ECLIPSE_MISSING_GITHUB_ID = "eclipse-missing-github-id";
     public static final String ECLIPSE_MISMATCH_GITHUB_ID = "eclipse-mismatch-github-id";
 
     @Serial
     private static final long serialVersionUID = 1L;
-    
+
     private final String code;
 
-	public CodedAuthException(String message, String code) {
+    public CodedAuthException(String message, String code) {
         super(message);
         this.code = code;
     }
-    
+
+    public CodedAuthException(String message, String code, Throwable cause) {
+        super(message, cause);
+        this.code = code;
+    }
+
     public String getCode() {
-		return code;
-	}
-    
+        return code;
+    }
 }

--- a/server/src/main/java/org/eclipse/openvsx/security/OAuth2AttributesConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/security/OAuth2AttributesConfig.java
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (c) 2023 Ericsson and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.*;
+
+/**
+ * Configuration example:
+ * <pre><code>
+ *ovsx:
+ *  oauth2:
+ *    attribute-names:
+ *      [provider-name]:
+ *        avatar-url: string
+ *        email: string
+ *        full-name: string
+ *        login-name: string
+ *        provider-url: string
+ * </code></pre>
+ */
+@ConfigurationProperties(prefix = "ovsx.oauth2")
+public record OAuth2AttributesConfig(Map<String, OAuth2AttributesMapping> attributeNames) {
+    private static final Map<String, OAuth2AttributesMapping> DEFAULT_MAPPINGS = Map.of(
+            "github", new OAuth2AttributesMapping("avatar_url", "email", "name", "login", "html_url")
+    );
+
+    public OAuth2AttributesMapping getAttributeMapping(String provider) {
+        return Optional.ofNullable(attributeNames).map(a -> a.get(provider)).orElse(DEFAULT_MAPPINGS.get(provider));
+    }
+
+    public List<String> getProviders() {
+        var providers = new ArrayList<>(DEFAULT_MAPPINGS.keySet());
+        if(attributeNames != null) {
+            providers.addAll(attributeNames.keySet());
+        }
+
+        return providers;
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/security/OAuth2AttributesMapping.java
+++ b/server/src/main/java/org/eclipse/openvsx/security/OAuth2AttributesMapping.java
@@ -1,0 +1,43 @@
+/** ******************************************************************************
+ * Copyright (c) 2025 Precies. Software OU and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.security;
+
+import org.eclipse.openvsx.entities.UserData;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public record OAuth2AttributesMapping(
+        String avatarUrl,
+        String email,
+        String fullName,
+        String loginName,
+        String providerUrl
+) {
+
+    /**
+     * @param provider The configured OAuth2 provider from which the user object came from.
+     * @param oauth2User The OAuth2 user object to get attributes from.
+     * @return A {@link UserData} instance with attributes set according to the current configuration.
+     */
+    public UserData toUserData(String provider, OAuth2User oauth2User) {
+        var userData = new UserData();
+        userData.setAuthId(oauth2User.getName());
+        userData.setProvider(provider);
+        userData.setAvatarUrl(getAttribute(oauth2User, avatarUrl));
+        userData.setEmail(getAttribute(oauth2User, email));
+        userData.setFullName(getAttribute(oauth2User, fullName));
+        userData.setLoginName(getAttribute(oauth2User, loginName));
+        userData.setProviderUrl(getAttribute(oauth2User, providerUrl));
+        return userData;
+    }
+
+    private <T> T getAttribute(OAuth2User oauth2User, String attribute) {
+        return attribute == null ? null : oauth2User.getAttribute(attribute);
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/security/SecurityConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/security/SecurityConfig.java
@@ -10,13 +10,11 @@
 package org.eclipse.openvsx.security;
 
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -32,18 +30,11 @@ public class SecurityConfig {
     @Value("${ovsx.webui.frontendRoutes:/extension/**,/namespace/**,/user-settings/**,/admin-dashboard/**}")
     String[] frontendRoutes;
 
-    private final ClientRegistrationRepository clientRegistrationRepository;
-
-    @Autowired
-    public SecurityConfig(@Autowired(required = false) ClientRegistrationRepository clientRegistrationRepository) {
-        this.clientRegistrationRepository = clientRegistrationRepository;
-    }
-
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, OAuth2UserServices userServices) throws Exception {
         var filterChain = http.authorizeHttpRequests(
                 registry -> registry
-                        .requestMatchers(antMatchers("/*", "/login/**", "/oauth2/**", "/can-login", "/user", "/user/auth-error", "/logout", "/actuator/health/**", "/actuator/metrics", "/actuator/metrics/**", "/actuator/prometheus", "/v3/api-docs/**", "/swagger-resources/**", "/swagger-ui/**", "/webjars/**"))
+                        .requestMatchers(antMatchers("/*", "/login/**", "/oauth2/**", "/login-providers", "/user", "/user/auth-error", "/logout", "/actuator/health/**", "/actuator/metrics", "/actuator/metrics/**", "/actuator/prometheus", "/v3/api-docs/**", "/swagger-resources/**", "/swagger-ui/**", "/webjars/**"))
                             .permitAll()
                         .requestMatchers(antMatchers("/api/*/*/review", "/api/*/*/review/delete", "/api/user/publish", "/api/user/namespace/create"))
                             .authenticated()

--- a/server/src/main/java/org/eclipse/openvsx/web/WebConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/WebConfig.java
@@ -53,7 +53,7 @@ public class WebConfig implements WebMvcConfigurer {
                         .allowedOrigins(webuiUrl)
                         .allowCredentials(true);
             }
-            registry.addMapping("/can-login")
+            registry.addMapping("/login-providers")
                     .allowedOrigins(webuiUrl);
             registry.addMapping("/documents/**")
                     .allowedOrigins("*");

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -30,6 +30,7 @@ import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.search.ExtensionSearch;
 import org.eclipse.openvsx.search.ISearchService;
 import org.eclipse.openvsx.search.SearchUtilService;
+import org.eclipse.openvsx.security.OAuth2AttributesConfig;
 import org.eclipse.openvsx.security.OAuth2UserServices;
 import org.eclipse.openvsx.security.SecurityConfig;
 import org.eclipse.openvsx.storage.*;
@@ -2394,9 +2395,10 @@ class RegistryAPITest {
                 TokenService tokens,
                 RepositoryService repositories,
                 EntityManager entityManager,
-                EclipseService eclipse
+                EclipseService eclipse,
+                OAuth2AttributesConfig attributesConfig
         ) {
-            return new OAuth2UserServices(users, tokens, repositories, entityManager, eclipse);
+            return new OAuth2UserServices(users, tokens, repositories, entityManager, eclipse, attributesConfig);
         }
 
         @Bean

--- a/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
@@ -23,6 +23,7 @@ import org.eclipse.openvsx.entities.PersonalAccessToken;
 import org.eclipse.openvsx.entities.UserData;
 import org.eclipse.openvsx.json.*;
 import org.eclipse.openvsx.repositories.RepositoryService;
+import org.eclipse.openvsx.security.OAuth2AttributesConfig;
 import org.eclipse.openvsx.security.OAuth2UserServices;
 import org.eclipse.openvsx.security.SecurityConfig;
 import org.eclipse.openvsx.storage.StorageUtilService;
@@ -555,9 +556,10 @@ class UserAPITest {
                 TokenService tokens,
                 RepositoryService repositories,
                 EntityManager entityManager,
-                EclipseService eclipse
+                EclipseService eclipse,
+                OAuth2AttributesConfig attributesConfig
         ) {
-            return new OAuth2UserServices(users, tokens, repositories, entityManager, eclipse);
+            return new OAuth2UserServices(users, tokens, repositories, entityManager, eclipse, attributesConfig);
         }
 
         @Bean
@@ -574,5 +576,4 @@ class UserAPITest {
             return new LatestExtensionVersionCacheKeyGenerator();
         }
     }
-    
 }

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
@@ -16,6 +16,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.persistence.EntityManager;
 import org.eclipse.openvsx.ExtensionValidator;
 import org.eclipse.openvsx.MockTransactionTemplate;
+import org.eclipse.openvsx.security.OAuth2AttributesConfig;
 import org.eclipse.openvsx.UserService;
 import org.eclipse.openvsx.cache.CacheService;
 import org.eclipse.openvsx.cache.FilesCacheKeyGenerator;
@@ -872,9 +873,10 @@ class VSCodeAPITest {
                 TokenService tokens,
                 RepositoryService repositories,
                 EntityManager entityManager,
-                EclipseService eclipse
+                EclipseService eclipse,
+                OAuth2AttributesConfig attributesConfig
         ) {
-            return new OAuth2UserServices(users, tokens, repositories, entityManager, eclipse);
+            return new OAuth2UserServices(users, tokens, repositories, entityManager, eclipse, attributesConfig);
         }
 
         @Bean
@@ -916,9 +918,10 @@ class VSCodeAPITest {
                 StorageUtilService storageUtil,
                 CacheService cache,
                 ExtensionValidator validator,
-                ClientRegistrationRepository clientRegistrationRepository
+                ClientRegistrationRepository clientRegistrationRepository,
+                OAuth2AttributesConfig attributesConfig
         ) {
-            return new UserService(entityManager, repositories, storageUtil, cache, validator, clientRegistrationRepository);
+            return new UserService(entityManager, repositories, storageUtil, cache, validator, clientRegistrationRepository, attributesConfig);
         }
 
         @Bean
@@ -968,5 +971,4 @@ class VSCodeAPITest {
             return new FilesCacheKeyGenerator();
         }
     }
-
 }

--- a/server/src/test/java/org/eclipse/openvsx/admin/AdminAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/admin/AdminAPITest.java
@@ -25,6 +25,7 @@ import org.eclipse.openvsx.publish.ExtensionVersionIntegrityService;
 import org.eclipse.openvsx.publish.PublishExtensionVersionHandler;
 import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.search.SearchUtilService;
+import org.eclipse.openvsx.security.OAuth2AttributesConfig;
 import org.eclipse.openvsx.security.OAuth2UserServices;
 import org.eclipse.openvsx.security.SecurityConfig;
 import org.eclipse.openvsx.storage.*;
@@ -1200,9 +1201,10 @@ class AdminAPITest {
                 TokenService tokens,
                 RepositoryService repositories,
                 EntityManager entityManager,
-                EclipseService eclipse
+                EclipseService eclipse,
+                OAuth2AttributesConfig attributesConfig
         ) {
-            return new OAuth2UserServices(users, tokens, repositories, entityManager, eclipse);
+            return new OAuth2UserServices(users, tokens, repositories, entityManager, eclipse, attributesConfig);
         }
 
         @Bean

--- a/server/src/test/java/org/eclipse/openvsx/web/SitemapControllerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/web/SitemapControllerTest.java
@@ -15,6 +15,7 @@ import org.eclipse.openvsx.UserService;
 import org.eclipse.openvsx.eclipse.EclipseService;
 import org.eclipse.openvsx.eclipse.TokenService;
 import org.eclipse.openvsx.repositories.RepositoryService;
+import org.eclipse.openvsx.security.OAuth2AttributesConfig;
 import org.eclipse.openvsx.security.OAuth2UserServices;
 import org.eclipse.openvsx.security.SecurityConfig;
 import org.junit.jupiter.api.Test;
@@ -75,9 +76,10 @@ class SitemapControllerTest {
                 TokenService tokens,
                 RepositoryService repositories,
                 EntityManager entityManager,
-                EclipseService eclipse
+                EclipseService eclipse,
+                OAuth2AttributesConfig attributesConfig
         ) {
-            return new OAuth2UserServices(users, tokens, repositories, entityManager, eclipse);
+            return new OAuth2UserServices(users, tokens, repositories, entityManager, eclipse, attributesConfig);
         }
 
         @Bean

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openvsx-webui",
-    "version": "0.15.1",
+    "version": "0.16.0",
     "description": "User interface for Eclipse Open VSX",
     "keywords": [
         "react",

--- a/webui/src/context.ts
+++ b/webui/src/context.ts
@@ -20,7 +20,7 @@ export interface MainContext {
     handleError: (err: Error | Partial<ErrorResponse>) => void;
     user?: UserData;
     updateUser: () => void;
-    canLogin: boolean;
+    loginProviders?: Record<string, string>;
 }
 
 // We don't include `undefined` as context value to avoid checking the value in all components

--- a/webui/src/default/login.tsx
+++ b/webui/src/default/login.tsx
@@ -1,0 +1,43 @@
+/** ******************************************************************************
+ * Copyright (c) 2025 Precies. Software OU and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+import React, { FunctionComponent, ReactNode, useState } from "react";
+import { Button, Dialog, DialogContent, DialogTitle, Stack } from "@mui/material";
+
+export const LoginComponent: FunctionComponent<LoginComponentProps> = (props) => {
+    const [dialogOpen, setDialogOpen] = useState(false);
+
+    const showLoginDialog = () => setDialogOpen(true);
+
+    const providers = Object.keys(props.loginProviders);
+    if (providers.length === 1) {
+        return props.renderButton(props.loginProviders[providers[0]]);
+    } else {
+        return <>
+            {props.renderButton(undefined, showLoginDialog)}
+            <Dialog
+                fullWidth
+                open={dialogOpen}
+                onClose={() => setDialogOpen(false)}
+            >
+                <DialogTitle>Log In</DialogTitle>
+                <DialogContent>
+                    <Stack spacing={2}>
+                        {providers.map((provider) => (<Button key={provider} fullWidth variant='contained' color='secondary' href={props.loginProviders[provider]}>{provider}</Button>))}
+                    </Stack>
+                </DialogContent>
+            </Dialog>
+        </>;
+    }
+};
+
+export interface LoginComponentProps {
+    loginProviders: Record<string, string>
+    renderButton: (href?: string, onClick?: () => void) => ReactNode
+}

--- a/webui/src/default/menu-content.tsx
+++ b/webui/src/default/menu-content.tsx
@@ -28,6 +28,7 @@ import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import LogoutIcon from '@mui/icons-material/Logout';
 import { AdminDashboardRoutes } from '../pages/admin-dashboard/admin-dashboard';
 import { LogoutForm } from '../pages/user/logout';
+import { LoginComponent } from './login';
 
 //-------------------- Mobile View --------------------//
 
@@ -117,24 +118,29 @@ export const MobileUserAvatar: FunctionComponent = () => {
 
 export const MobileMenuContent: FunctionComponent = () => {
     const location = useLocation();
-    const { service, user, canLogin } = useContext(MainContext);
+    const { user, loginProviders } = useContext(MainContext);
 
     return <>
-        {canLogin && (
+        {loginProviders && (
             user ? (
                 <MobileUserAvatar />
             ) : (
                 <MobileMenuItem>
-                    <Link href={service.getLoginUrl()}>
-                        <MobileMenuItemText>
-                            <AccountBoxIcon sx={itemIcon} />
-                            Log In
-                        </MobileMenuItemText>
-                    </Link>
+                    <LoginComponent
+                        loginProviders={loginProviders}
+                        renderButton={(href, onClick) => {
+                            return (<Link href={href} onClick={onClick}>
+                                <MobileMenuItemText>
+                                    <AccountBoxIcon sx={itemIcon} />
+                                    Log In
+                                </MobileMenuItemText>
+                            </Link>);
+                        }}
+                    />
                 </MobileMenuItem>
             )
         )}
-        {canLogin && !location.pathname.startsWith(UserSettingsRoutes.ROOT) && (
+        {loginProviders && !location.pathname.startsWith(UserSettingsRoutes.ROOT) && (
             <MobileMenuItem>
                 <RouteLink to='/user-settings/extensions'>
                     <MobileMenuItemText>
@@ -199,7 +205,7 @@ export const MenuLink = styled(Link)(headerItem);
 export const MenuRouteLink = styled(RouteLink)(headerItem);
 
 export const DefaultMenuContent: FunctionComponent = () => {
-    const { service, user, canLogin } = useContext(MainContext);
+    const { user, loginProviders } = useContext(MainContext);
     return <>
         <MenuLink href='https://github.com/eclipse/openvsx/wiki'>
             Documentation
@@ -210,7 +216,7 @@ export const DefaultMenuContent: FunctionComponent = () => {
         <MenuRouteLink to='/about'>
             About
         </MenuRouteLink>
-        {canLogin && (
+        {loginProviders && (
             <>
                 <Button variant='contained' color='secondary' href='/user-settings/extensions' sx={{ mx: 2.5 }}>
                     Publish
@@ -219,12 +225,26 @@ export const DefaultMenuContent: FunctionComponent = () => {
                     user ?
                         <UserAvatar />
                         :
-                        <IconButton
-                            href={service.getLoginUrl()}
-                            title='Log In'
-                            aria-label='Log In' >
-                            <AccountBoxIcon />
-                        </IconButton>
+                        <LoginComponent
+                            loginProviders={loginProviders}
+                            renderButton={(href, onClick) => {
+                                if (href) {
+                                    return (<IconButton
+                                        href={href}
+                                        title='Log In'
+                                        aria-label='Log In' >
+                                        <AccountBoxIcon />
+                                    </IconButton>);
+                                } else {
+                                    return (<IconButton
+                                        onClick={onClick}
+                                        title='Log In'
+                                        aria-label='Log In' >
+                                        <AccountBoxIcon />
+                                    </IconButton>);
+                                }
+                            }}
+                        />
                 }
             </>
         )}

--- a/webui/src/extension-registry-service.ts
+++ b/webui/src/extension-registry-service.ts
@@ -11,7 +11,8 @@
 import {
     Extension, UserData, ExtensionCategory, ExtensionReviewList, PersonalAccessToken, SearchResult, NewReview,
     SuccessResult, ErrorResult, CsrfTokenJson, isError, Namespace, NamespaceDetails, MembershipRole, SortBy,
-    SortOrder, UrlString, NamespaceMembershipList, PublisherInfo, SearchEntry, RegistryVersion
+    SortOrder, UrlString, NamespaceMembershipList, PublisherInfo, SearchEntry, RegistryVersion,
+    LoginProviders
 } from './extension-registry-types';
 import { createAbsoluteURL, addQuery } from './utils';
 import { sendRequest, ErrorResponse } from './server-request';
@@ -24,8 +25,9 @@ export class ExtensionRegistryService {
         this.admin = new AdminConstructor(this);
     }
 
-    getLoginUrl(): string {
-        return createAbsoluteURL([this.serverUrl, 'oauth2', 'authorization', 'github']);
+    getLoginProviders(abortController: AbortController): Promise<Readonly<LoginProviders|SuccessResult>> {
+        const endpoint = createAbsoluteURL([this.serverUrl, 'login-providers']);
+        return sendRequest({ abortController, endpoint });
     }
 
     getLogoutUrl(): string {
@@ -418,11 +420,6 @@ export class ExtensionRegistryService {
 
     async getRegistryVersion(abortController: AbortController): Promise<Readonly<RegistryVersion>> {
         const endpoint = createAbsoluteURL([this.serverUrl, 'api', 'version']);
-        return sendRequest({ abortController, endpoint });
-    }
-
-    async canLogin(abortController: AbortController): Promise<Readonly<boolean>> {
-        const endpoint = createAbsoluteURL([this.serverUrl, 'can-login']);
         return sendRequest({ abortController, endpoint });
     }
 }

--- a/webui/src/extension-registry-types.ts
+++ b/webui/src/extension-registry-types.ts
@@ -251,6 +251,10 @@ export interface RegistryVersion {
     version: string
 }
 
+export interface LoginProviders {
+    loginProviders: Record<string, string>
+}
+
 export type MembershipRole = 'contributor' | 'owner';
 export type SortBy = 'relevance' | 'timestamp' | 'rating' | 'downloadCount';
 export type SortOrder = 'asc' | 'desc';

--- a/webui/src/pages/admin-dashboard/admin-dashboard.tsx
+++ b/webui/src/pages/admin-dashboard/admin-dashboard.tsx
@@ -44,7 +44,7 @@ const Message: FunctionComponent<{message: string}> = ({ message }) => {
 };
 
 export const AdminDashboard: FunctionComponent<AdminDashboardProps> = props => {
-    const { user, canLogin } = useContext(MainContext);
+    const { user, loginProviders } = useContext(MainContext);
 
     const navigate = useNavigate();
     const toMainPage = () => navigate('/');
@@ -76,7 +76,7 @@ export const AdminDashboard: FunctionComponent<AdminDashboardProps> = props => {
         </>;
     } else if (user) {
         content = <Message message='You are not authorized as administrator.'/>;
-    } else if (!props.userLoading && canLogin) {
+    } else if (!props.userLoading && loginProviders) {
         content = <Message message='You are not logged in.'/>;
     }
 

--- a/webui/src/pages/user/user-settings.tsx
+++ b/webui/src/pages/user/user-settings.tsx
@@ -21,6 +21,7 @@ import { UserSettingsNamespaces } from './user-settings-namespaces';
 import { UserSettingsExtensions } from './user-settings-extensions';
 import { MainContext } from '../../context';
 import { UserData } from '../../extension-registry-types';
+import { LoginComponent } from '../../default/login';
 
 export namespace UserSettingsRoutes {
     export const ROOT = createRoute(['user-settings']);
@@ -33,7 +34,7 @@ export namespace UserSettingsRoutes {
 
 export const UserSettings: FunctionComponent<UserSettingsProps> = props => {
 
-    const { pageSettings, service, user, canLogin } = useContext(MainContext);
+    const { pageSettings, user, loginProviders } = useContext(MainContext);
     const { tab } = useParams();
 
     const renderTab = (tab: string, user: UserData): ReactNode => {
@@ -57,12 +58,14 @@ export const UserSettings: FunctionComponent<UserSettingsProps> = props => {
         }
 
         if (!user) {
-            return canLogin ? <Container>
+            return loginProviders ? <Container>
                 <Box mt={6}>
                     <Typography variant='h4'>Not Logged In</Typography>
                     <Box mt={2}>
                         <Typography variant='body1'>
-                            Please <Link color='secondary' href={service.getLoginUrl()}>log in with GitHub</Link> to
+                            Please <LoginComponent loginProviders={loginProviders} renderButton={(href, onClick) => {
+return (<Link color='secondary' href={href} onClick={onClick}>log in</Link>);
+}}/> to
                             access your account settings.
                         </Typography>
                     </Box>


### PR DESCRIPTION
Replace the references to `OAuth2User` by `AuthUser`. This allows downstream extenders to more easily contribute alternative OAuth2 providers: If the expected data is stored in different attributes it will be possible to bridge it by implementing the proper `AuthUser`.

New configuration example:

```yml
ovsx:
  oauth2:
    provider: gitlab
    attribute-names:
      gitlab:
        avatar-url: avatar_url
        email: email
        full-name: name
        login-name: username
        provider-url: '' # idk what this is for

spring:
  security:
    oauth2:
      client:
        registration:
          gitlab:
            client-id: [client-id]
            client-secret: [client-secret]
            authorization-grant-type: authorization_code
            redirect-uri: http://[openvsx-host-name]/login/oauth2/code/gitlab
            scope: read_user
            clientName: OpenVSX
        provider:
          gitlab:
            authorization-uri: http://[gitlab-host-name]/oauth/authorize
            token-uri: http://[gitlab-host-name]/oauth/token
            user-info-uri: http://[gitlab-host-name]/api/v4/user
            jwk-set-uri: http://[gitlab-host-name]/oauth/discovery/keys
            user-name-attribute: id
```