### PR TITLE
Replace Tomcat with Jetty

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -66,7 +66,10 @@ configurations {
 }
 
 dependencies {
-    implementation "org.springframework.boot:spring-boot-starter-web"
+    implementation("org.springframework.boot:spring-boot-starter-web") {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
+    }
+    implementation "org.springframework.boot:spring-boot-starter-jetty"
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-jooq"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"

--- a/server/src/dev/resources/application.yml
+++ b/server/src/dev/resources/application.yml
@@ -4,6 +4,10 @@ logging:
 
 server:
   port: 8080
+  jetty:
+    threads:
+      max-queue-capacity: 1
+    max-http-post-size: 536870912
 
 spring:
   application:


### PR DESCRIPTION
Use Jetty instead of Tomcat so that requests no longer get queued and the server remains responsive under all conditions. 
It also logs an error, which makes monitoring easier.

source: https://blog.qaware.de/posts/java-service-queues/#jetty-server