### PR TITLE
Automate namespace claim process

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/admin/AdminService.java
+++ b/server/src/main/java/org/eclipse/openvsx/admin/AdminService.java
@@ -34,6 +34,7 @@ import org.springframework.stereotype.Component;
 import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.eclipse.openvsx.entities.FileResource.*;
@@ -388,7 +389,19 @@ public class AdminService {
     }
 
     public UserData checkAdminUser() {
-        var user = users.findLoggedInUser();
+        return checkAdminUser(users.findLoggedInUser());
+    }
+
+    public UserData checkAdminUser(String tokenValue) {
+        var user = Optional.of(tokenValue)
+                .map(users::useAccessToken)
+                .map(PersonalAccessToken::getUser)
+                .orElse(null);
+
+        return checkAdminUser(user);
+    }
+
+    private UserData checkAdminUser(UserData user) {
         if (user == null || !UserData.ROLE_ADMIN.equals(user.getRole())) {
             throw new ErrorResultException("Administration role is required.", HttpStatus.FORBIDDEN);
         }

--- a/server/src/main/java/org/eclipse/openvsx/admin/ChangeNamespaceJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/admin/ChangeNamespaceJobRequestHandler.java
@@ -70,7 +70,11 @@ public class ChangeNamespaceJobRequestHandler implements JobRequestHandler<Chang
     @Override
     public void run(ChangeNamespaceJobRequest jobRequest) throws Exception {
         var oldNamespace = jobRequest.getData().oldNamespace();
-        synchronized (LOCKS.computeIfAbsent(oldNamespace, key -> new Object())) {
+        Object lock;
+        synchronized (LOCKS) {
+            lock = LOCKS.computeIfAbsent(oldNamespace, key -> new Object());
+        }
+        synchronized (lock) {
             execute(jobRequest);
         }
     }

--- a/server/src/main/java/org/eclipse/openvsx/repositories/PersonalAccessTokenJooqRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/PersonalAccessTokenJooqRepository.java
@@ -9,12 +9,10 @@
  * ****************************************************************************** */
 package org.eclipse.openvsx.repositories;
 
-import org.eclipse.openvsx.entities.UserData;
 import org.jooq.DSLContext;
 import org.springframework.stereotype.Component;
 
 import static org.eclipse.openvsx.jooq.Tables.PERSONAL_ACCESS_TOKEN;
-import static org.eclipse.openvsx.jooq.Tables.USER_DATA;
 
 @Component
 public class PersonalAccessTokenJooqRepository {
@@ -29,17 +27,6 @@ public class PersonalAccessTokenJooqRepository {
                 dsl.selectOne()
                         .from(PERSONAL_ACCESS_TOKEN)
                         .where(PERSONAL_ACCESS_TOKEN.VALUE.eq(value))
-        );
-    }
-
-    public boolean isAdminToken(String value) {
-        return dsl.fetchExists(
-                dsl.selectOne()
-                        .from(PERSONAL_ACCESS_TOKEN)
-                        .join(USER_DATA).on(USER_DATA.ID.eq(PERSONAL_ACCESS_TOKEN.USER_DATA))
-                        .where(PERSONAL_ACCESS_TOKEN.VALUE.eq(value))
-                        .and(PERSONAL_ACCESS_TOKEN.ACTIVE.eq(true))
-                        .and(USER_DATA.ROLE.eq(UserData.ROLE_ADMIN))
         );
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -342,10 +342,6 @@ public class RepositoryService {
         return  tokenRepo.findByValue(value);
     }
 
-    public boolean isAdminToken(String value) {
-        return tokenJooqRepo.isAdminToken(value);
-    }
-
     public PersonalAccessToken findAccessToken(long id) {
         return tokenRepo.findById(id);
     }

--- a/server/src/main/java/org/eclipse/openvsx/util/FileUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/FileUtil.java
@@ -38,7 +38,11 @@ public class FileUtil {
      * @param writer Writes to file
      */
     public static void writeSync(Path path, Consumer<Path> writer) {
-        synchronized (LOCKS.computeIfAbsent(path, key -> new Object())) {
+        Object lock;
+        synchronized (LOCKS) {
+            lock = LOCKS.computeIfAbsent(path, key -> new Object());
+        }
+        synchronized (lock) {
             if(!Files.exists(path)) {
                 writer.accept(path);
             }

--- a/server/src/test/java/org/eclipse/openvsx/admin/AdminAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/admin/AdminAPITest.java
@@ -1021,7 +1021,7 @@ class AdminAPITest {
         token.setActive(true);
         token.setValue(tokenValue);
         token.setUser(user);
-        Mockito.when(repositories.isAdminToken(tokenValue)).thenReturn(true);
+        Mockito.when(repositories.findAccessToken(tokenValue)).thenReturn(token);
 
         return token;
     }
@@ -1035,7 +1035,7 @@ class AdminAPITest {
         token.setActive(true);
         token.setValue(tokenValue);
         token.setUser(user);
-        Mockito.when(repositories.isAdminToken(tokenValue)).thenReturn(false);
+        Mockito.when(repositories.findAccessToken(tokenValue)).thenReturn(token);
 
         return token;
     }

--- a/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
@@ -194,7 +194,6 @@ class RepositoryServiceSmokeTest {
                 () -> repositories.findExtensionTargetPlatforms(extension),
                 () -> repositories.deactivateKeyPairs(),
                 () -> repositories.findActiveAccessTokens(userData),
-                () -> repositories.isAdminToken("tokenValue"),
                 () -> repositories.findLatestVersions(List.of(1L)),
                 () -> repositories.hasSameVersion(extVersion),
                 () -> repositories.hasActiveReview(extension, userData),


### PR DESCRIPTION
- Added support for token to `/admin/namespace/{namespaceName}/members`
- Added support for token to `/admin/namespace/{namespaceName}/change-member`
- Use `useAccessToken` method so that `accessedTimestamp` gets updated
- Bugfix: access `synchronizedMap` within `synchronized` block
- Fix unit tests