### PR TITLE
feat: using datagrid for tier & customer views

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -41,6 +41,8 @@
         "@mui/base": "^5.0.0-beta.9",
         "@mui/icons-material": "^5.13.7",
         "@mui/material": "^5.13.7",
+        "@mui/system": "^5.15.15",
+        "@mui/x-data-grid": "^7",
         "clipboard-copy": "^4.0.1",
         "clsx": "^1.2.1",
         "dompurify": "^3.0.4",

--- a/webui/src/pages/admin-dashboard/components/data-grid-filter-operators.tsx
+++ b/webui/src/pages/admin-dashboard/components/data-grid-filter-operators.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import React, { FC } from 'react';
+import { Autocomplete, TextField } from '@mui/material';
+import { GridFilterOperator, GridFilterInputValueProps } from '@mui/x-data-grid';
+
+/**
+ * Custom multi-select filter input component for DataGrid columns.
+ * Renders an Autocomplete with multiple selection support.
+ */
+export const MultiSelectFilterInput: FC<GridFilterInputValueProps & { options: string[] }> = ({
+  item,
+  applyValue,
+  options
+}) => {
+  const handleChange = (_event: React.SyntheticEvent, newValue: string[]) => {
+    applyValue({ ...item, value: newValue });
+  };
+
+  return (
+    <Autocomplete
+      multiple
+      size='small'
+      options={options}
+      value={(item.value as string[]) || []}
+      onChange={handleChange}
+      renderInput={(params) => (
+        <TextField {...params} variant='standard' placeholder='Filter...' />
+      )}
+      sx={{ minWidth: 150, mt: 'auto' }}
+    />
+  );
+};
+
+/**
+ * Creates filter operators for single-value columns with multi-select capability.
+ * Includes "is any of" and "is none of" operators.
+ *
+ * @param options - Array of possible values to select from
+ * @returns Array of GridFilterOperator for use in column definition
+ *
+ */
+export const createMultiSelectFilterOperators = (options: string[]): GridFilterOperator[] => [
+  {
+    label: 'is any of',
+    value: 'isAnyOf',
+    getApplyFilterFn: (filterItem) => {
+      if (!filterItem.value || (filterItem.value as string[]).length === 0) {
+        return null;
+      }
+      const filterValues = filterItem.value as string[];
+
+      return (value) => filterValues.indexOf(value as string) !== -1;
+    },
+    InputComponent: (props: GridFilterInputValueProps) => (
+      <MultiSelectFilterInput {...props} options={options} />
+    ),
+  },
+  {
+    label: 'is none of',
+    value: 'isNoneOf',
+    getApplyFilterFn: (filterItem) => {
+      if (!filterItem.value || (filterItem.value as string[]).length === 0) {
+        return null;
+      }
+      const filterValues = filterItem.value as string[];
+
+      return (value) => filterValues.indexOf(value as string) === -1;
+    },
+    InputComponent: (props: GridFilterInputValueProps) => (
+      <MultiSelectFilterInput {...props} options={options} />
+    ),
+  },
+];
+
+/**
+ * Creates filter operators for array-type columns with multi-select capability.
+ * Includes "contains any of" and "contains none of" operators.
+ *
+ * @param options - Array of possible values to select from
+ * @returns Array of GridFilterOperator for use in column definition
+ *
+ */
+export const createArrayContainsFilterOperators = (options: string[]): GridFilterOperator[] => [
+  {
+    label: 'contains any of',
+    value: 'containsAnyOf',
+    getApplyFilterFn: (filterItem) => {
+      if (!filterItem.value || (filterItem.value as string[]).length === 0) {
+        return null;
+      }
+      const filterValues = filterItem.value as string[];
+
+      return (value) => filterValues.some(fv => (value as string[]).indexOf(fv) !== -1);
+    },
+    InputComponent: (props: GridFilterInputValueProps) => (
+      <MultiSelectFilterInput {...props} options={options} />
+    ),
+  },
+  {
+    label: 'contains none of',
+    value: 'containsNoneOf',
+    getApplyFilterFn: (filterItem) => {
+      if (!filterItem.value || (filterItem.value as string[]).length === 0) {
+        return null;
+      }
+      const filterValues = filterItem.value as string[];
+
+      return (value) => !filterValues.some(fv => (value as string[]).indexOf(fv) !== -1);
+    },
+    InputComponent: (props: GridFilterInputValueProps) => (
+      <MultiSelectFilterInput {...props} options={options} />
+    ),
+  },
+];

--- a/webui/src/pages/admin-dashboard/components/index.ts
+++ b/webui/src/pages/admin-dashboard/components/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+export {
+  MultiSelectFilterInput,
+  createMultiSelectFilterOperators,
+  createArrayContainsFilterOperators
+} from './data-grid-filter-operators';

--- a/webui/src/pages/admin-dashboard/customers/customer-form-dialog.tsx
+++ b/webui/src/pages/admin-dashboard/customers/customer-form-dialog.tsx
@@ -42,6 +42,7 @@ interface CustomerFormDialogProps {
     onSubmit: (formData: Customer) => Promise<void>;
 }
 
+
 const Code = styled('code')(({ theme }) => ({
   fontFamily: 'source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace',
   backgroundColor: theme.palette.action.hover, // Subtle gray background
@@ -127,7 +128,7 @@ export const CustomerFormDialog: FC<CustomerFormDialogProps> = ({ open, customer
     const handleBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const { name } = e.target;
         setTouched(prev => ({ ...prev, [name]: true }));
-        
+
         // Validate the specific field on blur
         validateField(name);
     };
@@ -168,7 +169,7 @@ export const CustomerFormDialog: FC<CustomerFormDialogProps> = ({ open, customer
 
         // Validate all entries
         const invalidEntries = value.filter(cidr => !isValidCIDR(cidr.trim()));
-        
+
         if (invalidEntries.length > 0) {
             setTouched(prev => ({ ...prev, cidrBlocks: true }));
             setErrors(prev => ({
@@ -176,7 +177,7 @@ export const CustomerFormDialog: FC<CustomerFormDialogProps> = ({ open, customer
                 cidrBlocks: `Invalid CIDR block(s): ${invalidEntries.join(', ')}. Please enter valid IPv4 or IPv6 CIDR notation.`
             }));
         }
-        
+
         // Always update the value so the user can see and correct invalid entries
         setFormData(prev => ({
             ...prev,

--- a/webui/yarn.lock
+++ b/webui/yarn.lock
@@ -287,6 +287,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.25.7, @babel/runtime@npm:^7.28.4":
+  version: 7.28.6
+  resolution: "@babel/runtime@npm:7.28.6"
+  checksum: 10/fbcd439cb74d4a681958eb064c509829e3f46d8a4bfaaf441baa81bb6733d1e680bccc676c813883d7741bcaada1d0d04b15aa320ef280b5734e2192b50decf9
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.25.0":
   version: 7.25.0
   resolution: "@babel/template@npm:7.25.0"
@@ -930,6 +937,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/types@npm:^7.4.10":
+  version: 7.4.10
+  resolution: "@mui/types@npm:7.4.10"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/7492c6aa0b55e1d3c2bcbac7d3e0a41fe684aa5927a26911d9b6bef5d1ad85e578614af5da1f61e7ea0b37318d3c595bff29ae9af6f345572ad8d23cbd2211d0
+  languageName: node
+  linkType: hard
+
 "@mui/utils@npm:^5.15.14":
   version: 5.15.14
   resolution: "@mui/utils@npm:5.15.14"
@@ -948,6 +969,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/utils@npm:^5.16.6 || ^6.0.0 || ^7.0.0":
+  version: 7.3.7
+  resolution: "@mui/utils@npm:7.3.7"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.4"
+    "@mui/types": "npm:^7.4.10"
+    "@types/prop-types": "npm:^15.7.15"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.2.3"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/8b4110df220c7a3f4feee4e88b870fef20ac22499d24d572597f78ea6b586e28b19aac7f7cd2ed0b500d1b0b54b3b8b57d8d63cfa4f5a5cbae1c4527fbd77cbe
+  languageName: node
+  linkType: hard
+
 "@mui/utils@npm:^6.0.0-dev.20240529-082515-213b5e33ab":
   version: 6.0.0-dev.20240529-082515-213b5e33ab
   resolution: "@mui/utils@npm:6.0.0-dev.20240529-082515-213b5e33ab"
@@ -963,6 +1004,45 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/fa785f4cdc6c31c20279f955a0442462c8d73ae7e99a5277d6a6a3c34a1e522fc254e775493969308d25476f1854479cb3fe1cf5206ee2937d1eb55fc3bab904
+  languageName: node
+  linkType: hard
+
+"@mui/x-data-grid@npm:^7":
+  version: 7.29.12
+  resolution: "@mui/x-data-grid@npm:7.29.12"
+  dependencies:
+    "@babel/runtime": "npm:^7.25.7"
+    "@mui/utils": "npm:^5.16.6 || ^6.0.0 || ^7.0.0"
+    "@mui/x-internals": "npm:7.29.0"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    reselect: "npm:^5.1.1"
+    use-sync-external-store: "npm:^1.0.0"
+  peerDependencies:
+    "@emotion/react": ^11.9.0
+    "@emotion/styled": ^11.8.1
+    "@mui/material": ^5.15.14 || ^6.0.0 || ^7.0.0
+    "@mui/system": ^5.15.14 || ^6.0.0 || ^7.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: 10/a5557d85beb9991970b47b83303142342b3d223c568c174ddf61d5bbad2b2b48ed132d875274837a062c0bc76d5c65fd45d30ba21618a7ca77b0739caa59a96f
+  languageName: node
+  linkType: hard
+
+"@mui/x-internals@npm:7.29.0":
+  version: 7.29.0
+  resolution: "@mui/x-internals@npm:7.29.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.25.7"
+    "@mui/utils": "npm:^5.16.6 || ^6.0.0 || ^7.0.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/53ab96dd7719f2c18488c648ade3e45d58028fbbb99da9c3199f9190bcbdbedb06e7e397338b261ef0738d7973c66a6a43cffe4047e18919e210b67bfbe8ea87
   languageName: node
   linkType: hard
 
@@ -1290,6 +1370,13 @@ __metadata:
   version: 15.7.12
   resolution: "@types/prop-types@npm:15.7.12"
   checksum: 10/ac16cc3d0a84431ffa5cfdf89579ad1e2269549f32ce0c769321fdd078f84db4fbe1b461ed5a1a496caf09e637c0e367d600c541435716a55b1d9713f5035dfe
+  languageName: node
+  linkType: hard
+
+"@types/prop-types@npm:^15.7.15":
+  version: 15.7.15
+  resolution: "@types/prop-types@npm:15.7.15"
+  checksum: 10/31aa2f59b28f24da6fb4f1d70807dae2aedfce090ec63eaf9ea01727a9533ef6eaf017de5bff99fbccad7d1c9e644f52c6c2ba30869465dd22b1a7221c29f356
   languageName: node
   linkType: hard
 
@@ -5071,6 +5158,8 @@ __metadata:
     "@mui/base": "npm:^5.0.0-beta.9"
     "@mui/icons-material": "npm:^5.13.7"
     "@mui/material": "npm:^5.13.7"
+    "@mui/system": "npm:^5.15.15"
+    "@mui/x-data-grid": "npm:^7"
     "@playwright/test": "npm:^1.55.1"
     "@stylistic/eslint-plugin": "npm:^2.11.0"
     "@types/babel__core": "npm:^7"
@@ -5619,6 +5708,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^19.2.3":
+  version: 19.2.3
+  resolution: "react-is@npm:19.2.3"
+  checksum: 10/547ac397308204742447b5e4cf556cf09aa97f4cc1c95c4a28e4b2e73a7efab03e59d7b89b4a01f67bf9bf0ca87348a7f0e88bc87c0af6be458aaac1dec5e132
+  languageName: node
+  linkType: hard
+
 "react-router-dom@npm:^6.14.1":
   version: 6.23.1
   resolution: "react-router-dom@npm:6.23.1"
@@ -5733,6 +5829,13 @@ __metadata:
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
   checksum: 10/a72468e2589270d91f06c7d36ec97a88db53ae5d6fe3787fadc943f0b0276b10347f89b363b2a82285f650bdcc135ad4a257c61bdd4d00d6df1fa24875b0ddaf
+  languageName: node
+  linkType: hard
+
+"reselect@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "reselect@npm:5.1.1"
+  checksum: 10/1fdae11a39ed9c8d85a24df19517c8372ee24fefea9cce3fae9eaad8e9cefbba5a3d4940c6fe31296b6addf76e035588c55798f7e6e147e1b7c0855f119e7fa5
   languageName: node
   linkType: hard
 
@@ -6692,6 +6795,15 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10/b271ca7e3d46b7160222e3afa3e531505161c9a4e097febae9664e4b59912f4cbe94861361a4175edac3a03fee99d91e44b6a58c17a634bc5a664b19fc76fbcb
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.0.0":
+  version: 1.6.0
+  resolution: "use-sync-external-store@npm:1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/b40ad2847ba220695bff2d4ba4f4d60391c0fb4fb012faa7a4c18eb38b69181936f5edc55a522c4d20a788d1a879b73c3810952c9d0fd128d01cb3f22042c09e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
@netomi Here’s the implementation of MUI Datagrid for the admin views; we’ll be able to easily filter with this.

This implementation is not using the `/:tier:/customers` endpoint whatsoever.