### PR TITLE
Update to Spring Boot 3.2.2

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'jacoco'
     id 'nu.studer.jooq' version '8.2.1'
     id 'de.undercouch.download' version '5.4.0'
-    id 'org.springframework.boot' version '3.2.1'
+    id 'org.springframework.boot' version '3.2.2'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'io.gatling.gradle' version '3.9.5'
     id 'java'


### PR DESCRIPTION
Update Spring Boot to 3.2.2 for Jetty connection idle timeout fix [spring-projects/spring-boot#38960](https://github.com/spring-projects/spring-boot/issues/38960)