### PR TITLE
Dockerfile fix for Develocity access key

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM gradle:jdk17 as builder
 
 # Copy sources
@@ -10,7 +11,7 @@ ENV CI=true
 
 # Build the server application
 RUN --mount=type=secret,id=dv-key,env=DEVELOCITY_ACCESS_KEY \
-    ./gradlew --no-daemon assemble -Ddevelocity.url=https://ge.solutions-team.gradle.com/
+    ./gradlew --no-daemon assemble
 
 FROM eclipse-temurin:17.0.7_7-jdk
 


### PR DESCRIPTION
This should fix this [issue](https://github.com/eclipse/openvsx/actions/runs/13437413452/job/37542987642#step:10:39): `ERROR: failed to solve: unexpected key 'env' in 'env=DEVELOCITY_ACCESS_KEY'`.

This happens because GHA isn't using the latest dockerfile syntax yet, which is fixed by the `# syntax=docker/dockerfile:1` line. This is also documented in [Docker GHA secrets docs](https://docs.docker.com/build/ci/github-actions/secrets/), which I missed when I opened the initial PR https://github.com/eclipse/openvsx/pull/1091.