### PR TITLE
Migrate deprecated javax.annotation to jakarta.annotation

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.hibernate.orm)
     alias(libs.plugins.test.logger)
     alias(libs.plugins.gatling)
+    alias(libs.plugins.rewrite)
     id 'maven-publish'
 }
 
@@ -154,6 +155,8 @@ dependencies {
 
     gatling libs.gatling.core
     gatling libs.gatling.app
+
+    rewrite libs.rewrite.java
 }
 
 configurations.configureEach {
@@ -192,6 +195,11 @@ jooq {
             }
         }
     }
+}
+
+rewrite {
+    activeRecipe("org.openrewrite.java.migrate.jakarta.JavaxAnnotationMigrationToJakartaAnnotation")
+    setExportDatatables(true)
 }
 
 publishing {

--- a/server/gradle/libs.versions.toml
+++ b/server/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ jsonpath        = "2.9.0"
 junit           = "5.14.2"
 loki4j          = "1.4.2"
 re2j            = "1.7"
+rewrite-java    = "3.26.0"
 spring-boot     = "3.5.10"
 springdoc       = "2.8.13"
 testcontainers  = "1.21.4"
@@ -34,6 +35,7 @@ jooq-codegen                 = { id = "org.jooq.jooq-codegen-gradle", version.re
 spring-boot                  = { id = "org.springframework.boot", version.ref = "spring-boot"}
 spring-dependency-management = { id = "io.spring.dependency-management", version = "1.1.7" }
 test-logger                  = { id = "com.adarshr.test-logger", version = "4.0.0" }
+rewrite                      = { id = "org.openrewrite.rewrite", version = "7.25.0" }
 
 [libraries]
 awssdk-s3                    = { module = "software.amazon.awssdk:s3", version.ref = "aws" }
@@ -64,6 +66,7 @@ junit-jupiter-api            = { module = "org.junit.jupiter:junit-jupiter-api",
 junit-jupiter-engine         = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 loki-logback-appender        = { module = "com.github.loki4j:loki-logback-appender", version.ref = "loki4j" }
 re2j                         = { module = "com.google.re2j:re2j", version.ref = "re2j" }
+rewrite-java                 = { module = "org.openrewrite.recipe:rewrite-migrate-java", version.ref = "rewrite-java"}
 springdoc                    = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc" }
 testcontainers-elasticsearch = { module = "org.testcontainers:elasticsearch", version.ref = "testcontainers" }
 testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }

--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -25,7 +25,7 @@ import org.eclipse.openvsx.search.SearchResult;
 import org.eclipse.openvsx.search.SearchUtilService;
 import org.eclipse.openvsx.search.SimilarityCheckService;
 import org.eclipse.openvsx.storage.StorageUtilService;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import org.eclipse.openvsx.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/server/src/main/java/org/eclipse/openvsx/cache/ExpiredFileListener.java
+++ b/server/src/main/java/org/eclipse/openvsx/cache/ExpiredFileListener.java
@@ -14,7 +14,7 @@ import com.github.benmanes.caffeine.cache.RemovalListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/server/src/main/java/org/eclipse/openvsx/json/AccessTokenJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/AccessTokenJson.java
@@ -9,7 +9,7 @@
  ********************************************************************************/
 package org.eclipse.openvsx.json;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;

--- a/server/src/main/java/org/eclipse/openvsx/repositories/AdminScanDecisionRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/AdminScanDecisionRepository.java
@@ -19,7 +19,7 @@ import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.util.Streamable;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import java.time.LocalDateTime;
 import java.util.Collection;

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionScanRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionScanRepository.java
@@ -21,7 +21,7 @@ import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.util.Streamable;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import java.time.LocalDateTime;
 import java.util.Collection;

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -20,7 +20,7 @@ import org.springframework.data.domain.*;
 import org.springframework.data.util.Streamable;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import java.time.LocalDateTime;
 import java.util.Collection;

--- a/server/src/main/java/org/eclipse/openvsx/scanning/EntropyCalculator.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/EntropyCalculator.java
@@ -12,7 +12,7 @@
  ********************************************************************************/
 package org.eclipse.openvsx.scanning;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/server/src/main/java/org/eclipse/openvsx/scanning/ExtensionScanPersistenceService.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/ExtensionScanPersistenceService.java
@@ -24,8 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Map;

--- a/server/src/main/java/org/eclipse/openvsx/scanning/ExtensionScanService.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/ExtensionScanService.java
@@ -23,8 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/server/src/main/java/org/eclipse/openvsx/scanning/GitleaksRulesService.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/GitleaksRulesService.java
@@ -26,9 +26,9 @@ import org.springframework.stereotype.Service;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPubSub;
 
-import javax.annotation.Nullable;
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.Nullable;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;

--- a/server/src/main/java/org/eclipse/openvsx/scanning/HttpAuthHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/HttpAuthHandler.java
@@ -20,7 +20,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;

--- a/server/src/main/java/org/eclipse/openvsx/scanning/HttpClientExecutor.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/HttpClientExecutor.java
@@ -29,7 +29,7 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;

--- a/server/src/main/java/org/eclipse/openvsx/scanning/PublishCheck.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/PublishCheck.java
@@ -16,7 +16,7 @@ import org.eclipse.openvsx.entities.ExtensionScan;
 import org.eclipse.openvsx.entities.UserData;
 import org.eclipse.openvsx.util.TempFile;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/server/src/main/java/org/eclipse/openvsx/scanning/PublishCheckRunner.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/PublishCheckRunner.java
@@ -20,8 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;

--- a/server/src/main/java/org/eclipse/openvsx/scanning/RemoteScanner.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/RemoteScanner.java
@@ -15,7 +15,7 @@ package org.eclipse.openvsx.scanning;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/server/src/main/java/org/eclipse/openvsx/scanning/Scanner.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/Scanner.java
@@ -12,8 +12,8 @@
  ********************************************************************************/
 package org.eclipse.openvsx.scanning;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/server/src/main/java/org/eclipse/openvsx/scanning/ScannerException.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/ScannerException.java
@@ -13,8 +13,8 @@
 package org.eclipse.openvsx.scanning;
 
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Exception thrown when a scan operation fails.

--- a/server/src/main/java/org/eclipse/openvsx/scanning/ScannerFileProvider.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/ScannerFileProvider.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.io.IOException;
 
 /**

--- a/server/src/main/java/org/eclipse/openvsx/scanning/ScannerInvocationRequest.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/ScannerInvocationRequest.java
@@ -13,7 +13,7 @@
 package org.eclipse.openvsx.scanning;
 
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import org.jobrunr.jobs.lambdas.JobRequest;
 

--- a/server/src/main/java/org/eclipse/openvsx/scanning/ScannerRegistry.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/ScannerRegistry.java
@@ -14,8 +14,8 @@ package org.eclipse.openvsx.scanning;
 
 import org.springframework.stereotype.Component;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/server/src/main/java/org/eclipse/openvsx/scanning/SecretDetector.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/SecretDetector.java
@@ -19,7 +19,7 @@ import org.apache.tika.Tika;
 import org.eclipse.openvsx.util.ArchiveUtil;
 import org.eclipse.openvsx.util.SizeLimitInputStream;
 import jakarta.validation.constraints.NotNull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import java.io.BufferedReader;
 import java.io.BufferedInputStream;

--- a/server/src/main/java/org/eclipse/openvsx/scanning/SecretDetectorFactory.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/SecretDetectorFactory.java
@@ -15,7 +15,7 @@ package org.eclipse.openvsx.scanning;
 import com.google.re2j.Pattern;
 import jakarta.annotation.PostConstruct;
 import jakarta.validation.constraints.NotNull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/server/src/main/java/org/eclipse/openvsx/scanning/SecretRule.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/SecretRule.java
@@ -14,7 +14,7 @@ package org.eclipse.openvsx.scanning;
 
 import com.google.re2j.Pattern;
 import jakarta.validation.constraints.NotNull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import java.util.List;
 

--- a/server/src/main/java/org/eclipse/openvsx/scanning/SecretRuleLoader.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/SecretRuleLoader.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import jakarta.validation.constraints.NotNull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/server/src/main/java/org/eclipse/openvsx/search/ExtensionSearch.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/ExtensionSearch.java
@@ -13,7 +13,7 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 

--- a/server/src/main/java/org/eclipse/openvsx/search/SimilarityCheckService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/SimilarityCheckService.java
@@ -23,7 +23,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.util.List;
 
 /**

--- a/server/src/main/java/org/eclipse/openvsx/search/SimilarityService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/SimilarityService.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 @Service
 public class SimilarityService {

--- a/server/src/main/java/org/eclipse/openvsx/storage/CdnServiceConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/CdnServiceConfig.java
@@ -13,7 +13,7 @@ import com.google.common.collect.ImmutableMap;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/server/src/main/java/org/eclipse/openvsx/storage/IStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/IStorageService.java
@@ -16,7 +16,7 @@ import org.eclipse.openvsx.util.TempFile;
 import org.eclipse.openvsx.util.UrlUtil;
 import org.springframework.data.util.Pair;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;

--- a/server/src/main/java/org/eclipse/openvsx/storage/log/AwsDownloadCountHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/log/AwsDownloadCountHandler.java
@@ -27,7 +27,7 @@ import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;

--- a/server/src/main/java/org/eclipse/openvsx/storage/log/FastlyLogFileParser.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/log/FastlyLogFileParser.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.io.IOException;
 
 class FastlyLogFileParser implements LogFileParser {

--- a/server/src/main/java/org/eclipse/openvsx/storage/log/LogFileParser.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/log/LogFileParser.java
@@ -12,7 +12,7 @@
  *****************************************************************************/
 package org.eclipse.openvsx.storage.log;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 public interface LogFileParser {
     @Nullable LogRecord parse(String line);

--- a/server/src/main/java/org/eclipse/openvsx/storage/log/LogRecord.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/log/LogRecord.java
@@ -12,6 +12,6 @@
  *****************************************************************************/
 package org.eclipse.openvsx.storage.log;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 public record LogRecord(@Nonnull String method, int status, @Nonnull String url) {}

--- a/server/src/main/java/org/eclipse/openvsx/util/UrlUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/UrlUtil.java
@@ -21,7 +21,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.util.UriUtils;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;

--- a/server/src/main/java/org/eclipse/openvsx/web/ServerExceptionResolver.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/ServerExceptionResolver.java
@@ -18,7 +18,7 @@ import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.support.DefaultHandlerExceptionResolver;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 @RestControllerAdvice
 public class ServerExceptionResolver extends DefaultHandlerExceptionResolver {


### PR DESCRIPTION
This is an intermediate step and fixes #1605 .

This also integrates the rewrite plugin to more easily add recipes as needed.