### PR TITLE
chore: bump org.springframework.boot to 3.5.5

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'jacoco'
     id 'nu.studer.jooq' version '8.2.1'
     id 'de.undercouch.download' version '5.4.0'
-    id 'org.springframework.boot' version '3.5.3'
+    id 'org.springframework.boot' version '3.5.5'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'io.gatling.gradle' version '3.9.5'
     id 'java'


### PR DESCRIPTION
Bump org.springframework.boot to 3.5.5

Related issue: https://github.com/eclipse/openvsx/issues/1324