### PR TITLE
Add required configuration for publish checks

### DIFF
--- a/server/src/dev/resources/application.yml
+++ b/server/src/dev/resources/application.yml
@@ -179,9 +179,11 @@ ovsx:
     blocklist-check:
       enabled: true
       enforced: false
+      required: false
     similarity:
       enabled: true
       enforced: false
+      required: false
       similarity-threshold: 0.2
       skip-if-publisher-verified: false
       only-protect-verified-names: false
@@ -190,6 +192,7 @@ ovsx:
     secret-detection:
       enabled: true
       enforced: false
+      required: false
       rules-path: 'classpath:scanning/secret-detection-custom-rules.yaml'
       suppression-markers: 'secret-detector:ignore,gitleaks:allow,nosecret,@suppress-secret'
       gitleaks:

--- a/server/src/main/java/org/eclipse/openvsx/admin/ScanAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/admin/ScanAPI.java
@@ -348,6 +348,9 @@ public class ScanAPI {
             var pageNumber = offset / Math.max(size, 1);
             var pageable = PageRequest.of(pageNumber, size, sort);
             
+            // Automatically include scans with errored check results when filtering by ERRORED status
+            var includeCheckErrors = statusFilter.contains(ScanStatus.ERRORED);
+            
             var page = repositories.findScansFullyFiltered(
                 statusFilter.isEmpty() ? null : statusFilter,
                 normalizedNamespace.isEmpty() ? null : normalizedNamespace,
@@ -359,6 +362,7 @@ public class ScanAPI {
                 scannerNames,
                 enforcedOnly,
                 adminDecisionFilter,
+                includeCheckErrors,
                 pageable
             );
 
@@ -869,6 +873,7 @@ public class ScanAPI {
         json.setFindingsCount(checkResult.getFindingsCount());
         json.setSummary(checkResult.getSummary());
         json.setErrorMessage(checkResult.getErrorMessage());
+        json.setRequired(checkResult.getRequired());
         return json;
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/entities/ScanCheckResult.java
+++ b/server/src/main/java/org/eclipse/openvsx/entities/ScanCheckResult.java
@@ -125,6 +125,13 @@ public class ScanCheckResult implements Serializable {
     @Column(name = "scanner_job_id")
     private Long scannerJobId;
 
+    /**
+     * Whether this check was required (errors block publishing).
+     * When false, errors are logged but don't block publishing.
+     */
+    @Column(name = "required")
+    private Boolean required;
+
     // Getters and setters
 
     public long getId() {
@@ -229,6 +236,14 @@ public class ScanCheckResult implements Serializable {
 
     public void setScannerJobId(Long scannerJobId) {
         this.scannerJobId = scannerJobId;
+    }
+
+    public Boolean getRequired() {
+        return required;
+    }
+
+    public void setRequired(Boolean required) {
+        this.required = required;
     }
 
     /**

--- a/server/src/main/java/org/eclipse/openvsx/json/CheckResultJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/CheckResultJson.java
@@ -57,6 +57,9 @@ public class CheckResultJson {
     @Schema(description = "Error message if check failed with error")
     private String errorMessage;
 
+    @Schema(description = "Whether this check was required (errors block publishing). Null for scanner jobs.")
+    private Boolean required;
+
     // Getters and setters
 
     public String getCheckType() {
@@ -137,5 +140,13 @@ public class CheckResultJson {
 
     public void setErrorMessage(String errorMessage) {
         this.errorMessage = errorMessage;
+    }
+
+    public Boolean getRequired() {
+        return required;
+    }
+
+    public void setRequired(Boolean required) {
+        this.required = required;
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -272,7 +272,8 @@ public class PublishExtensionVersionHandler {
                             1,                       // findingsCount
                             reason,
                             null,                    // errorMessage
-                            null                     // scannerJobId - not a scanner job
+                            null,                    // scannerJobId - not a scanner job
+                            true
                     );
                     
                     // Also record as validation failure for the failures list

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -850,6 +850,7 @@ public class RepositoryService {
             @Nullable Collection<String> scannerNames,
             @Nullable Boolean enforcedOnly,
             @Nullable org.eclipse.openvsx.admin.ScanAPI.AdminDecisionFilterValues adminDecisionFilter,
+            boolean includeCheckErrors,
             org.springframework.data.domain.Pageable pageable
     ) {
         // Convert enums to strings for native query
@@ -877,7 +878,7 @@ public class RepositoryService {
             startedFrom, startedTo, checkTypesParam, applyCheckTypesFilter,
             scannerNamesParam, applyScannerNamesFilter, enforcedOnly,
             applyAdminDecisionFilter, filterAllowed, filterBlocked, filterNeedsReview,
-            pageable
+            includeCheckErrors, pageable
         );
     }
 
@@ -891,7 +892,8 @@ public class RepositoryService {
             @Nullable Collection<String> checkTypes,
             @Nullable Collection<String> scannerNames,
             @Nullable Boolean enforcedOnly,
-            @Nullable org.eclipse.openvsx.admin.ScanAPI.AdminDecisionFilterValues adminDecisionFilter
+            @Nullable org.eclipse.openvsx.admin.ScanAPI.AdminDecisionFilterValues adminDecisionFilter,
+            boolean includeCheckErrors
     ) {
         // Convert enums to strings for native query
         var statusesParam = (statuses == null || statuses.isEmpty()) 
@@ -917,7 +919,8 @@ public class RepositoryService {
             statusesParam, namespaceParam, publisherParam, nameParam, 
             startedFrom, startedTo, checkTypesParam, applyCheckTypesFilter,
             scannerNamesParam, applyScannerNamesFilter, enforcedOnly,
-            applyAdminDecisionFilter, filterAllowed, filterBlocked, filterNeedsReview
+            applyAdminDecisionFilter, filterAllowed, filterBlocked, filterNeedsReview,
+            includeCheckErrors
         );
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/scanning/BlocklistCheckConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/BlocklistCheckConfig.java
@@ -55,6 +55,18 @@ public class BlocklistCheckConfig {
     private boolean enforced;
 
     /**
+     * Whether errors during blocklist checking should block publication.
+     * <p>
+     * When true (default), exceptions during the check will block publishing.
+     * When false, exceptions are logged but publishing continues.
+     * <p>
+     * Property: {@code ovsx.scanning.blocklist-check.required}
+     * Default: {@code true}
+     */
+    @Value("${ovsx.scanning.blocklist-check.required:true}")
+    private boolean required;
+
+    /**
      * Message shown to users when their extension is blocked.
      * <p>
      * Property: {@code ovsx.scanning.blocklist-check.user-message}
@@ -69,6 +81,10 @@ public class BlocklistCheckConfig {
 
     public boolean isEnforced() {
         return enforced;
+    }
+
+    public boolean isRequired() {
+        return required;
     }
 
     public String getUserMessage() {

--- a/server/src/main/java/org/eclipse/openvsx/scanning/BlocklistCheckService.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/BlocklistCheckService.java
@@ -86,6 +86,11 @@ public class BlocklistCheckService implements PublishCheck {
     }
 
     @Override
+    public boolean isRequired() {
+        return config.isRequired();
+    }
+
+    @Override
     public String getUserFacingMessage(List<Failure> failures) {
         return config.getUserMessage();
     }

--- a/server/src/main/java/org/eclipse/openvsx/scanning/ExtensionScanService.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/ExtensionScanService.java
@@ -136,13 +136,16 @@ public class ExtensionScanService {
                 execution.findingsCount(),
                 execution.summary(),
                 execution.errorMessage(),
-                null   // scannerJobId - not applicable for publish checks
+                null,  // scannerJobId - not applicable for publish checks
+                execution.required()
             );
         }
 
-        if (checkResult.hasError()) {
+        // Handle required check errors - block publication
+        if (checkResult.hasRequiredCheckError()) {
+            var requiredError = checkResult.getRequiredErrors().get(0);
             markScanAsErrored(scan, checkResult.getErrorMessage());
-            throw new ErrorResultException(checkResult.getErrorMessage(), checkResult.error());
+            throw new ErrorResultException(checkResult.getErrorMessage(), requiredError.exception());
         }
 
         // Record all findings in the database (detailed failure records).

--- a/server/src/main/java/org/eclipse/openvsx/scanning/PublishCheck.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/PublishCheck.java
@@ -46,6 +46,18 @@ public interface PublishCheck {
     boolean isEnforced();
 
     /**
+     * Whether errors (exceptions) from this check should block publication.
+     * <p>
+     * If true (default): an exception during check execution will cause publishing to fail.
+     * If false: an exception is logged and recorded, but publishing continues.
+     * <p>
+     * This is useful for non-critical checks where availability issues shouldn't block publishing.
+     */
+    default boolean isRequired() {
+        return true;
+    }
+
+    /**
      * Execute the check.
      */
     Result check(Context context);

--- a/server/src/main/java/org/eclipse/openvsx/scanning/SecretDetectorConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/SecretDetectorConfig.java
@@ -129,6 +129,21 @@ public class SecretDetectorConfig {
     private boolean enforced;
 
     /**
+     * Whether errors (exceptions) from this check should block publishing.
+     * <p>
+     * If true (default): an error during secret scanning will cause publishing to fail.
+     * If false: errors are logged and recorded, but publishing continues.
+     * <p>
+     * Use false for non-critical deployments where secret detection availability
+     * issues (e.g., timeout, out of memory) shouldn't block all publishing.
+     * <p>
+     * Property: {@code ovsx.scanning.secret-detection.required}
+     * Default: {@code true}
+     */
+    @Value("${ovsx.scanning.secret-detection.required:true}")
+    private boolean required;
+
+    /**
      * Maximum line length to process in characters. Files with longer lines are skipped.
      * Very long lines (>10K) typically indicate minified/bundled code and may cause performance issues.
      * <p>
@@ -219,6 +234,10 @@ public class SecretDetectorConfig {
 
     public boolean isEnforced() {
         return enforced;
+    }
+
+    public boolean isRequired() {
+        return required;
     }
 
     public int getMinifiedLineThreshold() {

--- a/server/src/main/java/org/eclipse/openvsx/search/SimilarityCheckService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/SimilarityCheckService.java
@@ -66,6 +66,11 @@ public class SimilarityCheckService implements PublishCheck {
     }
 
     @Override
+    public boolean isRequired() {
+        return config.isRequired();
+    }
+
+    @Override
     public String getCheckType() {
         return CHECK_TYPE;
     }

--- a/server/src/main/java/org/eclipse/openvsx/search/SimilarityConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/SimilarityConfig.java
@@ -65,6 +65,17 @@ public class SimilarityConfig {
     @Value("${ovsx.scanning.similarity.enforced:true}")
     private boolean enforced;
 
+    /**
+     * Whether errors (exceptions) from this check should block publishing.
+     * <p>
+     * If true (default): an error during similarity checking will cause publishing to fail.
+     * If false: errors are logged and recorded, but publishing continues.
+     * <p>
+     * Property: {@code ovsx.scanning.similarity.required}
+     * Default: {@code true}
+     */
+    @Value("${ovsx.scanning.similarity.required:true}")
+    private boolean required;
 
     /**
      * Threshold used to decide whether two extension identifiers are "too similar".
@@ -119,6 +130,10 @@ public class SimilarityConfig {
     
     public boolean isEnforced() {
         return enforced;
+    }
+
+    public boolean isRequired() {
+        return required;
     }
 
     public double getSimilarityThreshold() {

--- a/server/src/main/resources/db/migration/V1_60__Scanning_Infrastructure.sql
+++ b/server/src/main/resources/db/migration/V1_60__Scanning_Infrastructure.sql
@@ -88,6 +88,7 @@ CREATE TABLE IF NOT EXISTS scan_check_result (
     summary VARCHAR(512),
     error_message VARCHAR(2048),
     scanner_job_id BIGINT,
+    required BOOLEAN,
     PRIMARY KEY (id),
     CONSTRAINT fk_scan_check_result_scan FOREIGN KEY (scan_id) 
         REFERENCES extension_scan(id) ON DELETE CASCADE
@@ -103,6 +104,7 @@ COMMENT ON COLUMN scan_check_result.check_type IS 'Type of check: BLOCKLIST, SEC
 COMMENT ON COLUMN scan_check_result.category IS 'PUBLISH_CHECK (sync) or SCANNER_JOB (async/sync scanner)';
 COMMENT ON COLUMN scan_check_result.result IS 'PASSED, FAILED, WARNING, ERROR, or SKIPPED';
 COMMENT ON COLUMN scan_check_result.summary IS 'Brief description like "Scanned 348 files, no threats found"';
+COMMENT ON COLUMN scan_check_result.required IS 'Whether check errors block publishing';
 
 
 -- ============================================================================

--- a/server/src/test/java/org/eclipse/openvsx/admin/ScanAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/admin/ScanAPITest.java
@@ -77,7 +77,7 @@ class ScanAPITest {
         Mockito.when(repositories.findScansFullyFiltered(
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-            Mockito.any(), Mockito.any(), Mockito.any()
+            Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.any()
         )).thenReturn(new PageImpl<>(List.of(scanC), org.springframework.data.domain.PageRequest.of(0, 1), 2));
         
         Mockito.when(repositories.findValidationFailures(Mockito.any())).thenReturn(Streamable.empty());
@@ -118,7 +118,7 @@ class ScanAPITest {
         Mockito.when(repositories.findScansFullyFiltered(
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-            Mockito.any(), Mockito.any(), Mockito.any()
+            Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.any()
         )).thenReturn(new PageImpl<>(List.of(scanA)));
         
         Mockito.when(repositories.findValidationFailures(Mockito.any())).thenReturn(Streamable.empty());
@@ -155,7 +155,7 @@ class ScanAPITest {
         Mockito.when(repositories.findScansFullyFiltered(
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-            Mockito.any(), Mockito.any(), Mockito.any()
+            Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.any()
         )).thenReturn(new PageImpl<>(List.of(scanA)));
 
         // Match by displayName partial (case-insensitive)
@@ -170,7 +170,7 @@ class ScanAPITest {
         Mockito.when(repositories.findScansFullyFiltered(
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-            Mockito.any(), Mockito.any(), Mockito.any()
+            Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.any()
         )).thenReturn(new PageImpl<>(List.of(scanB)));
 
         // Match by extensionName partial
@@ -193,7 +193,7 @@ class ScanAPITest {
         Mockito.when(repositories.findScansFullyFiltered(
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-            Mockito.any(), Mockito.any(), Mockito.any()
+            Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.any()
         )).thenReturn(new PageImpl<>(List.of(scanPassed, scanErrored)));
         
         Mockito.when(repositories.findValidationFailures(Mockito.any())).thenReturn(Streamable.empty());
@@ -220,7 +220,7 @@ class ScanAPITest {
         Mockito.when(repositories.findScansFullyFiltered(
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-            Mockito.any(), Mockito.any(), Mockito.any()
+            Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.any()
         )).thenReturn(new PageImpl<>(List.of(scanA)));
 
         Mockito.when(repositories.findVersion(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenReturn(null);
@@ -344,7 +344,7 @@ class ScanAPITest {
         Mockito.when(repositories.findScansFullyFiltered(
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-            Mockito.any(), Mockito.any(), Mockito.any()
+            Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.any()
         )).thenReturn(new PageImpl<>(List.of(scan)));
         
         Mockito.when(repositories.findVersion("0.0.1", "universal", "ext", "ns")).thenReturn(null);

--- a/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
@@ -294,8 +294,8 @@ class RepositoryServiceSmokeTest {
                 () -> repositories.countExtensionScansByStatusDateRangeAndEnforcement(ScanStatus.STARTED, NOW, NOW, true),
                 () -> repositories.findScansFiltered(List.of(ScanStatus.STARTED), "namespaceName", "publisher", "extensionName", NOW, NOW, page),
                 () -> repositories.countScansFiltered(List.of(ScanStatus.STARTED), "namespaceName", "publisher", "extensionName", NOW, NOW),
-                () -> repositories.findScansFullyFiltered(List.of(ScanStatus.STARTED), "namespaceName", "publisher", "extensionName", NOW, NOW, List.of("checkType"), List.of("scanner"), true, null, page),
-                () -> repositories.countScansFullyFiltered(List.of(ScanStatus.STARTED), "namespaceName", "publisher", "extensionName", NOW, NOW, List.of("checkType"), List.of("scanner"), true, null),
+                () -> repositories.findScansFullyFiltered(List.of(ScanStatus.STARTED), "namespaceName", "publisher", "extensionName", NOW, NOW, List.of("checkType"), List.of("scanner"), true, null, false, page),
+                () -> repositories.countScansFullyFiltered(List.of(ScanStatus.STARTED), "namespaceName", "publisher", "extensionName", NOW, NOW, List.of("checkType"), List.of("scanner"), true, null, false),
                 // Statistics queries with full filter support
                 () -> repositories.countScansForStatistics(ScanStatus.STARTED, NOW, NOW, List.of("checkType"), List.of("scanner"), true),
                 () -> repositories.countAdminDecisionsForStatistics("ALLOWED", NOW, NOW, List.of("checkType"), List.of("scanner"), true),

--- a/server/src/test/java/org/eclipse/openvsx/scanning/ExtensionScanServiceEnforcementTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/scanning/ExtensionScanServiceEnforcementTest.java
@@ -109,7 +109,8 @@ class ExtensionScanServiceEnforcementTest {
             result,
             0,
             null,
-            "summary"
+            "summary",
+            true
         );
     }
 
@@ -122,9 +123,9 @@ class ExtensionScanServiceEnforcementTest {
             .thenReturn(new PublishCheckRunner.Result(
                 List.of(),
                 List.of(checkExecution("CHECK_1", ScanCheckResult.CheckResult.PASSED)),
+                List.of(),
                 false,
-                null,
-                null
+                false
             ));
 
         // Act - should not throw
@@ -142,9 +143,9 @@ class ExtensionScanServiceEnforcementTest {
             .thenReturn(new PublishCheckRunner.Result(
                 List.of(),
                 List.of(checkExecution("CHECK_1", ScanCheckResult.CheckResult.PASSED)),
+                List.of(),
                 false,
-                null,
-                null
+                false
             ));
 
         // Act
@@ -167,9 +168,9 @@ class ExtensionScanServiceEnforcementTest {
             .thenReturn(new PublishCheckRunner.Result(
                 findings,
                 List.of(checkExecution("CHECK_1", ScanCheckResult.CheckResult.PASSED)),
+                List.of(),
                 false,
-                null,
-                null
+                false
             ));
 
         // Act: should NOT throw because nothing is enforced
@@ -190,9 +191,9 @@ class ExtensionScanServiceEnforcementTest {
             .thenReturn(new PublishCheckRunner.Result(
                 findings,
                 List.of(checkExecution("CHECK_1", ScanCheckResult.CheckResult.REJECT)),
+                List.of(),
                 true,
-                null,
-                null
+                false
             ));
 
         // Act & Assert: should throw ErrorResultException
@@ -213,9 +214,9 @@ class ExtensionScanServiceEnforcementTest {
             .thenReturn(new PublishCheckRunner.Result(
                 findings,
                 List.of(checkExecution("CHECK_1", ScanCheckResult.CheckResult.REJECT)),
+                List.of(),
                 true,
-                null,
-                null
+                false
             ));
 
         // Act & Assert
@@ -237,9 +238,9 @@ class ExtensionScanServiceEnforcementTest {
             .thenReturn(new PublishCheckRunner.Result(
                 findings,
                 List.of(checkExecution("CHECK_1", ScanCheckResult.CheckResult.REJECT)),
+                List.of(),
                 true,
-                null,
-                null
+                false
             ));
 
         // Act & Assert: blocked because at least one enforced check failed
@@ -265,16 +266,17 @@ class ExtensionScanServiceEnforcementTest {
                     ScanCheckResult.CheckResult.ERROR,
                     0,
                     "Check failed unexpectedly",
-                    "Error"
+                    "Error",
+                    true
                 )),
+                List.of(new PublishCheckRunner.CheckError("CHECK_1", exception, true)),  // errors
                 false,
-                exception,
-                "CHECK_1"
+                true
             ));
 
         // Act & Assert
         assertThatThrownBy(() -> svc.runValidation(scan, extensionFile, user))
-            .isInstanceOf(RuntimeException.class)
+            .isInstanceOf(ErrorResultException.class)
             .hasMessageContaining("Check failed unexpectedly");
 
         verify(persistenceService).markAsErrored(eq(scan), anyString());
@@ -288,9 +290,9 @@ class ExtensionScanServiceEnforcementTest {
             .thenReturn(new PublishCheckRunner.Result(
                 List.of(),
                 List.of(checkExecution("CHECK_1", ScanCheckResult.CheckResult.PASSED)),
+                List.of(),
                 false,
-                null,
-                null
+                false
             ));
 
         // Act
@@ -311,9 +313,9 @@ class ExtensionScanServiceEnforcementTest {
             .thenReturn(new PublishCheckRunner.Result(
                 findings,
                 List.of(checkExecution("CHECK_1", ScanCheckResult.CheckResult.PASSED)),
+                List.of(),
                 false,
-                null,
-                null
+                false
             ));
 
         // Act - should not throw
@@ -332,9 +334,9 @@ class ExtensionScanServiceEnforcementTest {
             .thenReturn(new PublishCheckRunner.Result(
                 findings,
                 List.of(checkExecution("CHECK_1", ScanCheckResult.CheckResult.REJECT)),
+                List.of(),
                 true,
-                null,
-                null
+                false
             ));
 
         // Act & Assert: throws and transitions to REJECTED
@@ -358,9 +360,9 @@ class ExtensionScanServiceEnforcementTest {
             .thenReturn(new PublishCheckRunner.Result(
                 findings,
                 List.of(checkExecution("CHECK_1", ScanCheckResult.CheckResult.PASSED)),
+                List.of(),
                 false,
-                null,
-                null
+                false
             ));
 
         // Act

--- a/server/src/test/java/org/eclipse/openvsx/scanning/PublishCheckRunnerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/scanning/PublishCheckRunnerTest.java
@@ -102,6 +102,7 @@ class PublishCheckRunnerTest {
         var errorCheck = mock(PublishCheck.class);
         when(errorCheck.getCheckType()).thenReturn("ERROR_CHECK");
         when(errorCheck.isEnabled()).thenReturn(true);
+        when(errorCheck.isRequired()).thenReturn(true);
         when(errorCheck.check(any())).thenThrow(new RuntimeException("Check failed"));
         var runner = new PublishCheckRunner(List.of(errorCheck));
 
@@ -109,7 +110,7 @@ class PublishCheckRunnerTest {
 
         assertFalse(result.passed());
         assertTrue(result.hasError());
-        assertEquals("ERROR_CHECK", result.errorCheckType());
+        assertEquals("ERROR_CHECK", result.getRequiredErrors().get(0).checkType());
         assertNotNull(result.getErrorMessage());
     }
 
@@ -118,6 +119,7 @@ class PublishCheckRunnerTest {
         var errorCheck = mock(PublishCheck.class);
         when(errorCheck.getCheckType()).thenReturn("ERROR");
         when(errorCheck.isEnabled()).thenReturn(true);
+        when(errorCheck.isRequired()).thenReturn(true);
         when(errorCheck.check(any())).thenThrow(new RuntimeException("Boom"));
 
         // Create a simple mock that won't be called
@@ -160,9 +162,9 @@ class PublishCheckRunnerTest {
         var result = new PublishCheckRunner.Result(
                 List.of(enforcedFinding, warningFinding),
                 List.of(),
+                List.of(),
                 true,
-                null,
-                null
+                false
         );
 
         var enforced = result.getEnforcedFindings();
@@ -198,6 +200,7 @@ class PublishCheckRunnerTest {
         when(check.getCheckType()).thenReturn(type);
         when(check.isEnabled()).thenReturn(enabled);
         when(check.isEnforced()).thenReturn(enforced);
+        when(check.isRequired()).thenReturn(true);
         when(check.check(any())).thenReturn(result);
         when(check.getUserFacingMessage(any())).thenReturn("User message");
         return check;

--- a/webui/src/components/scan-admin/scan-card/scan-card-expand-strip-badges.tsx
+++ b/webui/src/components/scan-admin/scan-card/scan-card-expand-strip-badges.tsx
@@ -95,12 +95,18 @@ export const ScanCardExpandStripBadges: React.FC<ScanCardExpandStripBadgesProps>
         height: '20px',
         fontSize: '0.7rem',
         flexShrink: 0,
-        ...(badge.type === 'threat' ? {
-            backgroundColor: badge.isEnforced ? theme.palette.quarantined.dark : undefined,
+        ...(badge.type === 'error' ? {
+            // Error badges: solid grey for required, striped for optional
+            // Must set backgroundColor to 'transparent' when using striped background to override Chip defaults
+            backgroundColor: badge.isEnforced ? theme.palette.errorStatus.dark : 'transparent',
+            color: theme.palette.errorStatus.light,
+            background: !badge.isEnforced ? `${theme.palette.unenforced.stripe}, ${theme.palette.errorStatus.dark}` : undefined,
+        } : badge.type === 'threat' ? {
+            backgroundColor: badge.isEnforced ? theme.palette.quarantined.dark : 'transparent',
             color: theme.palette.quarantined.light,
             background: !badge.isEnforced ? `${theme.palette.unenforced.stripe}, ${theme.palette.quarantined.dark}` : undefined,
         } : {
-            backgroundColor: badge.isEnforced ? theme.palette.rejected.dark : undefined,
+            backgroundColor: badge.isEnforced ? theme.palette.rejected.dark : 'transparent',
             color: theme.palette.rejected.light,
             background: !badge.isEnforced ? `${theme.palette.unenforced.stripe}, ${theme.palette.rejected.dark}` : undefined,
         }),

--- a/webui/src/components/scan-admin/scan-card/scan-card-expanded-content.tsx
+++ b/webui/src/components/scan-admin/scan-card/scan-card-expanded-content.tsx
@@ -123,6 +123,9 @@ const CheckResultItem: React.FC<CheckResultItemProps> = ({ checkResult }) => {
     const theme = useTheme();
     const colors = getCheckResultColor(checkResult.result, theme);
     const isPassed = checkResult.result === 'PASSED';
+    const isError = checkResult.result === 'ERROR';
+    // Non-required errors get striped styling to indicate they didn't block publishing
+    const isOptionalError = isError && checkResult.required === false;
 
     return (
         <Box sx={{
@@ -139,7 +142,10 @@ const CheckResultItem: React.FC<CheckResultItemProps> = ({ checkResult }) => {
                     label={checkResult.result}
                     size='small'
                     sx={{
-                        bgcolor: colors.bg,
+                        bgcolor: isOptionalError ? 'transparent' : colors.bg,
+                        background: isOptionalError
+                            ? `${theme.palette.unenforced.stripe}, ${colors.bg}`
+                            : undefined,
                         color: colors.text,
                         fontWeight: 600,
                         fontSize: '0.7rem',

--- a/webui/src/components/scan-admin/scan-card/utils.ts
+++ b/webui/src/components/scan-admin/scan-card/utils.ts
@@ -20,7 +20,7 @@ import { ScanResult } from '../../../context/scan-admin';
 export interface DetailBadge {
     label: string;
     isEnforced: boolean;
-    type: 'threat' | 'validation';
+    type: 'threat' | 'validation' | 'error';
 }
 
 // ============================================================================
@@ -103,6 +103,18 @@ export const getDetailBadges = (scan: ScanResult): DetailBadge[] => {
             isEnforced: failure.enforcedFlag,
             type: 'validation'
         });
+    });
+
+    // Add badges for check results with ERROR status
+    scan.checkResults?.forEach(checkResult => {
+        if (checkResult.result === 'ERROR') {
+            badges.push({
+                label: checkResult.checkType,
+                // Use "enforced" styling (solid) for required checks, striped for optional
+                isEnforced: checkResult.required !== false,
+                type: 'error'
+            });
+        }
     });
 
     return badges;

--- a/webui/src/context/scan-admin/scan-api-effects.ts
+++ b/webui/src/context/scan-admin/scan-api-effects.ts
@@ -209,6 +209,7 @@ export const useScansEffect = (
                             findingsCount: result.findingsCount || null,
                             summary: result.summary || null,
                             errorMessage: result.errorMessage || null,
+                            required: result.required ?? null,
                         })),
                         extensionIcon: scan.extensionIcon,
                         downloadUrl: scan.downloadUrl || null,

--- a/webui/src/context/scan-admin/scan-types.ts
+++ b/webui/src/context/scan-admin/scan-types.ts
@@ -56,6 +56,8 @@ export interface CheckResult {
     findingsCount: number | null;
     summary: string | null;
     errorMessage: string | null;
+    /** Whether this check was required (errors block publishing). Null for scanner jobs. */
+    required: boolean | null;
 }
 
 export interface ScanResult {


### PR DESCRIPTION
Adds a required config option to publish checks that controls whether check errors block publishing. When required = false, errors are logged but publishing continues.

- Returns partial secret scan results on timeout (if findings exist)
- Auto-includes scans with errored check results when filtering by ERRORED status
- Shows error badges in admin UI for checks that errored