### PR TITLE
Update Spring Boot to 3.5.3

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'jacoco'
     id 'nu.studer.jooq' version '8.2.1'
     id 'de.undercouch.download' version '5.4.0'
-    id 'org.springframework.boot' version '3.3.11'
+    id 'org.springframework.boot' version '3.5.3'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'io.gatling.gradle' version '3.9.5'
     id 'java'
@@ -38,7 +38,6 @@ def versions = [
     tika: '3.1.0',
     bouncycastle: '1.80',
     commons_lang3: '3.12.0',
-    httpclient5: '5.2.1',
     jaxb_api: '2.3.1',
     jaxb_impl: '2.3.8',
     gatling: '3.13.5',
@@ -107,7 +106,7 @@ dependencies {
     implementation "javax.xml.bind:jaxb-api:${versions.jaxb_api}"
     implementation "com.sun.xml.bind:jaxb-impl:${versions.jaxb_impl}"
     implementation "org.apache.commons:commons-lang3:${versions.commons_lang3}"
-    implementation "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
+    implementation "org.apache.httpcomponents.client5:httpclient5"
     implementation "org.apache.tika:tika-core:${versions.tika}"
     implementation "com.github.loki4j:loki-logback-appender:${versions.loki4j}"
     implementation "io.micrometer:micrometer-tracing"

--- a/server/src/main/java/org/eclipse/openvsx/migration/GenerateKeyPairJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/GenerateKeyPairJobRequestHandler.java
@@ -9,6 +9,7 @@
  * ****************************************************************************** */
 package org.eclipse.openvsx.migration;
 
+import io.micrometer.common.util.StringUtils;
 import org.eclipse.openvsx.admin.RemoveFileJobRequest;
 import org.eclipse.openvsx.entities.ExtensionVersion;
 import org.eclipse.openvsx.entities.FileResource;
@@ -63,8 +64,10 @@ public class GenerateKeyPairJobRequestHandler implements JobRequestHandler<Handl
                 deleteKeyPairs();
                 break;
             default:
-                var values = String.join(",", KEYPAIR_MODE_CREATE, KEYPAIR_MODE_RENEW, KEYPAIR_MODE_DELETE);
-                throw new IllegalArgumentException("Unsupported value for 'ovsx.integrity.key-pair' defined. Supported values are: " + values);
+                if(StringUtils.isNotEmpty(keyPairMode)) {
+                    var values = String.join(",", KEYPAIR_MODE_CREATE, KEYPAIR_MODE_RENEW, KEYPAIR_MODE_DELETE);
+                    throw new IllegalArgumentException("Unsupported value '" + keyPairMode + "' for 'ovsx.integrity.key-pair' defined. Supported values are: " + values);
+                }
         }
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/search/DatabaseSearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/DatabaseSearchService.java
@@ -26,6 +26,7 @@ import org.springframework.data.util.Streamable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -70,7 +71,7 @@ public class DatabaseSearchService implements ISearchService {
                 .map(extensionSearch -> new SearchHit<>(null, null, null, 0.0f, null, null, null, null, null, null, extensionSearch))
                 .toList();
 
-        return new SearchHitsImpl<>(totalHits, TotalHitsRelation.OFF, 0f, null, null, searchHits, null, null, null);
+        return new SearchHitsImpl<>(totalHits, TotalHitsRelation.OFF, 0f, Duration.ZERO, null, null, searchHits, null, null, null);
     }
 
     private List<ExtensionSearch> applyPaging(Options options, List<ExtensionSearch> sortedExtensions) {

--- a/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
@@ -41,6 +41,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StopWatch;
 
+import java.time.Duration;
 import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -249,7 +250,7 @@ public class ElasticSearchService implements ISearchService {
     public SearchHits<ExtensionSearch> search(Options options) {
         var resultWindow = options.requestedOffset() + options.requestedSize();
         if(resultWindow > getMaxResultWindow()) {
-            return new SearchHitsImpl<>(0, TotalHitsRelation.OFF, 0f, null, null, Collections.emptyList(), null, null, null);
+            return new SearchHitsImpl<>(0, TotalHitsRelation.OFF, 0f, Duration.ZERO, null, null, Collections.emptyList(), null, null, null);
         }
 
         var queryBuilder = new NativeQueryBuilder();
@@ -291,6 +292,7 @@ public class ElasticSearchService implements ISearchService {
                     firstSearchHitsPage.getTotalHits(),
                     firstSearchHitsPage.getTotalHitsRelation(),
                     firstSearchHitsPage.getMaxScore(),
+                    Duration.ZERO,
                     null,
                     null,
                     searchHits,

--- a/server/src/main/java/org/eclipse/openvsx/security/SecurityConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/security/SecurityConfig.java
@@ -17,7 +17,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
 @Configuration
@@ -34,21 +34,21 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http, OAuth2UserServices userServices) throws Exception {
         var filterChain = http.authorizeHttpRequests(
                 registry -> registry
-                        .requestMatchers(antMatchers("/*", "/login/**", "/oauth2/**", "/login-providers", "/user", "/user/auth-error", "/logout", "/actuator/health/**", "/actuator/metrics", "/actuator/metrics/**", "/actuator/prometheus", "/v3/api-docs/**", "/swagger-resources/**", "/swagger-ui/**", "/webjars/**"))
+                        .requestMatchers(pathMatchers("/*", "/login/**", "/oauth2/**", "/login-providers", "/user", "/user/auth-error", "/logout", "/actuator/health/**", "/actuator/metrics", "/actuator/metrics/**", "/actuator/prometheus", "/v3/api-docs/**", "/swagger-resources/**", "/swagger-ui/**", "/webjars/**"))
                             .permitAll()
-                        .requestMatchers(antMatchers("/api/*/*/review", "/api/*/*/review/delete", "/api/user/publish", "/api/user/namespace/create"))
+                        .requestMatchers(pathMatchers("/api/*/*/review", "/api/*/*/review/delete", "/api/user/publish", "/api/user/namespace/create"))
                             .authenticated()
-                        .requestMatchers(antMatchers("/api/**", "/vscode/**", "/documents/**", "/admin/api/**", "/admin/report"))
+                        .requestMatchers(pathMatchers("/api/**", "/vscode/**", "/documents/**", "/admin/api/**", "/admin/report"))
                             .permitAll()
-                        .requestMatchers(antMatchers("/admin/**"))
+                        .requestMatchers(pathMatchers("/admin/**"))
                             .hasAuthority("ROLE_ADMIN")
-                        .requestMatchers(antMatchers(frontendRoutes))
+                        .requestMatchers(pathMatchers(frontendRoutes))
                             .permitAll()
                         .anyRequest()
                             .authenticated()
                 )
                 .cors(configurer -> configurer.configure(http))
-                .csrf(configurer -> configurer.ignoringRequestMatchers(antMatchers("/api/-/publish", "/api/-/namespace/create", "/api/-/query", "/vscode/**", "/admin/api/**")))
+                .csrf(configurer -> configurer.ignoringRequestMatchers(pathMatchers("/api/-/publish", "/api/-/namespace/create", "/api/-/query", "/vscode/**", "/admin/api/**")))
                 .exceptionHandling(configurer -> configurer.authenticationEntryPoint(new Http403ForbiddenEntryPoint()));
 
         if(userServices.canLogin()) {
@@ -65,13 +65,13 @@ public class SecurityConfig {
         return filterChain.build();
     }
 
-    private RequestMatcher[] antMatchers(String... patterns)
+    private RequestMatcher[] pathMatchers(String... patterns)
     {
-        var antMatchers = new RequestMatcher[patterns.length];
+        var pathMatchers = new RequestMatcher[patterns.length];
         for(var i = 0; i < patterns.length; i++) {
-            antMatchers[i] = AntPathRequestMatcher.antMatcher(patterns[i]);
+            pathMatchers[i] = PathPatternRequestMatcher.withDefaults().matcher(patterns[i]);
         }
 
-        return antMatchers;
+        return pathMatchers;
     }
 }

--- a/server/src/test/java/org/eclipse/openvsx/IntegrationTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/IntegrationTest.java
@@ -22,6 +22,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestTemplate;
 
 import javax.cache.CacheManager;
 import java.io.IOException;
@@ -43,6 +44,9 @@ class IntegrationTest {
 
     @Autowired
     TestRestTemplate restTemplate;
+
+    @Autowired
+    RestTemplate nonRedirectingRestTemplate;
 
     @Autowired
     TestService testService;
@@ -218,7 +222,7 @@ class IntegrationTest {
 
     void getVscodeDownloadLink() throws URISyntaxException {
         var path = "/vscode/gallery/publishers/editorconfig/vsextensions/editorconfig/0.16.6/vspackage";
-        var response = restTemplate.getForEntity(apiCall(path), String.class);
+        var response = nonRedirectingRestTemplate.getForEntity(apiCall(path), String.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
         var expectedPath = "/vscode/asset/EditorConfig/EditorConfig/0.16.6/Microsoft.VisualStudio.Services.VSIXPackage";
         assertThat(response.getHeaders().getLocation()).isEqualTo(new URI(apiCall(expectedPath)));

--- a/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
@@ -33,12 +33,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.util.Streamable;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -57,19 +57,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(UserAPI.class)
 @AutoConfigureWebClient
-@MockBean({
+@MockitoBean(types = {
         EclipseService.class, ClientRegistrationRepository.class, StorageUtilService.class, CacheService.class,
         ExtensionValidator.class, SimpleMeterRegistry.class
 })
 class UserAPITest {
 
-    @SpyBean
+    @MockitoSpyBean
     UserService users;
 
-    @MockBean
+    @MockitoBean
     EntityManager entityManager;
     
-    @MockBean
+    @MockitoBean
     RepositoryService repositories;
 
     @Autowired
@@ -548,6 +548,19 @@ class UserAPITest {
         @Bean
         TransactionTemplate transactionTemplate() {
             return new MockTransactionTemplate();
+        }
+
+        @Bean
+        UserService userService(
+                EntityManager entityManager,
+                RepositoryService repositories,
+                StorageUtilService storageUtil,
+                CacheService cache,
+                ExtensionValidator validator,
+                @Autowired(required = false) ClientRegistrationRepository clientRegistrationRepository,
+                OAuth2AttributesConfig attributesConfig
+        ) {
+            return new UserService(entityManager, repositories, storageUtil, cache, validator, clientRegistrationRepository, attributesConfig);
         }
 
         @Bean

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
@@ -40,7 +40,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.elasticsearch.core.SearchHit;
@@ -49,6 +48,7 @@ import org.springframework.data.elasticsearch.core.TotalHitsRelation;
 import org.springframework.data.util.Streamable;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -59,6 +59,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -72,24 +73,24 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(VSCodeAPI.class)
 @AutoConfigureWebClient
-@MockBean({
+@MockitoBean( types = {
     ClientRegistrationRepository.class, GoogleCloudStorageService.class, AzureBlobStorageService.class,
     AwsStorageService.class, AzureDownloadCountService.class, CacheService.class, UpstreamVSCodeService.class,
-    VSCodeIdService.class, EntityManager.class, EclipseService.class, ExtensionValidator.class, SimpleMeterRegistry.class,
+    VSCodeIdService.class, EclipseService.class, ExtensionValidator.class, SimpleMeterRegistry.class,
     FileCacheDurationConfig.class
 })
 class VSCodeAPITest {
 
-    @MockBean
+    @MockitoBean
     EntityManager entityManager;
 
-    @MockBean
+    @MockitoBean
     RepositoryService repositories;
 
-    @MockBean
+    @MockitoBean
     SearchUtilService search;
 
-    @MockBean
+    @MockitoBean
     ExtensionVersionIntegrityService integrityService;
 
     @Autowired
@@ -632,7 +633,7 @@ class VSCodeAPITest {
         List<SearchHit<ExtensionSearch>> searchResults = !builtInExtensionNamespace.equals(namespaceName)
                 ? Collections.singletonList(new SearchHit<>("0", "1", null, 1.0f, null, null, null, null, null, null, entry1))
                 : Collections.emptyList();
-        var searchHits = new SearchHitsImpl<>(searchResults.size(), TotalHitsRelation.EQUAL_TO, 1.0f, "1", null,
+        var searchHits = new SearchHitsImpl<>(searchResults.size(), TotalHitsRelation.EQUAL_TO, 1.0f, Duration.ZERO, null, null,
                 searchResults, null, null, null);
 
         Mockito.when(integrityService.isEnabled())

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeIdUpdateServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeIdUpdateServiceTest.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
@@ -28,10 +28,10 @@ import java.util.UUID;
 @ExtendWith(SpringExtension.class)
 class VSCodeIdUpdateServiceTest {
 
-    @MockBean
+    @MockitoBean
     RepositoryService repositories;
 
-    @MockBean
+    @MockitoBean
     VSCodeIdService idService;
 
     @Autowired

--- a/server/src/test/java/org/eclipse/openvsx/admin/AdminAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/admin/AdminAPITest.java
@@ -38,8 +38,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.util.Streamable;
@@ -47,6 +45,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -69,7 +69,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(AdminAPI.class)
 @AutoConfigureWebClient
-@MockBean({
+@MockitoBean(types = {
     ClientRegistrationRepository.class, UpstreamRegistryService.class, GoogleCloudStorageService.class,
     AzureBlobStorageService.class, AwsStorageService.class, VSCodeIdService.class, AzureDownloadCountService.class,
     CacheService.class, PublishExtensionVersionHandler.class, SearchUtilService.class, EclipseService.class,
@@ -77,19 +77,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 })
 class AdminAPITest {
     
-    @SpyBean
+    @MockitoSpyBean
     UserService users;
 
-    @MockBean
+    @MockitoBean
     JobRequestScheduler scheduler;
 
-    @MockBean
+    @MockitoBean
     RepositoryService repositories;
 
-    @MockBean
+    @MockitoBean
     EntityManager entityManager;
 
-    @MockBean
+    @MockitoBean
     ExtensionVersionIntegrityService integrityService;
 
     @Autowired
@@ -1287,6 +1287,19 @@ class AdminAPITest {
         @Bean
         TransactionTemplate transactionTemplate() {
             return new MockTransactionTemplate();
+        }
+
+        @Bean
+        UserService userService(
+                EntityManager entityManager,
+                RepositoryService repositories,
+                StorageUtilService storageUtil,
+                CacheService cache,
+                ExtensionValidator validator,
+                @Autowired(required = false) ClientRegistrationRepository clientRegistrationRepository,
+                OAuth2AttributesConfig attributesConfig
+        ) {
+            return new UserService(entityManager, repositories, storageUtil, cache, validator, clientRegistrationRepository, attributesConfig);
         }
 
         @Bean

--- a/server/src/test/java/org/eclipse/openvsx/admin/AdminStatisticsJobRequestHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/admin/AdminStatisticsJobRequestHandlerTest.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Map;
@@ -25,10 +25,10 @@ import java.util.Map;
 @ExtendWith(SpringExtension.class)
 class AdminStatisticsJobRequestHandlerTest {
 
-    @MockBean
+    @MockitoBean
     RepositoryService repositories;
 
-    @MockBean
+    @MockitoBean
     AdminStatisticsService service;
 
     @Autowired

--- a/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
@@ -32,10 +32,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.util.Streamable;
 import org.springframework.http.*;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.client.HttpClientErrorException;
@@ -52,20 +52,20 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(SpringExtension.class)
-@MockBean({
+@MockitoBean(types = {
     EntityManager.class, SearchUtilService.class, GoogleCloudStorageService.class, AzureBlobStorageService.class,
     AwsStorageService.class, VSCodeIdService.class, AzureDownloadCountService.class, CacheService.class,
     UserService.class, PublishExtensionVersionHandler.class, SimpleMeterRegistry.class, FileCacheDurationConfig.class
 })
 class EclipseServiceTest {
 
-    @MockBean
+    @MockitoBean
     RepositoryService repositories;
 
-    @MockBean
+    @MockitoBean
     TokenService tokens;
 
-    @MockBean
+    @MockitoBean
     RestTemplate restTemplate;
 
     @Autowired

--- a/server/src/test/java/org/eclipse/openvsx/publish/ExtensionVersionIntegrityServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/ExtensionVersionIntegrityServiceTest.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
@@ -34,7 +34,7 @@ import java.util.zip.ZipFile;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
-@MockBean({ CacheService.class, RepositoryService.class, EntityManager.class })
+@MockitoBean(types = { CacheService.class, RepositoryService.class, EntityManager.class })
 class ExtensionVersionIntegrityServiceTest {
 
     @Autowired

--- a/server/src/test/java/org/eclipse/openvsx/search/DatabaseSearchServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/search/DatabaseSearchServiceTest.java
@@ -20,10 +20,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.util.Streamable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.LocalDateTime;
@@ -34,10 +34,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(SpringExtension.class)
 class DatabaseSearchServiceTest {
 
-    @MockBean
+    @MockitoBean
     EntityManager entityManager;
 
-    @MockBean
+    @MockitoBean
     RepositoryService repositories;
 
     @Autowired

--- a/server/src/test/java/org/eclipse/openvsx/search/ElasticSearchServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/search/ElasticSearchServiceTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.IndexOperations;
@@ -39,16 +39,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(SpringExtension.class)
-@MockBean({JobRequestScheduler.class})
+@MockitoBean(types = {JobRequestScheduler.class})
 class ElasticSearchServiceTest {
 
-    @MockBean
+    @MockitoBean
     EntityManager entityManager;
 
-    @MockBean
+    @MockitoBean
     RepositoryService repositories;
 
-    @MockBean
+    @MockitoBean
     ElasticsearchOperations searchOperations;
 
     @Autowired

--- a/server/src/test/java/org/eclipse/openvsx/storage/AzureBlobStorageServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/storage/AzureBlobStorageServiceTest.java
@@ -9,10 +9,6 @@
  * ****************************************************************************** */
 package org.eclipse.openvsx.storage;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.net.URI;
-
 import org.eclipse.openvsx.cache.FilesCacheKeyGenerator;
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.ExtensionVersion;
@@ -22,12 +18,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 @ExtendWith(SpringExtension.class)
-@MockBean({ StorageUtilService.class })
+@MockitoBean(types = { StorageUtilService.class })
 class AzureBlobStorageServiceTest {
 
     @Autowired

--- a/server/src/test/java/org/eclipse/openvsx/web/SitemapControllerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/web/SitemapControllerTest.java
@@ -24,9 +24,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -37,12 +37,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(SitemapController.class)
 @AutoConfigureWebClient
-@MockBean({
+@MockitoBean(types = {
         EclipseService.class, SimpleMeterRegistry.class, UserService.class, TokenService.class, EntityManager.class
 })
 class SitemapControllerTest {
 
-    @MockBean
+    @MockitoBean
     RepositoryService repositories;
 
     @Autowired


### PR DESCRIPTION
- Fix tests
- Let Spring determine version of `org.apache.httpcomponents.client5:httpclient5`
- Fix `SearchHitsImpl` instance creation
- Replace ant matcher with path matcher
- Only throw `IllegalArgumentException` if `ovsx.integrity.key-pair` has a value