### PR TITLE
Use generated file name for file caching

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/cache/FilesCacheKeyGenerator.java
+++ b/server/src/main/java/org/eclipse/openvsx/cache/FilesCacheKeyGenerator.java
@@ -9,6 +9,7 @@
  * ****************************************************************************** */
 package org.eclipse.openvsx.cache;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.eclipse.openvsx.adapter.WebResourceService;
 import org.eclipse.openvsx.entities.FileResource;
 import org.eclipse.openvsx.storage.IStorageService;
@@ -17,6 +18,7 @@ import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 
 @Component
 public class FilesCacheKeyGenerator implements KeyGenerator {
@@ -46,5 +48,21 @@ public class FilesCacheKeyGenerator implements KeyGenerator {
 
     public String generate(String namespace, String extension, String targetPlatform, String version, String name) {
         return UrlUtil.createApiFileUrl("", namespace, extension, targetPlatform, version, name);
+    }
+
+    public Path generateCachedExtensionPath(FileResource resource) {
+        var key = generate(resource);
+        return generateCachedPath(key, "ce_", ".tmp");
+    }
+
+    public Path generateCachedWebResourcePath(String namespace, String extension, String targetPlatform, String version, String name, String fileExtension) {
+        var key = generate(namespace, extension, targetPlatform, version, name);
+        return generateCachedPath(key, "cr_", fileExtension);
+    }
+
+    private Path generateCachedPath(String key, String prefix, String extension) {
+        var hash = DigestUtils.sha256Hex(key);
+        var tmp = System.getProperty("java.io.tmpdir");
+        return Path.of(tmp, prefix + hash + extension);
     }
 }

--- a/server/src/main/resources/ehcache.xml
+++ b/server/src/main/resources/ehcache.xml
@@ -92,6 +92,7 @@
                 <events-to-fire-on>EXPIRED</events-to-fire-on>
                 <events-to-fire-on>EVICTED</events-to-fire-on>
                 <events-to-fire-on>REMOVED</events-to-fire-on>
+                <events-to-fire-on>UPDATED</events-to-fire-on>
             </listener>
         </listeners>
         <resources>
@@ -110,6 +111,7 @@
                 <events-to-fire-on>EXPIRED</events-to-fire-on>
                 <events-to-fire-on>EVICTED</events-to-fire-on>
                 <events-to-fire-on>REMOVED</events-to-fire-on>
+                <events-to-fire-on>UPDATED</events-to-fire-on>
             </listener>
         </listeners>
         <resources>

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
@@ -892,8 +892,13 @@ class VSCodeAPITest {
         }
 
         @Bean
-        WebResourceService webResourceService(StorageUtilService storageUtil, RepositoryService repositories, CacheService cache) {
-            return new WebResourceService(storageUtil, repositories, cache);
+        WebResourceService webResourceService(
+                StorageUtilService storageUtil,
+                RepositoryService repositories,
+                CacheService cache,
+                FilesCacheKeyGenerator filesCacheKeyGenerator
+        ) {
+            return new WebResourceService(storageUtil, repositories, cache, filesCacheKeyGenerator);
         }
 
         @Bean

--- a/server/src/test/java/org/eclipse/openvsx/storage/AzureBlobStorageServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/storage/AzureBlobStorageServiceTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 
+import org.eclipse.openvsx.cache.FilesCacheKeyGenerator;
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.ExtensionVersion;
 import org.eclipse.openvsx.entities.FileResource;
@@ -60,8 +61,13 @@ class AzureBlobStorageServiceTest {
     @TestConfiguration
     static class TestConfig {
         @Bean
-        AzureBlobStorageService azureBlobStorageService() {
-            return new AzureBlobStorageService();
+        FilesCacheKeyGenerator filesCacheKeyGenerator() {
+            return new FilesCacheKeyGenerator();
+        }
+
+        @Bean
+        AzureBlobStorageService azureBlobStorageService(FilesCacheKeyGenerator filesCacheKeyGenerator) {
+            return new AzureBlobStorageService(filesCacheKeyGenerator);
         }
     }
 }


### PR DESCRIPTION
Use generated file name to prevent orphaned files when multiple requests get the same uncached file at the same time.