### PR TITLE
Encode '+' in URL path segments to support SemVer build metadata

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/util/UrlUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/UrlUtil.java
@@ -101,7 +101,12 @@ public final class UrlUtil {
 
         var path = Arrays.stream(segments)
                 .filter(StringUtils::isNotEmpty)
-                .map(segment -> UriUtils.encodePathSegment(segment, StandardCharsets.UTF_8))
+                .map(segment ->
+                    UriUtils.encodePathSegment(segment, StandardCharsets.UTF_8)
+                        .replace("+", "%2B")
+)
+
+
                 .collect(Collectors.joining("/"));
 
         if (baseUrl.isEmpty() || baseUrl.charAt(baseUrl.length() - 1) != '/') {


### PR DESCRIPTION
Semantic Versioning lets us use "+" for build metadata (like 1.0.0+10), but AWS S3 sees "+" as a space even in URL path segments, which causes 403 errors when we try to access extension resources. This change makes sure that '+' is always encoded as '%2B' when building API URLs in UrlUtil.createApiUrl. This keeps Semantic Versioning the same. 

In short It was possible to publish extensions that used Semantic Versioning with build metadata (for example, 1.0.0+10), but later they wouldn't load or download, which caused 403 errors. The + sign in URLs is treated as a space by AWS S3, even in path segments. 

UriUtils.encodePathSegment not encoding the + character when making API URLs was the cause of the problem. Because of this, URLs with versions that had + were made wrong for resources that were backed by S3. When making URL path segments, this change fixes the problem by explicitly encoding + as %2B in UrlUtil.createApiUrl. The fix is applied in one place, so it affects all API URLs in the same way, without changing Semantic Versioning.