### PR TITLE
Expose version of the registry service via API endpoint

### DIFF
--- a/server/src/dev/resources/application.yml
+++ b/server/src/dev/resources/application.yml
@@ -142,3 +142,5 @@ ovsx:
       timezone: US/Eastern
   integrity:
     key-pair: create # create, renew, delete, 'undefined'
+  registry:
+    version: 'v0.14.3'

--- a/server/src/main/java/org/eclipse/openvsx/IExtensionRegistry.java
+++ b/server/src/main/java/org/eclipse/openvsx/IExtensionRegistry.java
@@ -46,4 +46,6 @@ public interface IExtensionRegistry {
     ResponseEntity<byte[]> getNamespaceLogo(String namespaceName, String fileName);
 
     String getPublicKey(String publicId);
+
+    RegistryVersionJson getRegistryVersion();
 }

--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -28,6 +28,7 @@ import org.eclipse.openvsx.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -83,6 +84,9 @@ public class LocalRegistryService implements IExtensionRegistry {
 
     @Autowired
     ExtensionVersionIntegrityService integrityService;
+
+    @Value("${ovsx.registry.version:}")
+    String registryVersion;
 
     @Override
     public NamespaceJson getNamespace(String namespaceName) {
@@ -1020,5 +1024,15 @@ public class LocalRegistryService implements IExtensionRegistry {
         }
 
         return keyPair.getPublicKeyText();
+    }
+
+    @Override
+    public RegistryVersionJson getRegistryVersion() {
+        if (this.registryVersion == null || this.registryVersion.isEmpty()) {
+            throw new NotFoundException();
+        }
+        var registryVersion = new RegistryVersionJson();
+        registryVersion.version = this.registryVersion;
+        return registryVersion;
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
@@ -1716,4 +1716,43 @@ public class RegistryAPI {
 
         return ResponseEntity.notFound().build();
     }
+
+    @GetMapping(path = "/api/version", produces = MediaType.APPLICATION_JSON_VALUE)
+    @CrossOrigin
+    @Operation(summary = "Return the registry version")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "The registry version is returned in JSON format"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "The registry version could not be determined"
+        ),
+        @ApiResponse(
+            responseCode = "429",
+            description = "A client has sent too many requests in a given amount of time",
+            headers = {
+                @Header(
+                    name = "X-Rate-Limit-Retry-After-Seconds",
+                    description = "Number of seconds to wait after receiving a 429 response",
+                    schema = @Schema(type = "integer", format = "int32")
+                ),
+                @Header(
+                    name = "X-Rate-Limit-Remaining",
+                    description = "Remaining number of requests left",
+                    schema = @Schema(type = "integer", format = "int32")
+                )
+            }
+        )
+    })
+    public ResponseEntity<RegistryVersionJson> getServerVersion() {
+        try {
+            return ResponseEntity.ok()
+                        .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic())
+                        .body(local.getRegistryVersion());
+        } catch (ErrorResultException exc) {
+            return exc.toResponseEntity(RegistryVersionJson.class);
+        }
+    }
 }

--- a/server/src/main/java/org/eclipse/openvsx/UpstreamRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/UpstreamRegistryService.java
@@ -384,6 +384,28 @@ public class UpstreamRegistryService implements IExtensionRegistry {
         }
     }
 
+    /**
+     * Returns the version of the upstream registry.
+     *
+     * This functionality is currently not used, but could be called when
+     * the need to show or check the version of the upstream registry arises.
+     *
+     * @return the version of the upstream registry
+     */
+    @Override
+    public RegistryVersionJson getRegistryVersion() {
+        var urlTemplate = urlConfigService.getUpstreamUrl() + "/api/version";
+
+        try {
+            ResponseEntity<RegistryVersionJson> response = restTemplate.getForEntity(urlTemplate,
+                    RegistryVersionJson.class);
+            return response.getBody();
+        } catch (RestClientException exc) {
+            logger.error("GET " + urlTemplate, exc);
+            throw new NotFoundException();
+        }
+    }
+
     private void handleError(Throwable exc) throws RuntimeException {
         if (exc instanceof HttpStatusCodeException) {
             var status = ((HttpStatusCodeException) exc).getStatusCode();

--- a/server/src/main/java/org/eclipse/openvsx/json/RegistryVersionJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/RegistryVersionJson.java
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (c) 2024 STMicroelectronics
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.json;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(
+    name = "RegistryVersion",
+    description = "Version of the registry service"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RegistryVersionJson extends ResultJson {
+    public static RegistryVersionJson error(String message) {
+        var result = new RegistryVersionJson();
+        result.error = message;
+        return result;
+    }
+
+    @Schema(description = "Registry version")
+    @NotNull
+    public String version;
+}

--- a/webui/src/default/default-app.tsx
+++ b/webui/src/default/default-app.tsx
@@ -33,6 +33,17 @@ if (serverHost.startsWith('3000-')) {
 }
 const service = new ExtensionRegistryService(`${location.protocol}//${serverHost}`);
 
+async function getServerVersion(): Promise<string> {
+   const abortController = new AbortController();
+   try {
+    const result = await service.getRegistryVersion(abortController);
+    return result.version;
+   } catch (error) {
+    console.error('Could not determine server version');
+    return 'unknown';
+   }
+}
+
 const App = () => {
     const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
     const theme = useMemo(
@@ -40,7 +51,7 @@ const App = () => {
         [prefersDarkMode],
     );
 
-    const pageSettings = createPageSettings(prefersDarkMode, service.serverUrl);
+    const pageSettings = createPageSettings(prefersDarkMode, service.serverUrl, getServerVersion());
     return (
         <HelmetProvider>
             <ThemeProvider theme={theme}>

--- a/webui/src/default/page-settings.tsx
+++ b/webui/src/default/page-settings.tsx
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
 
-import React, { FunctionComponent, ReactNode } from 'react';
+import React, { FunctionComponent, ReactNode, Suspense, lazy } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { styled, Theme } from '@mui/material/styles';
 import { Link, Typography, Box } from '@mui/material';
@@ -22,7 +22,7 @@ import OpenVSXLogo from './openvsx-registry-logo';
 import About from './about';
 import { createAbsoluteURL } from '../utils';
 
-export default function createPageSettings(prefersDarkMode: boolean, serverUrl: string): PageSettings {
+export default function createPageSettings(prefersDarkMode: boolean, serverUrl: string, serverVersionPromise: Promise<string>): PageSettings {
     const toolbarContent: FunctionComponent = () =>
         <RouteLink to={ExtensionListRoutes.MAIN} aria-label={`Home - Open VSX Registry`}>
             <OpenVSXLogo width='auto' height='40px' marginTop='8px' prefersDarkMode={prefersDarkMode} />
@@ -38,6 +38,13 @@ export default function createPageSettings(prefersDarkMode: boolean, serverUrl: 
     });
 
     const StyledRouteLink = styled(RouteLink)(link);
+
+    const ServerVersion = lazy(async () => {
+        const version = await serverVersionPromise;
+        return { default: () => <Typography variant='body2' sx={{ fontSize: '0.8rem' }}>Server Version: {version}</Typography> };
+    });
+
+
     const footerContent: FunctionComponent<{ expanded: boolean }> = () =>
         <Box sx={{
             display: 'flex',
@@ -58,6 +65,9 @@ export default function createPageSettings(prefersDarkMode: boolean, serverUrl: 
             >
                 <GitHubIcon />&nbsp;eclipse/openvsx
             </Link>
+            <Suspense fallback={<div>Loading version...</div>}>
+                <ServerVersion/>
+            </Suspense>
             <StyledRouteLink to='/about'>
                 About This Service
             </StyledRouteLink>

--- a/webui/src/extension-registry-service.ts
+++ b/webui/src/extension-registry-service.ts
@@ -11,7 +11,7 @@
 import {
     Extension, UserData, ExtensionCategory, ExtensionReviewList, PersonalAccessToken, SearchResult, NewReview,
     SuccessResult, ErrorResult, CsrfTokenJson, isError, Namespace, NamespaceDetails, MembershipRole, SortBy,
-    SortOrder, UrlString, NamespaceMembershipList, PublisherInfo, SearchEntry
+    SortOrder, UrlString, NamespaceMembershipList, PublisherInfo, SearchEntry, RegistryVersion
 } from './extension-registry-types';
 import { createAbsoluteURL, addQuery } from './utils';
 import { sendRequest, ErrorResponse } from './server-request';
@@ -394,6 +394,11 @@ export class ExtensionRegistryService {
             headers: headers,
             endpoint: createAbsoluteURL([this.serverUrl, 'user', 'extensions'])
         });
+    }
+
+    async getRegistryVersion(abortController: AbortController): Promise<Readonly<RegistryVersion>> {
+        const endpoint = createAbsoluteURL([this.serverUrl, 'api', 'version']);
+        return sendRequest({ abortController, endpoint });
     }
 }
 

--- a/webui/src/extension-registry-types.ts
+++ b/webui/src/extension-registry-types.ts
@@ -238,6 +238,10 @@ export interface TargetPlatformVersion {
     checked: boolean;
 }
 
+export interface RegistryVersion {
+    version: string
+}
+
 export type MembershipRole = 'contributor' | 'owner';
 export type SortBy = 'relevance' | 'timestamp' | 'rating' | 'downloadCount';
 export type SortOrder = 'asc' | 'desc';


### PR DESCRIPTION
**Server:**
* Define server version in gradle.properties
* Add gradle task to create a resources properties file in the build directory
* Expose server version at the endpoint: /api/version

**Web-ui:**
* Display the server version in the footer.

Fixes #21