### PR TITLE
Use public profile

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/UserAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/UserAPI.java
@@ -112,11 +112,7 @@ public class UserAPI {
         json.role = user.getRole();
         json.tokensUrl = createApiUrl(serverUrl, "user", "tokens");
         json.createTokenUrl = createApiUrl(serverUrl, "user", "token", "create");
-        try {
-            eclipse.enrichUserJson(json, user);
-        } catch (ErrorResultException e) {
-            logger.error("Failed to enrich UserJson", e);
-        }
+        eclipse.enrichUserJson(json, user);
         return json;
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/admin/AdminService.java
+++ b/server/src/main/java/org/eclipse/openvsx/admin/AdminService.java
@@ -265,12 +265,7 @@ public class AdminService {
 
         var userPublishInfo = new UserPublishInfoJson();
         userPublishInfo.user = user.toUserJson();
-        try {
-            eclipse.enrichUserJson(userPublishInfo.user, user);
-        } catch (ErrorResultException e) {
-            userPublishInfo.user.error = e.getMessage();
-        }
-
+        eclipse.adminEnrichUserJson(userPublishInfo.user, user);
         userPublishInfo.activeAccessTokenNum = (int) repositories.countActiveAccessTokens(user);
         var extVersions = repositories.findLatestVersions(user);
         var types = new String[]{DOWNLOAD, MANIFEST, ICON, README, LICENSE, CHANGELOG, VSIXMANIFEST};

--- a/server/src/main/java/org/eclipse/openvsx/eclipse/PublisherComplianceChecker.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/PublisherComplianceChecker.java
@@ -86,14 +86,10 @@ public class PublisherComplianceChecker {
             return false;
         }
 
-        var json = new UserJson();
-        try {
-            eclipseService.enrichUserJson(json, user);
-            return json.publisherAgreement.status == null || !json.publisherAgreement.status.equals("none");
-        } catch(ErrorResultException e) {
-            // no way to determine whether the user has a publisher agreement
-            return true;
-        }
+        var profile = eclipseService.getPublicProfile(user.getEclipsePersonId());
+        return profile.publisherAgreements != null
+                && profile.publisherAgreements.openVsx != null
+                && profile.publisherAgreements.openVsx.version != null;
     }
 
     private void deactivateExtensions(Streamable<PersonalAccessToken> accessTokens) {

--- a/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
@@ -91,6 +91,22 @@ public class EclipseServiceTest {
     }
 
     @Test
+    public void testGetPublicProfile() throws Exception {
+        var urlTemplate = "https://test.openvsx.eclipse.org/account/profile/{personId}";
+        Mockito.when(restTemplate.exchange(eq(urlTemplate), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class), eq(Map.of("personId", "test"))))
+                .thenReturn(mockProfileResponse());
+
+        var profile = eclipse.getPublicProfile("test");
+
+        assertThat(profile).isNotNull();
+        assertThat(profile.name).isEqualTo("test");
+        assertThat(profile.githubHandle).isEqualTo("test");
+        assertThat(profile.publisherAgreements).isNotNull();
+        assertThat(profile.publisherAgreements.openVsx).isNotNull();
+        assertThat(profile.publisherAgreements.openVsx.version).isEqualTo("1");
+    }
+
+    @Test
     public void testGetUserProfile() throws Exception {
         Mockito.when(restTemplate.exchange(any(RequestEntity.class), eq(String.class)))
             .thenReturn(mockProfileResponse());


### PR DESCRIPTION
- Use public profile when checking Eclipse publisher agreement
- Use public profile when checking if publisher is compliant
- Add testGetPublicProfile unit test back in