### PR TITLE
Add system provider for users

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/extension_control/ExtensionControlService.java
+++ b/server/src/main/java/org/eclipse/openvsx/extension_control/ExtensionControlService.java
@@ -88,9 +88,10 @@ public class ExtensionControlService {
     @Transactional
     public UserData createExtensionControlUser() {
         var userName = "ExtensionControlUser";
-        var user = repositories.findUserByLoginName(null, userName);
+        var user = repositories.findUserByLoginName("system", userName);
         if(user == null) {
             user = new UserData();
+            user.setProvider("system");
             user.setLoginName(userName);
             entityManager.persist(user);
         }

--- a/server/src/main/java/org/eclipse/openvsx/migration/FixTargetPlatformsService.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/FixTargetPlatformsService.java
@@ -29,9 +29,10 @@ public class FixTargetPlatformsService {
     @Transactional
     public UserData getUser() {
         var userName = "FixTargetPlatformMigration";
-        var user = repositories.findUserByLoginName(null, userName);
+        var user = repositories.findUserByLoginName("system", userName);
         if(user == null) {
             user = new UserData();
+            user.setProvider("system");
             user.setLoginName(userName);
             entityManager.persist(user);
         }

--- a/server/src/main/java/org/eclipse/openvsx/mirror/DataMirrorService.java
+++ b/server/src/main/java/org/eclipse/openvsx/mirror/DataMirrorService.java
@@ -131,12 +131,21 @@ public class DataMirrorService {
 
     @Transactional
     public UserData createMirrorUser() {
-        var user = repositories.findUserByLoginName(null, userName);
-        if(user == null) {
-            user = new UserData();
-            user.setLoginName(userName);
-            entityManager.persist(user);
+        var user = repositories.findUserByLoginName("system", userName);
+        if(user != null) {
+            return user;
         }
+
+        user = repositories.findUserByLoginName(null, userName);
+        if(user != null) {
+            user.setProvider("system");
+            return user;
+        }
+
+        user = new UserData();
+        user.setProvider("system");
+        user.setLoginName(userName);
+        entityManager.persist(user);
         return user;
     }
 

--- a/server/src/main/resources/db/migration/V1_49__System_User.sql
+++ b/server/src/main/resources/db/migration/V1_49__System_User.sql
@@ -1,0 +1,1 @@
+UPDATE user_data SET provider = 'system' WHERE login_name IN ('ExtensionControlUser', 'FixTargetPlatformMigration');


### PR DESCRIPTION
Use `"system"` as user data provider, because `null` values are treated as distinct values, making it possible to insert multiple user data rows with the same login name and `null` as provider.