### PR TITLE
chore: Fix CVE-2025-22235 by upgrading org.springframework.boot to 3.3.11

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'jacoco'
     id 'nu.studer.jooq' version '8.2.1'
     id 'de.undercouch.download' version '5.4.0'
-    id 'org.springframework.boot' version '3.3.10'
+    id 'org.springframework.boot' version '3.3.11'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'io.gatling.gradle' version '3.9.5'
     id 'java'


### PR DESCRIPTION
Updated the Spring Boot plugin version from `3.3.10` to `3.3.11` to fix high severity CVE-2025-22235.