### PR TITLE
Fix refreshing eclipse oauth2 token

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/eclipse/TokenService.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/TokenService.java
@@ -27,6 +27,8 @@ import org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType;
 import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -118,18 +120,19 @@ public class TokenService {
         var tokenUri = reg.getProviderDetails().getTokenUri();
 
         var headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
 
         var objectMapper = new ObjectMapper();
-        var data = objectMapper.createObjectNode()
-                .put("grant_type", "refresh_token")
-                .put("client_id", reg.getClientId())
-                .put("client_secret", reg.getClientSecret())
-                .put("refresh_token", token.refreshToken());
+
+        var data = new LinkedMultiValueMap<>();
+        data.add("grant_type", "refresh_token");
+        data.add("client_id", reg.getClientId());
+        data.add("client_secret", reg.getClientSecret());
+        data.add("refresh_token", token.refreshToken());
 
         try {
-            var request = new HttpEntity<>(objectMapper.writeValueAsString(data), headers);
+            var request = new HttpEntity<>(data, headers);
             var restTemplate = new RestTemplate();
             var response = restTemplate.postForObject(tokenUri, request, String.class);
             var root = objectMapper.readTree(response);


### PR DESCRIPTION
This fixes #1387 .

Since the Eclipse oauth provider has switched to keycloak, refreshing an existing token did not work anymore as keycloak expects the POST parameters provided with `application/x-www-form-urlencoded` instead of json.