### PR TITLE
Makes the menu user avatar link to the user profile

### DIFF
--- a/webui/src/pages/user/avatar.tsx
+++ b/webui/src/pages/user/avatar.tsx
@@ -61,7 +61,7 @@ export const UserAvatar: FunctionComponent = () => {
             transformOrigin={{ vertical: 'top', horizontal: 'right' }}
             onClose={handleClose} >
             <AvatarMenuItem>
-                <Link href={user.homepage} underline='hover'>
+                <Link href={UserSettingsRoutes.PROFILE} underline='hover'>
                     <Typography variant='body2' color='text.primary'>
                         Logged in as
                     </Typography>


### PR DESCRIPTION
<img width="1828" height="1806" alt="CleanShot 2025-08-21 at 15 26 39" src="https://github.com/user-attachments/assets/e13e66d6-4b9c-4f5e-92de-012388064b9a" />

I believe the first link on this dropdown should go to the user's profile in Open VSX, and not to their GitHub URL, that's rather confusing.