### PR TITLE
Synchronize resource file writing

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/storage/IStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/IStorageService.java
@@ -62,5 +62,5 @@ public interface IStorageService {
 
     void copyNamespaceLogo(Namespace oldNamespace, Namespace newNamespace);
 
-    Path getCachedFile(FileResource resource) throws IOException;
+    Path getCachedFile(FileResource resource);
 }

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
@@ -363,7 +363,7 @@ public class StorageUtilService implements IStorageService {
     }
 
     @Override
-    public Path getCachedFile(FileResource resource) throws IOException {
+    public Path getCachedFile(FileResource resource) {
         return switch (resource.getStorageType()) {
             case STORAGE_GOOGLE -> googleStorage.getCachedFile(resource);
             case STORAGE_AZURE -> azureStorage.getCachedFile(resource);

--- a/server/src/main/java/org/eclipse/openvsx/util/FileUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/FileUtil.java
@@ -1,0 +1,47 @@
+/** ******************************************************************************
+ * Copyright (c) 2025 Precies. Software OU and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+
+package org.eclipse.openvsx.util;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class FileUtil {
+
+    private static final Map<Path, Object> LOCKS;
+
+    static {
+        var MAX_SIZE = 100;
+        LOCKS = Collections.synchronizedMap(new LinkedHashMap<>(MAX_SIZE) {
+            protected boolean removeEldestEntry(Map.Entry eldest){
+                return size() > MAX_SIZE;
+            }
+        });
+    }
+
+    private FileUtil(){}
+
+    /***
+     * Write to file synchronously, if it doesn't already exist.
+     * @param path File path to write to
+     * @param writer Writes to file
+     */
+    public static void writeSync(Path path, Consumer<Path> writer) {
+        synchronized (LOCKS.computeIfAbsent(path, key -> new Object())) {
+            if(!Files.exists(path)) {
+                writer.accept(path);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Synchronize resource file writing in case the cache is empty and multiple requests try to write to the same file path simultaneously.