### PR TITLE
Improve file cache key

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "org.hibernate.orm:hibernate-gradle-plugin:6.2.2.Final"
+        classpath "com.adarshr.test-logger:com.adarshr.test-logger.gradle.plugin:4.0.0"
     }
 }
 plugins {
@@ -16,6 +17,7 @@ plugins {
     id 'java'
 }
 apply plugin: 'org.hibernate.orm'
+apply plugin: 'com.adarshr.test-logger'
 
 def jooqSrcDir = 'src/main/jooq-gen'
 def versions = [

--- a/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
@@ -342,7 +342,7 @@ public class LocalVSCodeService implements IVSCodeService {
         }
         if(!Files.exists(file)) {
             logger.error("File doesn't exist {}", file);
-            cache.evictWebResourceFile(namespaceName, extensionName, null, version, name);
+            cache.evictWebResourceFile(namespaceName, extensionName, targetPlatform, version, name);
             throw new NotFoundException();
         }
         return file;

--- a/server/src/main/java/org/eclipse/openvsx/adapter/WebResourceService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/WebResourceService.java
@@ -101,7 +101,6 @@ public class WebResourceService {
                     return null;
                 }
 
-
                 var file = filesCacheKeyGenerator.generateCachedWebResourcePath(namespace, extension, targetPlatform, version, name, ".unpkg.json");
                 FileUtil.writeSync(file, (p) -> {
                     var baseUrl = UrlUtil.createApiUrl(UrlUtil.getBaseUrl(), "vscode", "unpkg", namespace, extension, version);

--- a/server/src/main/java/org/eclipse/openvsx/cache/FilesCacheKeyGenerator.java
+++ b/server/src/main/java/org/eclipse/openvsx/cache/FilesCacheKeyGenerator.java
@@ -13,7 +13,6 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.eclipse.openvsx.adapter.WebResourceService;
 import org.eclipse.openvsx.entities.FileResource;
 import org.eclipse.openvsx.storage.IStorageService;
-import org.eclipse.openvsx.util.UrlUtil;
 import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.stereotype.Component;
 
@@ -47,7 +46,7 @@ public class FilesCacheKeyGenerator implements KeyGenerator {
     }
 
     public String generate(String namespace, String extension, String targetPlatform, String version, String name) {
-        return UrlUtil.createApiFileUrl("", namespace, extension, targetPlatform, version, name);
+        return String.join("|", namespace.toLowerCase(), extension.toLowerCase(), targetPlatform, version, name);
     }
 
     public Path generateCachedExtensionPath(FileResource resource) {

--- a/server/src/test/java/org/eclipse/openvsx/IntegrationTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/IntegrationTest.java
@@ -11,6 +11,7 @@ package org.eclipse.openvsx;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.eclipse.openvsx.json.*;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,11 +23,14 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 
+import javax.cache.CacheManager;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.openvsx.cache.CacheService.CACHE_EXTENSION_FILES;
+import static org.eclipse.openvsx.cache.CacheService.CACHE_WEB_RESOURCE_FILES;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
@@ -45,6 +49,15 @@ class IntegrationTest {
 
     private String apiCall(String path) {
         return "http://localhost:" + port + path;
+    }
+
+    @AfterAll
+    static void clearFileCaches(@Autowired CacheManager cacheManager) {
+        var cache = cacheManager.getCache(CACHE_WEB_RESOURCE_FILES);
+        cache.removeAll();
+
+        cache = cacheManager.getCache(CACHE_EXTENSION_FILES);
+        cache.removeAll();
     }
 
     @Test


### PR DESCRIPTION
- Differentiate between `null` and `universal` target platform. `UrlUtil.getFileApiUrl` treats `universal` as `null` and excludes it from the url.
- Make namespace and extension names case insensitive, same as in the database.
- Pass `targetPlatform` when evicting webresource file.