### PR TITLE
Enabled caching by default

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,7 +3,7 @@ FROM gradle:jdk17 as builder
 
 # Copy sources
 WORKDIR /home/gradle
-COPY --chown=gradle:gradle gradlew *.gradle ./
+COPY --chown=gradle:gradle gradlew *.gradle gradle.properties ./
 COPY --chown=gradle:gradle gradle ./gradle/
 COPY --chown=gradle:gradle src ./src/
 

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.parallel=true
+org.gradle.vfs.watch=true
+org.gradle.caching=true


### PR DESCRIPTION
Enabled caching by default by specifying it in the root gradle.properties file. I also enabled filesystem watching and parallel execution by default, which often improves performance.

Since I tested this locally and I have caching enabled by default in my `$GRADLE_USER_HOME/gradle.properties` I didn't notice that the open vsx server project doesn't - this will fix it.