### PR TITLE
Debounce webui search

### DIFF
--- a/webui/src/pages/extension-list/extension-list.tsx
+++ b/webui/src/pages/extension-list/extension-list.tsx
@@ -39,7 +39,7 @@ export const ExtensionList: FunctionComponent<ExtensionListProps> = props => {
             clearTimeout(cancellationToken.timeout);
             enableLoadMore.current = false;
         };
-    }, []);
+    });
 
     useEffect(() => {
         filterSize.current = props.filter.size || filterSize.current;


### PR DESCRIPTION
The search input field on the open-vsx.org is not debounced. So, for example, if I rapidly type "123456" into the search field and add a debug log for the requests sent by the page, I see a separate query sent for each character:

![image](https://github.com/eclipse/openvsx/assets/20653241/9faa321d-4ef9-4aae-a236-b5d28b10041a)

There is, however, code present for debouncing the sending of new searches and aborting old requests. It's just not run at the correct time. I believe the empty useEffect dependency list (removed in this MR) was an accidental mistake. Without that empty list, the debounce behavior appears correct; the useEffect callback cancels all but the last search within the debounce period. Only the final query is sent to the server.