### PR TITLE
Increase mobile header menu breakpoint to lg

### DIFF
--- a/webui/src/header-menu.tsx
+++ b/webui/src/header-menu.tsx
@@ -22,7 +22,7 @@ export const HeaderMenu: FunctionComponent = () => {
         defaultMenuContent: DefaultMenuContent,
         mobileMenuContent: MobileMenuContent
     } = pageSettings.elements;
-    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+    const isMobile = useMediaQuery(theme.breakpoints.down('lg'));
     if (isMobile && MobileMenuContent) {
         return <MobileHeaderMenu menuContent={MobileMenuContent} />;
     } else if (DefaultMenuContent) {


### PR DESCRIPTION
Increase mobile header menu breakpoint to lg, so that webui also looks good on tablets in portrait mode and on phones in landscape mode.