### PR TITLE
Fix searching by publisher

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
@@ -303,7 +303,7 @@ public class ElasticSearchService implements ISearchService {
 
         if (!StringUtils.isEmpty(options.namespace())) {
             // Filter by namespace
-            boolQuery.must(QueryBuilders.term(builder -> builder.field("namespace").value(options.namespace()).caseInsensitive(true)));
+            boolQuery.must(QueryBuilders.term(builder -> builder.field("namespace.keyword").value(options.namespace()).caseInsensitive(true)));
         }
         if (!StringUtils.isEmpty(options.category())) {
             // Filter by selected category


### PR DESCRIPTION
This fixes #1522.

The original version did a term search using the analysed `namespace` field, however we want an exact match for the search by publisher, thus using `namespace.keyword` instead.