### PR TITLE
server: fix `sortBy` and `sortOrder`

### DIFF
--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -2064,7 +2064,7 @@ public class RegistryAPITest {
         var searchOptions = new ISearchService.Options("foo", null, null, 10, 0, "desc", "relevance", false);
         Mockito.when(search.search(searchOptions))
                 .thenReturn(searchHits);
-        Mockito.when(repositories.findExtensions(Set.of(extension.getId())))
+        Mockito.when(repositories.findExtensions(List.of(extension.getId())))
                 .thenReturn(Streamable.of(extension));
         return Arrays.asList(extension);
     }


### PR DESCRIPTION
**Description**

Fixes: #780 

The commit fixes an issue when respecting `sortBy` and `sortOder`. The proper ordering provided by the search-hits were not respected when collecting them after being streamed.