### PR TITLE
Suppress MediaTypeNotSupportedException in server logs

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/web/ServerExceptionResolver.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/ServerExceptionResolver.java
@@ -1,0 +1,38 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.jspecify.annotations.NonNull;
+import org.springframework.core.Ordered;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.support.DefaultHandlerExceptionResolver;
+
+@RestControllerAdvice
+public class ServerExceptionResolver extends DefaultHandlerExceptionResolver {
+
+    public ServerExceptionResolver() {
+        super();
+        setOrder(Ordered.HIGHEST_PRECEDENCE);
+    }
+
+    @Override
+    protected void logException(@NonNull Exception ex, @NonNull HttpServletRequest request) {
+        // do not log HttpMediaTypeNotSupportedException, see https://github.com/eclipse/openvsx/issues/1505
+        // this just pollutes the server logs but bringing no added value
+        if (!(ex instanceof HttpMediaTypeNotSupportedException)) {
+            super.logException(ex, request);
+        }
+    }
+}


### PR DESCRIPTION
This fixes #1505 .

These type of exceptions happen regularily, most probably due to bots, when spring assumes a missing `Content-Type` header though it expects one, e.g. when doing an `extensionquery`.