### PR TITLE
cli: rate limit requests in load-test-extensions

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -39,6 +39,7 @@
         "follow-redirects": "^1.14.6",
         "is-ci": "^2.0.0",
         "leven": "^3.1.0",
+        "limiter": "^2.1.0",
         "semver": "^7.6.0",
         "tmp": "^0.2.1"
     },

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -1725,6 +1725,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"just-performance@npm:4.3.0":
+  version: 4.3.0
+  resolution: "just-performance@npm:4.3.0"
+  checksum: 10/5e5f0664f357d291aac9ccca6357b997254600f2d2dd429e9b63e058035c44b6b1c73dbae51f58af7918c0701db4b20d4f365ed61e77d87c92a0183efb77a72a
+  languageName: node
+  linkType: hard
+
 "keytar@npm:^7.7.0":
   version: 7.9.0
   resolution: "keytar@npm:7.9.0"
@@ -1759,6 +1766,15 @@ __metadata:
     prelude-ls: "npm:^1.2.1"
     type-check: "npm:~0.4.0"
   checksum: 10/2e4720ff79f21ae08d42374b0a5c2f664c5be8b6c8f565bb4e1315c96ed3a8acaa9de788ffed82d7f2378cf36958573de07ef92336cb5255ed74d08b8318c9ee
+  languageName: node
+  linkType: hard
+
+"limiter@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "limiter@npm:2.1.0"
+  dependencies:
+    just-performance: "npm:4.3.0"
+  checksum: 10/d6292c2a576fe7c4664652a64d286cb3701dd18e1878e01207840d809c62ce6db46ec6ee5e2ab53d548cb56152d0aeeb8555e32fe9177fcb4b04983ef04f805e
   languageName: node
   linkType: hard
 
@@ -2165,6 +2181,7 @@ __metadata:
     follow-redirects: "npm:^1.14.6"
     is-ci: "npm:^2.0.0"
     leven: "npm:^3.1.0"
+    limiter: "npm:^2.1.0"
     rimraf: "npm:^3.0.2"
     semver: "npm:^7.6.0"
     tmp: "npm:^0.2.1"


### PR DESCRIPTION
To avoid running into rate limits when loading test extensions, a rate limiter with a matching amount of tokens per interval is added.

Contributed on behalf of STMicroelectronics