### PR TITLE
Update last-updated-date of extensions whenever extension is changed

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
@@ -140,6 +140,8 @@ public class ExtensionService {
             extension.setActive(false);
             search.removeSearchEntry(extension);
         }
+
+        extension.setLastUpdatedDate(TimeUtil.getCurrentUTC());
     }
 
     /**


### PR DESCRIPTION
Currently, the last-updated-date is only updated when a new extension version is published. This causes the mirror to be out-of-sync with upstream whenever an extension version is deleted.

This commit updates the last-updated-date whenever an extension is changed, including the scenario above.

Fixes #955 