### PR TITLE
chore: add group Gradle property; add maven-publish plugin

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -15,6 +15,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.0'
     id 'io.gatling.gradle' version '3.9.5'
     id 'java'
+    id 'maven-publish'
 }
 apply plugin: 'org.hibernate.orm'
 apply plugin: 'com.adarshr.test-logger'
@@ -160,6 +161,16 @@ jooq {
                     }
                 }
             }
+        }
+    }
+}
+
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifact ('scripts/run-server.sh') 
+            artifact bootJar
         }
     }
 }

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -1,3 +1,5 @@
 org.gradle.parallel=true
 org.gradle.vfs.watch=true
 org.gradle.caching=true
+# Needs for Red Hat's Project Manipulation Extension (PME) work
+group=org.eclipse.openvsx


### PR DESCRIPTION
This pull request introduces changes to the Gradle build configuration to enable Maven publishing and support Red Hat's Project Manipulation Extension (PME).

### Gradle Build Configuration Enhancements:

* Added the `maven-publish` plugin to the `plugins` block to enable Maven publishing.
* Added a `publishing` block to configure Maven publications, including publishing the `bootJar` artifact and a script (`scripts/run-server.sh`).

### Gradle Properties Update:

* [`server/gradle.properties`](diffhunk://#diff-62ac93ddfd7892b087091fc168370c2b3cf4ce7afb24cbb1f1a1e34951dff37aR4-R5): Added a `group` property (`org.eclipse.openvsx`) to support Red Hat's Project Manipulation Extension (PME) work.