### PR TITLE
(Java) Parentheses should be removed

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
@@ -350,7 +350,7 @@ public class LocalVSCodeService implements IVSCodeService {
     }
 
     private StreamingResponseBody builtinExtensionResponse() {
-        return (out) -> out.write(builtinExtensionMessage().getBytes(StandardCharsets.UTF_8));
+        return out -> out.write(builtinExtensionMessage().getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeIdUpdateService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeIdUpdateService.java
@@ -170,7 +170,7 @@ public class VSCodeIdUpdateService {
 
     private void updatePublicIdNulls(Map<Long, String> changedPublicIds, Set<String> newPublicIds, Map<Long, String> publicIdMap) {
         // remove unchanged random public ids
-        changedPublicIds.entrySet().removeIf((e) -> {
+        changedPublicIds.entrySet().removeIf(e -> {
             var publicId = e.getValue() == null ? publicIdMap.get(e.getKey()) : null;
             var remove = publicId != null && !newPublicIds.contains(publicId);
             if(remove) {

--- a/server/src/main/java/org/eclipse/openvsx/adapter/WebResourceService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/WebResourceService.java
@@ -81,7 +81,7 @@ public class WebResourceService {
                 var fileExtIndex = fileEntry.getName().lastIndexOf('.');
                 var fileExt = fileExtIndex != -1 ? fileEntry.getName().substring(fileExtIndex) : "";
                 var file = filesCacheKeyGenerator.generateCachedWebResourcePath(namespace, extension, targetPlatform, version, name, fileExt);
-                FileUtil.writeSync(file, (p) -> {
+                FileUtil.writeSync(file, p -> {
                     try (var in = zip.getInputStream(fileEntry)) {
                         Files.copy(in, p);
                     } catch(IOException e) {
@@ -104,7 +104,7 @@ public class WebResourceService {
                 }
 
                 var file = filesCacheKeyGenerator.generateCachedWebResourcePath(namespace, extension, targetPlatform, version, name, ".unpkg.json");
-                FileUtil.writeSync(file, (p) -> {
+                FileUtil.writeSync(file, p -> {
                     var baseUrl = UrlUtil.createApiUrl(UrlUtil.getBaseUrl(), "vscode", "unpkg", namespace, extension, version);
                     var mapper = new ObjectMapper();
                     var node = mapper.createArrayNode();

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionJooqRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionJooqRepository.java
@@ -213,7 +213,7 @@ public class ExtensionJooqRepository {
                 .join(EXTENSION).on(EXTENSION.NAMESPACE_ID.eq(NAMESPACE.ID))
                 .where(EXTENSION.ACTIVE.eq(true))
                 .fetch()
-                .map((row) -> {
+                .map(row -> {
                     return new SitemapRow(
                             row.get(NAMESPACE.NAME),
                             row.get(EXTENSION.NAME),

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepository.java
@@ -593,7 +593,7 @@ public class ExtensionVersionJooqRepository {
         }
 
         return query.fetch()
-                .map((row) -> {
+                .map(row -> {
                    var extVersion = new ExtensionVersion();
                    extVersion.setId(row.get(EXTENSION_VERSION.ID));
                    extVersion.setVersion(row.get(EXTENSION_VERSION.VERSION));
@@ -621,7 +621,7 @@ public class ExtensionVersionJooqRepository {
         query.addJoin(EXTENSION, EXTENSION.ID.eq(EXTENSION_VERSION.EXTENSION_ID));
         query.addJoin(NAMESPACE, NAMESPACE.ID.eq(EXTENSION.NAMESPACE_ID));
         query.addConditions(EXTENSION_VERSION.EXTENSION_ID.eq(extensionId));
-        return query.fetchOne((row) -> {
+        return query.fetchOne(row -> {
             var namespace = new Namespace();
             namespace.setId(row.get(NAMESPACE.ID));
             namespace.setName(row.get(NAMESPACE.NAME));
@@ -686,7 +686,7 @@ public class ExtensionVersionJooqRepository {
         query.addJoin(USER_DATA, USER_DATA.ID.eq(PERSONAL_ACCESS_TOKEN.USER_DATA));
         query.addJoin(SIGNATURE_KEY_PAIR, JoinType.LEFT_OUTER_JOIN, SIGNATURE_KEY_PAIR.ID.eq(EXTENSION_VERSION.SIGNATURE_KEY_PAIR_ID));
         query.addConditions(EXTENSION_VERSION.EXTENSION_ID.eq(extension.getId()));
-        return query.fetchOne((row) -> toExtensionVersionFull(row, extension, null));
+        return query.fetchOne(row -> toExtensionVersionFull(row, extension, null));
     }
 
     public ExtensionVersion findLatest(
@@ -1063,7 +1063,7 @@ public class ExtensionVersionJooqRepository {
                 EXTENSION_VERSION.VERSION,
                 EXTENSION_VERSION.PREVIEW
         );
-        return query.fetchOne((row) -> {
+        return query.fetchOne(row -> {
             if(row == null) {
                 return null;
             }
@@ -1173,7 +1173,7 @@ public class ExtensionVersionJooqRepository {
             query.addConditions(EXTENSION_VERSION.VERSION.eq(version));
         }
 
-        return query.fetchOne((row) -> {
+        return query.fetchOne(row -> {
             var extVersion = toExtensionVersionFull(row);
             extVersion.getExtension().setDeprecated(row.get(EXTENSION.DEPRECATED));
             extVersion.getExtension().setDownloadable(row.get(EXTENSION.DOWNLOADABLE));

--- a/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
@@ -256,7 +256,7 @@ public class AwsStorageService implements IStorageService {
                 .build();
 
         var path = filesCacheKeyGenerator.generateCachedExtensionPath(resource);
-        FileUtil.writeSync(path, (p) -> {
+        FileUtil.writeSync(path, p -> {
             try (var stream = getS3Client().getObject(request)) {
                 Files.copy(stream, p);
             } catch(IOException e) {

--- a/server/src/main/java/org/eclipse/openvsx/storage/AzureBlobStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AzureBlobStorageService.java
@@ -244,7 +244,7 @@ public class AzureBlobStorageService implements IStorageService {
         }
 
         var path = filesCacheKeyGenerator.generateCachedExtensionPath(resource);
-        FileUtil.writeSync(path, (p) -> {
+        FileUtil.writeSync(path, p -> {
             getContainerClient().getBlobClient(blobName).downloadToFile(p.toAbsolutePath().toString());
         });
         return path;

--- a/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
@@ -219,7 +219,7 @@ public class GoogleCloudStorageService implements IStorageService {
 
         var objectId = getObjectId(resource);
         var path = filesCacheKeyGenerator.generateCachedExtensionPath(resource);
-        FileUtil.writeSync(path, (p) -> {
+        FileUtil.writeSync(path, p -> {
             getStorage().downloadTo(BlobId.of(bucketId, objectId), p);
         });
 


### PR DESCRIPTION
(Java) Parentheses should be removed from a single lambda parameter when its type is inferred