### PR TITLE
Fix ambiguity in secret check service task executor

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/scanning/ExtensionScanCompletionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/ExtensionScanCompletionService.java
@@ -426,7 +426,6 @@ public class ExtensionScanCompletionService {
      * 3. If no failures and no threats: activate extension
      * 4. If failures or threats: log and skip (keep inactive)
      */
-    @Transactional
     private boolean completeExtensionScan(String scanId, List<ScannerJob> jobs) {
         // Get extension version ID from first job
         // All jobs in a scan group scan the same extension version

--- a/server/src/main/java/org/eclipse/openvsx/scanning/SecretCheckService.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/SecretCheckService.java
@@ -16,6 +16,7 @@ import org.eclipse.openvsx.util.TempFile;
 import org.eclipse.openvsx.util.ArchiveUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.task.AsyncTaskExecutor;
@@ -72,7 +73,7 @@ public class SecretCheckService implements PublishCheck {
             SecretDetectorConfig config,
             ExtensionScanConfig scanConfig,
             SecretDetectorFactory scannerFactory,
-            AsyncTaskExecutor taskExecutor) {
+            @Qualifier("applicationTaskExecutor") AsyncTaskExecutor taskExecutor) {
         this.config = config;
         this.scanConfig = scanConfig;
         this.taskExecutor = taskExecutor;

--- a/server/src/test/java/org/eclipse/openvsx/scanning/ScannerInvocationTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/scanning/ScannerInvocationTest.java
@@ -29,7 +29,6 @@ class ScannerInvocationTest {
         var invocation = new Scanner.Invocation.Completed(result);
 
         assertEquals(result, invocation.result());
-        assertInstanceOf(Scanner.Invocation.Completed.class, invocation);
     }
 
     @Test
@@ -38,62 +37,16 @@ class ScannerInvocationTest {
         var invocation = new Scanner.Invocation.Submitted(submission);
 
         assertEquals(submission, invocation.submission());
-        assertInstanceOf(Scanner.Invocation.Submitted.class, invocation);
     }
 
     @Test
-    void patternMatching_worksForCompleted() {
-        Scanner.Invocation invocation = new Scanner.Invocation.Completed(
-                Scanner.Result.clean()
-        );
-
-        String type = switch (invocation) {
-            case Scanner.Invocation.Completed c -> "completed";
-            case Scanner.Invocation.Submitted s -> "submitted";
-        };
-
-        assertEquals("completed", type);
-    }
-
-    @Test
-    void patternMatching_worksForSubmitted() {
-        Scanner.Invocation invocation = new Scanner.Invocation.Submitted(
-                new Scanner.Submission("job-123")
-        );
-
-        String type = switch (invocation) {
-            case Scanner.Invocation.Completed c -> "completed";
-            case Scanner.Invocation.Submitted s -> "submitted";
-        };
-
-        assertEquals("submitted", type);
-    }
-
-    @Test
-    void completed_canAccessResultDetails() {
-        var threat = new Scanner.Threat("virus", "desc", "HIGH");
+    void completed_withThreats() {
+        var threat = new Scanner.Threat("virus", "Malware detected", "HIGH");
         var result = Scanner.Result.withThreats(List.of(threat));
         var invocation = new Scanner.Invocation.Completed(result);
 
-        // Access result through pattern matching
-        if (invocation instanceof Scanner.Invocation.Completed completed) {
-            assertFalse(completed.result().isClean());
-            assertEquals(1, completed.result().getThreats().size());
-        } else {
-            fail("Should be Completed");
-        }
-    }
-
-    @Test
-    void submitted_canAccessSubmissionDetails() {
-        var submission = new Scanner.Submission("external-job-456");
-        var invocation = new Scanner.Invocation.Submitted(submission);
-
-        // Access submission through pattern matching
-        if (invocation instanceof Scanner.Invocation.Submitted submitted) {
-            assertEquals("external-job-456", submitted.submission().externalJobId());
-        } else {
-            fail("Should be Submitted");
-        }
+        assertFalse(invocation.result().isClean());
+        assertEquals(1, invocation.result().getThreats().size());
+        assertEquals("virus", invocation.result().getThreats().get(0).getName());
     }
 }

--- a/server/src/test/java/org/eclipse/openvsx/scanning/ScannerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/scanning/ScannerTest.java
@@ -139,14 +139,4 @@ class ScannerTest {
         assertEquals("LOW", threat.getSeverity());
     }
 
-    // === PollStatus enum tests ===
-
-    @Test
-    void pollStatus_hasExpectedValues() {
-        assertEquals(4, Scanner.PollStatus.values().length);
-        assertNotNull(Scanner.PollStatus.SUBMITTED);
-        assertNotNull(Scanner.PollStatus.PROCESSING);
-        assertNotNull(Scanner.PollStatus.COMPLETED);
-        assertNotNull(Scanner.PollStatus.FAILED);
-    }
 }


### PR DESCRIPTION
Fix ambiguity in secret check service task executor. Removed unneeded code.