### PR TITLE
chore(deps): bump apache:tika to 3.2.2 version

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -35,7 +35,7 @@ def versions = [
     jobrunr: '7.5.0',
     bucket4j: '0.12.7',
     bucket4j_redis: '8.10.1',
-    tika: '3.1.0',
+    tika: '3.2.2',
     bouncycastle: '1.80',
     commons_lang3: '3.12.0',
     jaxb_api: '2.3.1',


### PR DESCRIPTION
Update apache:tika version to 3.2.2 to fix critical CVE: CVE-2025-66516