### PR TITLE
feat: centering banner button

### DIFF
--- a/webui/src/components/banner.tsx
+++ b/webui/src/components/banner.tsx
@@ -39,11 +39,11 @@ export const Banner: FunctionComponent<PropsWithChildren<BannerProps>> = props =
                 </Grid>
                 {
                     props.showDismissButton &&
-                    <Grid item xs={12} sm='auto' sx={{ 
-                        whiteSpace: 'nowrap', 
-                        alignSelf: 'center', 
+                    <Grid item xs={12} sm='auto' sx={{
+                        whiteSpace: 'nowrap',
+                        alignSelf: 'center',
                         display: 'flex',
-                        justifyContent: 'center', 
+                        justifyContent: 'center',
                         flexBasis: '100%'
                     }}>
                         <Button


### PR DESCRIPTION
Related to https://github.com/EclipseFdn/open-vsx.org/issues/221

This patch centres the ‘Got it’ button on the vertical axes for desktop, and on the horizontal axes for mobile.

https://github.com/user-attachments/assets/4121990e-141d-4bc2-8d43-09b284541bd6