### PR TITLE
Fix order of parameters passed in the NamingUtil

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/cache/ExtensionJsonCacheKeyGenerator.java
+++ b/server/src/main/java/org/eclipse/openvsx/cache/ExtensionJsonCacheKeyGenerator.java
@@ -26,6 +26,6 @@ public class ExtensionJsonCacheKeyGenerator implements KeyGenerator {
     }
 
     public String generate(String namespaceName, String extensionName, String targetPlatform, String version) {
-        return NamingUtil.toFileFormat(namespaceName, extensionName, version, targetPlatform);
+        return NamingUtil.toFileFormat(namespaceName, extensionName, targetPlatform, version);
     }
 }


### PR DESCRIPTION
The ExtensionJsonCacheKeyGenerator class passes the `version` and `targetPlatform` parameters in the wrong order to the `NamingUtil.toFileFormat`.