### PR TITLE
Add SBOM generation and upload workflow for webui and cli packages

### DIFF
--- a/.github/workflows/generate-yarn-sboms.yml
+++ b/.github/workflows/generate-yarn-sboms.yml
@@ -1,0 +1,93 @@
+name: Generate Yarn SBOM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  DT_PARENT_PROJECT_ID_CLI: "e4ead4c5-b141-4d4e-ab28-0d502b0be024"
+  DT_PARENT_PROJECT_ID_WEBUI: "6db35d0e-dce5-4737-a4d1-4f4f2998edda"
+  CYCLONEDX_YARN_PLUGIN_VERSION: "3.2.1"
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    if: >
+      startsWith(github.event.release.tag_name || inputs.tag, 'cli-') ||
+      startsWith(github.event.release.tag_name || inputs.tag, 'webui-')
+    outputs:
+      project-version: ${{ steps.metadata.outputs.PROJECT_VERSION }}
+      product-name: ${{ steps.metadata.outputs.PRODUCT_NAME }}
+      product-path: ${{ steps.metadata.outputs.PRODUCT_PATH }}
+      parent-project-id: ${{ steps.metadata.outputs.PARENT_PROJECT_ID }}
+    steps:
+      - name: Resolve product metadata from tag
+        id: metadata
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          if [[ "$TAG" == cli-* ]]; then
+            echo "PRODUCT_NAME=openvsx-cli" >> $GITHUB_OUTPUT
+            echo "PRODUCT_PATH=cli" >> $GITHUB_OUTPUT
+            echo "PARENT_PROJECT_ID=${{ env.DT_PARENT_PROJECT_ID_CLI }}" >> $GITHUB_OUTPUT
+            echo "PROJECT_VERSION=${TAG#cli-}" >> $GITHUB_OUTPUT
+          elif [[ "$TAG" == webui-* ]]; then
+            echo "PRODUCT_NAME=openvsx-webui" >> $GITHUB_OUTPUT
+            echo "PRODUCT_PATH=webui" >> $GITHUB_OUTPUT
+            echo "PARENT_PROJECT_ID=${{ env.DT_PARENT_PROJECT_ID_WEBUI }}" >> $GITHUB_OUTPUT
+            echo "PROJECT_VERSION=${TAG#webui-}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout repository at release tag
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: '24.x'
+          package-manager-cache: false
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Enable Corepack (Yarn Berry)
+        working-directory: ${{ steps.metadata.outputs.PRODUCT_PATH }}
+        run: corepack enable
+
+      - name: Install dependencies
+        working-directory: ${{ steps.metadata.outputs.PRODUCT_PATH }}
+        run: yarn install --immutable
+
+      - name: Generate SBOM
+        working-directory: ${{ steps.metadata.outputs.PRODUCT_PATH }}
+        run: |
+          yarn dlx -q @cyclonedx/yarn-plugin-cyclonedx@${{ env.CYCLONEDX_YARN_PLUGIN_VERSION }} \
+            --output-format JSON \
+            --output-file bom.json \
+            --production
+
+      - name: Upload SBOM as artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom
+          path: ${{ steps.metadata.outputs.PRODUCT_PATH }}/bom.json
+
+  store-sbom-data:
+    needs: ["generate-sbom"]
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: ${{ needs.generate-sbom.outputs.product-name }}
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: sbom
+      bomFilename: bom.json
+      parentProject: ${{ needs.generate-sbom.outputs.parent-project-id }}


### PR DESCRIPTION
### Overview
Implements the first half of the required SBOMs from #1610:
> - Source SBOM (Yarn) **[done]**
>   - ovsx CLI  **[done]**
>   - openvsx-webui front end library  **[done]**
> - Source SBOM (Gradle)
>   - openvsx server
> - Image SBOM (docker) 
>   - openvsx-webui docker image
>   - openvsx-server docker image

The following 3 products will be covered in a subsequent PR.

### What does this PR do?
This PR aims to bootstrap the EF Security Team initiative of supporting projects in implementing automated SBOM generation and upload workflows, with the goal of enhancing software supply chain security.

We wanted this to seamlessly integrate with your existing release processes, so we implemented 1 workflow meant to generate SBOMs for `yarn` based products. 

Currently the workflow is triggered by new product releases being published. A yarn plugin is used to generate the SBOM, which is then uploaded as an artifact. The `store-sbom-data` reusable workflow stores additional metadata about the project and upon completion, the self service system downloads the SBOM from artifacts and uploads it to our DependencyTrack [instance](https://sbom.eclipse.org/), under the `Eclipse OpenVSX/ovsx cli` and `Eclipse OpenVSX/openvsx webui` entries. To view the SBOMs, you can log into the instance by using your EF account credentials.

We have tested the SBOM generation separately and everything worked successfully (see [test run](https://github.com/iliescuioana/openvsx/actions/runs/22393327052)). However, due to limited permissions, we'd ask if you could manually run it once so we can confirm the upload to our instance works as expected (for the version input the latest release tag of either `cli-` or `webui-` products can be used).

Otherwise feel free to update the workflow as needed, edits by maintainers are enabled. Please let us know if you have any questions we can help with.
