### PR TITLE
Fix gatling configuration / setup after upgrade to Java 25

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -8,13 +8,14 @@ buildscript {
     }
 }
 plugins {
+    id 'java'
+    id 'scala'
     id 'jacoco'
     id 'org.jooq.jooq-codegen-gradle' version '3.19.26'
     id 'de.undercouch.download' version '5.4.0'
     id 'org.springframework.boot' version '3.5.6'
     id 'io.spring.dependency-management' version '1.1.0'
-    id 'io.gatling.gradle' version '3.9.5'
-    id 'java'
+    id 'io.gatling.gradle' version '3.14.9'
     id 'maven-publish'
 }
 apply plugin: 'org.hibernate.orm'
@@ -40,7 +41,7 @@ def versions = [
     commons_lang3: '3.12.0',
     jaxb_api: '2.3.1',
     jaxb_impl: '2.3.8',
-    gatling: '3.9.5',
+    gatling: '3.14.9',
     loki4j: '1.4.2',
     jedis: '6.2.0'
 ]
@@ -69,6 +70,22 @@ configurations {
     devRuntimeOnly.extendsFrom runtimeOnly
 
     gatling.exclude group: "io.gatling.highcharts", module: "gatling-charts-highcharts"
+}
+
+dependencyManagement {
+    gatling {
+        dependencies {
+            dependencySet(group: 'io.netty', version: '4.2.7.Final') {
+                entry 'netty-codec-http'
+                entry 'netty-codec'
+                entry 'netty-handler'
+                entry 'netty-buffer'
+                entry 'netty-transport'
+                entry 'netty-common'
+                entry 'netty-transport-native-epoll'
+            }
+        }
+    }
 }
 
 dependencies {
@@ -224,6 +241,12 @@ jacocoTestReport {
     }
 
     dependsOn test // tests are required to run before generating the report
+}
+
+tasks.withType(ScalaCompile).configureEach {
+    scalaCompileOptions.forkOptions.with {
+        jvmArgs = ['-Xss100m'] // Scala compiler may require a larger stack size when compiling Gatling simulations
+    }
 }
 
 apply from: 'dependencies.gradle'


### PR DESCRIPTION
After the upgrade to Java 25 and gradle wrapper upgrade, the gatling plugin was not working anymore.

This PR fixes the setup. Main issue was the missing scala plugin and that the gatling configuration was inheriting an incompatible netty version.