### PR TITLE
Add configuration setting to disable automatic storage migration

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageMigration.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageMigration.java
@@ -33,6 +33,7 @@ import static org.eclipse.openvsx.entities.FileResource.*;
 
 @Component
 @ConditionalOnProperty(value = "ovsx.data.mirror.enabled", havingValue = "false", matchIfMissing = true)
+@ConditionalOnProperty(value = "ovsx.storage.migration.enabled", havingValue = "true", matchIfMissing = true)
 public class StorageMigration {
 
     protected final Logger logger = LoggerFactory.getLogger(StorageMigration.class);


### PR DESCRIPTION
This PR allows to specify a configuration option `osvx.storage.migration.enabled` to explicitly disable the automatic storage migration in case the primary storage type has changed.

If this option is not specified it behaves as before, enabling the storage migration if mirror mode is disabled.

The reasoning for this change is that the existing storage migration only runs sequentially and for a large instance of openvsx it will be impractical so we want to explicitly disable the automatic migration to perform it manually while still be able to set the primary storage type to another one.

For the change also the wiki page about the deployment needs to be adapted to document this new setting.