### PR TITLE
Add AdminServiceConstructor

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openvsx-webui",
-    "version": "0.12.0",
+    "version": "0.12.0-next.94189ad0",
     "description": "User interface for Eclipse Open VSX",
     "keywords": [
         "react",


### PR DESCRIPTION
Add `AdminServiceConstructor`, so that implementing type can be passed as a parameter and `ExtensionRegistryService` (this) can be passed into the `AdminServiceConstructor`.