### PR TITLE
chore: bump springframework-boot to 3.5.6 version

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'jacoco'
     id 'nu.studer.jooq' version '8.2.1'
     id 'de.undercouch.download' version '5.4.0'
-    id 'org.springframework.boot' version '3.5.5'
+    id 'org.springframework.boot' version '3.5.6'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'io.gatling.gradle' version '3.9.5'
     id 'java'


### PR DESCRIPTION
This PR upgrades [Spring Boot to 3.5.6](https://github.com/spring-projects/spring-boot/releases/tag/v3.5.6), this version uses Spring Framework 6.2.11 and Spring Security 6.5.5 that contain a few major CVE (cve-2025-41248, cve-2025-41249) fixes.

Hello @amvanbaren, Since I can't join the slack channel:

<img width="1143" height="335" alt="Image" src="https://github.com/user-attachments/assets/eb38c14b-7a37-4bae-8d82-8b726677fcde" />

I'm not sure where is the best place to ask questions. So, I ask here: do you have an ETA for when the new release will happen? 
Asking because we'd like to have current changes and https://github.com/eclipse/openvsx/pull/1327 in the next release. 