### PR TITLE
feat: add publisher agreement compliance check

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
@@ -34,6 +34,7 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
@@ -561,5 +562,19 @@ public class ExtensionProcessor implements AutoCloseable {
         vsixManifest.setType(FileResource.VSIXMANIFEST);
         vsixManifest.setContent(ArchiveUtil.readEntry(zipFile, VSIX_MANIFEST, ObservationRegistry.NOOP));
         return vsixManifest;
+    }
+
+    public boolean isPotentiallyMalicious() {
+        readInputStream();
+        Enumeration<? extends ZipEntry> entries = zipFile.entries();
+        while (entries.hasMoreElements()) {
+            ZipEntry entry = entries.nextElement();
+            if (entry.getExtra() != null) {
+                logger.warn("Potentially harmful zip entry with extra fields detected: {}", entry.getName());
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
@@ -68,7 +68,7 @@ public class ExtensionService {
         return download.getExtension();
     }
 
-    public ExtensionVersion publishVersion(InputStream content, PersonalAccessToken token) {
+    public ExtensionVersion publishVersion(InputStream content, PersonalAccessToken token) throws ErrorResultException {
         return Observation.createNotStarted("ExtensionService#publishVersion", observations).observe(() -> {
             var extensionFile = createExtensionFile(content);
             var download = doPublish(extensionFile, null, token, TimeUtil.getCurrentUTC(), true);

--- a/server/src/main/java/org/eclipse/openvsx/entities/ExtensionVersion.java
+++ b/server/src/main/java/org/eclipse/openvsx/entities/ExtensionVersion.java
@@ -75,6 +75,8 @@ public class ExtensionVersion implements Serializable {
 
     boolean active;
 
+    boolean potentiallyMalicious;
+
     String displayName;
 
     @Column(length = 2048)
@@ -318,6 +320,14 @@ public class ExtensionVersion implements Serializable {
         this.active = active;
     }
 
+    public boolean isPotentiallyMalicious() {
+        return potentiallyMalicious;
+    }
+
+    public void setPotentiallyMalicious(boolean potentiallyMalicious) {
+        this.potentiallyMalicious = potentiallyMalicious;
+    }
+
 	public String getDisplayName() {
 		return displayName;
 	}
@@ -487,6 +497,7 @@ public class ExtensionVersion implements Serializable {
                 && preRelease == that.preRelease
                 && preview == that.preview
                 && active == that.active
+                && potentiallyMalicious == that.potentiallyMalicious
                 && Objects.equals(getId(extension), getId(that.extension)) // use id to prevent infinite recursion
                 && Objects.equals(version, that.version)
                 && Objects.equals(targetPlatform, that.targetPlatform)
@@ -517,7 +528,7 @@ public class ExtensionVersion implements Serializable {
     public int hashCode() {
         return Objects.hash(
                 id, getId(extension), version, targetPlatform, semver, preRelease, preview, timestamp, getId(publishedWith),
-                active, displayName, description, engines, categories, tags, extensionKind, license, homepage, repository,
+                active, potentiallyMalicious, displayName, description, engines, categories, tags, extensionKind, license, homepage, repository,
                 sponsorLink, bugs, markdown, galleryColor, galleryTheme, localizedLanguages, qna, dependencies,
                 bundledExtensions, signatureKeyPair, type
         );

--- a/server/src/main/java/org/eclipse/openvsx/migration/CheckPotentiallyMaliciousExtensionVersionsService.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/CheckPotentiallyMaliciousExtensionVersionsService.java
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (c) 2024 STMicroelectronics and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.migration;
+
+import io.micrometer.observation.ObservationRegistry;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.jobrunr.jobs.context.JobRunrDashboardLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.eclipse.openvsx.ExtensionProcessor;
+import org.eclipse.openvsx.entities.ExtensionVersion;
+import org.eclipse.openvsx.util.NamingUtil;
+import org.eclipse.openvsx.util.TempFile;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CheckPotentiallyMaliciousExtensionVersionsService {
+
+    protected final Logger logger = new JobRunrDashboardLogger(LoggerFactory.getLogger(PotentiallyMaliciousJobRequestHandler.class));
+
+    private final EntityManager entityManager;
+
+    public CheckPotentiallyMaliciousExtensionVersionsService(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Transactional
+    public void checkPotentiallyMaliciousExtensionVersion(ExtensionVersion extVersion, TempFile extensionFile) {
+        try(var extProcessor = new ExtensionProcessor(extensionFile, ObservationRegistry.NOOP)) {
+            boolean isMalicious = extProcessor.isPotentiallyMalicious();
+            extVersion.setPotentiallyMalicious(isMalicious);
+            if (isMalicious) {
+                logger.warn("Extension version is potentially malicious: {}", NamingUtil.toLogFormat(extVersion));
+            }
+        }
+        entityManager.merge(extVersion);
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationRunner.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationRunner.java
@@ -50,6 +50,7 @@ public class MigrationRunner implements JobRequestHandler<HandlerJobRequest<?>> 
         fixTargetPlatformMigration();
         generateSha256ChecksumMigration();
         extensionVersionSignatureMigration();
+        checkPotentiallyMaliciousExtensionVersions();
     }
 
     private void extractResourcesMigration() {
@@ -92,5 +93,11 @@ public class MigrationRunner implements JobRequestHandler<HandlerJobRequest<?>> 
         if(!mirrorEnabled) {
             scheduler.enqueue(new HandlerJobRequest<>(GenerateKeyPairJobRequestHandler.class));
         }
+    }
+
+    private void checkPotentiallyMaliciousExtensionVersions() {
+        var jobName = "CheckPotentiallyMaliciousExtensionVersions";
+        var handler = PotentiallyMaliciousJobRequestHandler.class;
+        repositories.findNotMigratedPotentiallyMalicious().forEach(item -> migrations.enqueueMigration(jobName, handler, item));
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/migration/PotentiallyMaliciousJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/PotentiallyMaliciousJobRequestHandler.java
@@ -1,0 +1,57 @@
+/********************************************************************************
+ * Copyright (c) 2024 STMicroelectronics and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.migration;
+
+import org.eclipse.openvsx.util.NamingUtil;
+import org.jobrunr.jobs.annotations.Job;
+import org.jobrunr.jobs.context.JobRunrDashboardLogger;
+import org.jobrunr.jobs.lambdas.JobRequestHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.util.AbstractMap;
+
+@Component
+public class PotentiallyMaliciousJobRequestHandler implements JobRequestHandler<MigrationJobRequest> {
+
+    protected final Logger logger = new JobRunrDashboardLogger(LoggerFactory.getLogger(PotentiallyMaliciousJobRequestHandler.class));
+
+    private final MigrationService migrations;
+    private final CheckPotentiallyMaliciousExtensionVersionsService service;
+
+    public PotentiallyMaliciousJobRequestHandler(MigrationService migrations, CheckPotentiallyMaliciousExtensionVersionsService service) {
+        this.migrations = migrations;
+        this.service = service;
+    }
+
+    @Override
+    @Job(name = "Check published extensions for potentially malicious vsix file", retries = 3)
+    public void run(MigrationJobRequest jobRequest) throws Exception {
+        var download = migrations.getResource(jobRequest);
+        var extVersion = download.getExtension();
+        logger.info("Checking extension version for potentially malicious vsix file: {}", NamingUtil.toLogFormat(extVersion));
+
+        var content = migrations.getContent(download);
+        var entry = new AbstractMap.SimpleEntry<>(download, content);
+        try(var extensionFile = migrations.getExtensionFile(entry)) {
+            if(Files.size(extensionFile.getPath()) == 0) {
+                logger.info("Extension file is empty, skipping: {}", download.getName());
+                return;
+            }
+
+            logger.info("Checking vsix file for potentially malicious metadata: {}", download.getName());
+            service.checkPotentiallyMaliciousExtensionVersion(extVersion, extensionFile);
+        }
+
+    }
+
+}

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -204,6 +204,12 @@ public class PublishExtensionVersionHandler {
         service.storeDownload(download, extensionFile);
         service.persistResource(download);
         try(var processor = new ExtensionProcessor(extensionFile, ObservationRegistry.NOOP)) {
+            extVersion.setPotentiallyMalicious(processor.isPotentiallyMalicious());
+            if (extVersion.isPotentiallyMalicious()) {
+                logger.warn("Extension version is potentially malicious: {}", NamingUtil.toLogFormat(extVersion));
+                return;
+            }
+
             Consumer<FileResource> consumer = resource -> {
                 service.storeResource(resource);
                 service.persistResource(resource);

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepository.java
@@ -46,6 +46,7 @@ public class ExtensionVersionJooqRepository {
                     EXTENSION.NAME,
                     EXTENSION_VERSION.ID,
                     EXTENSION_VERSION.VERSION,
+                    EXTENSION_VERSION.POTENTIALLY_MALICIOUS,
                     EXTENSION_VERSION.TARGET_PLATFORM,
                     EXTENSION_VERSION.PREVIEW,
                     EXTENSION_VERSION.PRE_RELEASE,
@@ -411,6 +412,7 @@ public class ExtensionVersionJooqRepository {
                 USER_DATA.PROVIDER,
                 EXTENSION_VERSION.ID,
                 EXTENSION_VERSION.VERSION,
+                EXTENSION_VERSION.POTENTIALLY_MALICIOUS,
                 EXTENSION_VERSION.TARGET_PLATFORM,
                 EXTENSION_VERSION.PREVIEW,
                 EXTENSION_VERSION.PRE_RELEASE,
@@ -531,6 +533,7 @@ public class ExtensionVersionJooqRepository {
         extVersion.setDependencies(toList(record.get(extensionVersionMapper.map(EXTENSION_VERSION.DEPENDENCIES)), converter));
         extVersion.setBundledExtensions(toList(record.get(extensionVersionMapper.map(EXTENSION_VERSION.BUNDLED_EXTENSIONS)), converter));
         extVersion.setSponsorLink(record.get(extensionVersionMapper.map(EXTENSION_VERSION.SPONSOR_LINK)));
+        extVersion.setPotentiallyMalicious(record.get(extensionVersionMapper.map(EXTENSION_VERSION.POTENTIALLY_MALICIOUS)));
 
         if(extension == null) {
             var namespace = new Namespace();
@@ -637,6 +640,7 @@ public class ExtensionVersionJooqRepository {
                 USER_DATA.PROVIDER,
                 EXTENSION_VERSION.ID,
                 EXTENSION_VERSION.VERSION,
+                EXTENSION_VERSION.POTENTIALLY_MALICIOUS,
                 EXTENSION_VERSION.TARGET_PLATFORM,
                 EXTENSION_VERSION.PREVIEW,
                 EXTENSION_VERSION.PRE_RELEASE,
@@ -736,6 +740,7 @@ public class ExtensionVersionJooqRepository {
         latestQuery.addSelect(
                 EXTENSION_VERSION.ID,
                 EXTENSION_VERSION.VERSION,
+                EXTENSION_VERSION.POTENTIALLY_MALICIOUS,
                 EXTENSION_VERSION.TARGET_PLATFORM,
                 EXTENSION_VERSION.PREVIEW,
                 EXTENSION_VERSION.PRE_RELEASE,
@@ -780,6 +785,7 @@ public class ExtensionVersionJooqRepository {
                 EXTENSION.LAST_UPDATED_DATE,
                 EXTENSION.ACTIVE,
                 latest.field(EXTENSION_VERSION.ID),
+                latest.field(EXTENSION_VERSION.POTENTIALLY_MALICIOUS),
                 latest.field(EXTENSION_VERSION.VERSION),
                 latest.field(EXTENSION_VERSION.TARGET_PLATFORM),
                 latest.field(EXTENSION_VERSION.PREVIEW),
@@ -909,6 +915,7 @@ public class ExtensionVersionJooqRepository {
                 EXTENSION.LAST_UPDATED_DATE,
                 EXTENSION_VERSION.ID,
                 EXTENSION_VERSION.VERSION,
+                EXTENSION_VERSION.POTENTIALLY_MALICIOUS,
                 EXTENSION_VERSION.TARGET_PLATFORM,
                 EXTENSION_VERSION.PREVIEW,
                 EXTENSION_VERSION.PRE_RELEASE,

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -495,6 +495,10 @@ public class RepositoryService {
         return findNotMigratedItems("V1_35__FileResource_Generate_Sha256_Checksum.sql");
     }
 
+    public Streamable<MigrationItem> findNotMigratedPotentiallyMalicious() {
+        return findNotMigratedItems("V1_46__ExtensionVersion_PotentiallyMalicious.sql");
+    }
+
     private Streamable<MigrationItem> findNotMigratedItems(String migrationScript) {
         return migrationItemRepo.findByMigrationScriptAndMigrationScheduledFalseOrderById(migrationScript);
     }

--- a/server/src/main/jooq-gen/org/eclipse/openvsx/jooq/tables/ExtensionVersion.java
+++ b/server/src/main/jooq-gen/org/eclipse/openvsx/jooq/tables/ExtensionVersion.java
@@ -224,6 +224,11 @@ public class ExtensionVersion extends TableImpl<ExtensionVersionRecord> {
      */
     public final TableField<ExtensionVersionRecord, Boolean> UNIVERSAL_TARGET_PLATFORM = createField(DSL.name("universal_target_platform"), SQLDataType.BOOLEAN, this, "");
 
+    /**
+     * The column <code>publc.extension_version.potentially_malicious</code>.
+     */
+    public final TableField<ExtensionVersionRecord, Boolean> POTENTIALLY_MALICIOUS = createField(DSL.name("potentially_malicious"), SQLDataType.BOOLEAN, this, "");
+
     private ExtensionVersion(Name alias, Table<ExtensionVersionRecord> aliased) {
         this(alias, aliased, null);
     }

--- a/server/src/main/jooq-gen/org/eclipse/openvsx/jooq/tables/records/ExtensionVersionRecord.java
+++ b/server/src/main/jooq-gen/org/eclipse/openvsx/jooq/tables/records/ExtensionVersionRecord.java
@@ -511,6 +511,22 @@ public class ExtensionVersionRecord extends UpdatableRecordImpl<ExtensionVersion
         return (Boolean) get(34);
     }
 
+    /**
+     * Setter for
+     * <code>public.extension_version.potentially_malicious</code>.
+     */
+    public void setPotentiallyMalicious(Boolean value) {
+        set(35, value);
+    }
+
+    /**
+     * Getter for
+     * <code>public.extension_version.potentially_malicious</code>.
+     */
+    public Boolean getPotentiallyMalicious() {
+        return (Boolean) get(35);
+    }
+
     // -------------------------------------------------------------------------
     // Primary key information
     // -------------------------------------------------------------------------
@@ -534,7 +550,7 @@ public class ExtensionVersionRecord extends UpdatableRecordImpl<ExtensionVersion
     /**
      * Create a detached, initialised ExtensionVersionRecord
      */
-    public ExtensionVersionRecord(Long id, String bugs, String description, String displayName, String galleryColor, String galleryTheme, String homepage, String license, String markdown, Boolean preview, String qna, String repository, LocalDateTime timestamp, String version, Long extensionId, Long publishedWithId, Boolean active, String dependencies, String bundledExtensions, String engines, String categories, String tags, String extensionKind, Boolean preRelease, String targetPlatform, String localizedLanguages, String sponsorLink, Long signatureKeyPairId, Integer semverMajor, Integer semverMinor, Integer semverPatch, String semverPreRelease, Boolean semverIsPreRelease, String semverBuildMetadata, Boolean universalTargetPlatform) {
+    public ExtensionVersionRecord(Long id, String bugs, String description, String displayName, String galleryColor, String galleryTheme, String homepage, String license, String markdown, Boolean preview, String qna, String repository, LocalDateTime timestamp, String version, Long extensionId, Long publishedWithId, Boolean active, String dependencies, String bundledExtensions, String engines, String categories, String tags, String extensionKind, Boolean preRelease, String targetPlatform, String localizedLanguages, String sponsorLink, Long signatureKeyPairId, Integer semverMajor, Integer semverMinor, Integer semverPatch, String semverPreRelease, Boolean semverIsPreRelease, String semverBuildMetadata, Boolean universalTargetPlatform, Boolean potentiallyMalicious) {
         super(ExtensionVersion.EXTENSION_VERSION);
 
         setId(id);
@@ -572,6 +588,7 @@ public class ExtensionVersionRecord extends UpdatableRecordImpl<ExtensionVersion
         setSemverIsPreRelease(semverIsPreRelease);
         setSemverBuildMetadata(semverBuildMetadata);
         setUniversalTargetPlatform(universalTargetPlatform);
+        setPotentiallyMalicious(potentiallyMalicious);
         resetChangedOnNotNull();
     }
 }

--- a/server/src/main/resources/db/migration/V1_46__ExtensionVersion_PotentiallyMalicious.sql
+++ b/server/src/main/resources/db/migration/V1_46__ExtensionVersion_PotentiallyMalicious.sql
@@ -1,0 +1,11 @@
+ALTER TABLE extension_version ADD COLUMN potentially_malicious BOOLEAN;
+UPDATE extension_version SET potentially_malicious = FALSE;
+
+
+INSERT INTO migration_item(id, migration_script, entity_id, migration_scheduled)
+SELECT nextval('hibernate_sequence'), 'V1_46__ExtensionVersion_PotentiallyMalicious.sql', fr.id, FALSE
+FROM file_resource fr
+JOIN extension_version ev ON ev.id = fr.extension_id
+JOIN extension e ON e.id = ev.extension_id
+WHERE fr.type = 'download'
+ORDER BY e.download_count DESC;

--- a/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
@@ -152,6 +152,7 @@ class RepositoryServiceSmokeTest {
                 () -> repositories.findNotMigratedVsixManifests(),
                 () -> repositories.findNotMigratedTargetPlatforms(),
                 () -> repositories.findNotMigratedSha256Checksums(),
+                () -> repositories.findNotMigratedPotentiallyMalicious(),
                 () -> repositories.topMostActivePublishingUsers(1),
                 () -> repositories.topNamespaceExtensions(1),
                 () -> repositories.topNamespaceExtensionVersions(1),


### PR DESCRIPTION
This commit enforces that only extension versions compliant with the publisher agreement can be published.

Already existing extensions versions are checked as part of a migration job.

Contributed on behalf of STMicroelectronics