### PR TITLE
Improve error handling in VSCodeAPI wrt file resources

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/adapter/WebResourceService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/WebResourceService.java
@@ -90,7 +90,11 @@ public class WebResourceService {
                 return null;
             }
         } catch (IOException | UncheckedIOException e) {
-            throw new ErrorResultException("Failed to read extension files for " + NamingUtil.toLogFormat(namespace, extension, targetPlatform, version), HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new ErrorResultException(
+                    "Failed to read extension files for " +
+                    NamingUtil.toLogFormat(namespace, extension, targetPlatform, version) + ": " + e.getMessage(),
+                    HttpStatus.INTERNAL_SERVER_ERROR
+            );
         }
     }
 
@@ -115,7 +119,11 @@ public class WebResourceService {
 
             return node;
         } catch (IOException | UncheckedIOException e) {
-            throw new ErrorResultException("Failed to read extension files for " + NamingUtil.toLogFormat(namespace, extension, targetPlatform, version), HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new ErrorResultException(
+                    "Failed to read extension files for " +
+                    NamingUtil.toLogFormat(namespace, extension, targetPlatform, version) + ": " + e.getMessage(),
+                    HttpStatus.INTERNAL_SERVER_ERROR
+            );
         }
     }
 


### PR DESCRIPTION
there are sometimes exceptions like that:

```
[open-vsx-org-production-7d74f5f6dd-pjn99 open-vsx-org] 2026-02-18T10:03:56.073Z  WARN 1 --- [openvsx-server] [p126039047-6632] [                                                 ] o.e.jetty.ee10.servlet.ServletChannel    : /vscode/asset/MS-CEINTL/vscode-language-pack-zh-hant/1.108.0/Microsoft.VisualStudio.Code.WebResources/extension/translations/extensions/vscode.configuration-editing.i18n.json 
[open-vsx-org-production-7d74f5f6dd-pjn99 open-vsx-org]  
[open-vsx-org-production-7d74f5f6dd-pjn99 open-vsx-org] jakarta.servlet.ServletException: Request processing failed: org.eclipse.openvsx.util.ErrorResultException: Failed to read extension files for MS-CEINTL.vscode-language-pack-zh-hant 1.108.0 
```

with a full stacktrace. This is both annoying and not helpful as the cause of the exception is not logged.

This PR makes sure that the thrown ErrorResultException is handled by returning an explicit internal server error and logging the exception message without the full stacktrace.