### PR TITLE
Fix search relevance

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
@@ -284,7 +284,7 @@ public class ElasticSearchService implements ISearchService {
         }
 
         var queryBuilder = new NativeQueryBuilder();
-        queryBuilder.withQuery(builder -> builder.bool(boolQuery -> createSearchQuery(boolQuery, options)));
+        createQuery(queryBuilder, options);
 
         // Sort search results according to 'sortOrder' and 'sortBy' options
         sortResults(queryBuilder, options.sortOrder(), options.sortBy());
@@ -396,6 +396,22 @@ public class ElasticSearchService implements ISearchService {
         return boolQuery;
     }
 
+    private void createQuery(NativeQueryBuilder queryBuilder, Options options) {
+        if(SortBy.RELEVANCE.equals(options.sortBy())) {
+            queryBuilder.withQuery(
+                    builder -> builder.functionScore(
+                            scoreQuery -> scoreQuery.query(
+                                    sortQueryBuilder -> sortQueryBuilder.bool(boolQuery -> createSearchQuery(boolQuery, options))
+                            ).functions(
+                                    functionBuilder -> functionBuilder.fieldValueFactor(factor -> factor.field("relevance").factor(1.0))
+                            )
+                    )
+            );
+        } else {
+            queryBuilder.withQuery(builder -> builder.bool(boolQuery -> createSearchQuery(boolQuery, options)));
+        }
+    }
+
     private void sortResults(NativeQueryBuilder queryBuilder, String sortOrder, String sortBy) {
         sortOrder = sortOrder.toLowerCase();
         var orders = Map.of("asc", SortOrder.Asc, "desc", SortOrder.Desc);
@@ -418,7 +434,7 @@ public class ElasticSearchService implements ISearchService {
 
         var scoreSort = new SortOptions.Builder().score(builder -> builder.order(order)).build();
         var fieldSort = new SortOptions.Builder().field(builder -> builder.field(sortBy).unmappedType(type).order(order)).build();
-        var sortOptions = sortBy.equals(SortBy.RELEVANCE) ? List.of(scoreSort, fieldSort) : List.of(fieldSort, scoreSort);
+        var sortOptions = sortBy.equals(SortBy.RELEVANCE) ? List.of(scoreSort) : List.of(fieldSort, scoreSort);
         queryBuilder.withSort(sortOptions);
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/search/RelevanceService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/RelevanceService.java
@@ -79,15 +79,7 @@ public class RelevanceService {
     private double calculateRelevance(Extension extension, ExtensionVersion latest, SearchStats stats, ExtensionSearch entry) {
         var extensionId = NamingUtil.toExtensionId(extension);
         logger.debug(">> [{}] CALCULATE RELEVANCE", extensionId);
-        var ratingValue = 0.0;
-        if (extension.getAverageRating() != null) {
-            logger.debug("[{}] INCLUDE AVG RATING", extensionId);
-            var reviewCount = extension.getReviewCount();
-            // Reduce the rating relevance if there are only few reviews
-            var countRelevance = saturate(reviewCount, 0.25);
-            ratingValue = (extension.getAverageRating() / 5.0) * countRelevance;
-            logger.debug("[{}] {} = {} * {} | {}", extensionId, ratingValue, extension.getAverageRating() / 5.0, countRelevance, reviewCount);
-        }
+        var ratingValue = calculateRating(extension, stats) / 5.0;
         var downloadsValue = entry.getDownloadCount() / stats.downloadRef;
         var timestamp = latest.getTimestamp();
         var timestampValue = Duration.between(stats.oldest, timestamp).toSeconds() / stats.timestampRef;
@@ -128,10 +120,6 @@ public class RelevanceService {
         return Math.clamp(value, 0.0, 1.0);
     }
 
-    private double saturate(double value, double factor) {
-        return 1 - 1.0 / (value * factor + 1);
-    }
-
     private boolean isVerified(ExtensionVersion extVersion) {
         if (extVersion.getPublishedWith() == null)
             return false;
@@ -148,9 +136,8 @@ public class RelevanceService {
 
         public SearchStats(RepositoryService repositories) {
             var now = TimeUtil.getCurrentUTC();
-            var maxDownloads = repositories.getMaxExtensionDownloadCount();
             var oldestTimestamp = repositories.getOldestExtensionTimestamp();
-            this.downloadRef = maxDownloads * 1.5 + 100;
+            this.downloadRef = Math.max(repositories.getMaxExtensionDownloadCount(), 1);
             this.oldest = oldestTimestamp == null ? now : oldestTimestamp;
             this.timestampRef = Duration.between(this.oldest, now).toSeconds() + 60;
             this.averageReviewRating = repositories.getAverageReviewRating();

--- a/server/src/test/java/org/eclipse/openvsx/search/DatabaseSearchServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/search/DatabaseSearchServiceTest.java
@@ -61,6 +61,8 @@ class DatabaseSearchServiceTest {
         var ext2 = mockExtension("java", 4.0, 100, 10000, "redhat", List.of("Snippets", "Programming Languages"));
         var ext3 = mockExtension("openshift", 1.0, 100, 10, "redhat", List.of("Snippets", "Other"));
         Mockito.when(repositories.findAllActiveExtensions()).thenReturn(Streamable.of(List.of(ext1, ext2, ext3)));
+        Mockito.when(repositories.getMaxExtensionDownloadCount()).thenReturn(10000);
+        Mockito.when(repositories.getAverageReviewRating()).thenReturn(3.96735905);
 
         var searchOptions = searchOptions(null, null, 50, 0, null, SortBy.RELEVANCE);
         var result = search.search(searchOptions);
@@ -79,6 +81,8 @@ class DatabaseSearchServiceTest {
         var ext1 = mockExtension("yaml", 3.0, 100, 0, "redhat", List.of("Snippets", "Programming Languages"));
         var ext2 = mockExtension("java", 4.0, 100, 0, "redhat", List.of("Snippets", "Programming Languages"));
         Mockito.when(repositories.findAllActiveExtensions()).thenReturn(Streamable.of(List.of(ext1, ext2)));
+        Mockito.when(repositories.getMaxExtensionDownloadCount()).thenReturn(0);
+        Mockito.when(repositories.getAverageReviewRating()).thenReturn(3.5);
 
         var searchOptions = searchOptions(null, "Programming Languages", 50, 0, "desc", null);
         var result = search.search(searchOptions);


### PR DESCRIPTION
Fixes EclipseFdn/open-vsx.org#3194

- Use function_score query when sort by relevance
- Use IMDB rating formula for rating relevance
- Remove magic constants for downloadRef