### PR TITLE
Add maxConcurrency setting for scanners

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/repositories/ScannerJobRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ScannerJobRepository.java
@@ -77,7 +77,12 @@ public interface ScannerJobRepository extends Repository<ScannerJob, Long> {
      * rather than creating a new one.
      */
     Optional<ScannerJob> findByScanIdAndScannerType(String scanId, String scannerType);
-    
+
+    /**
+     * Count scan jobs by status and scanner type.
+     */
+    long countByStatusAndScannerType(ScannerJob.JobStatus status, String scannerType);
+
     /**
      * Find scan jobs by status that were created before a certain time.
      * 

--- a/server/src/main/java/org/eclipse/openvsx/scanning/RemoteScanner.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/RemoteScanner.java
@@ -77,7 +77,10 @@ public class RemoteScanner implements Scanner {
     public boolean isAsync() {
         return config.isAsync();
     }
-    
+
+    @Override
+    public int getMaxConcurrency() { return config.getMaxConcurrency(); }
+
     @Override
     public boolean enforcesThreats() {
         return config.isEnforced();

--- a/server/src/main/java/org/eclipse/openvsx/scanning/RemoteScannerProperties.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/RemoteScannerProperties.java
@@ -136,7 +136,9 @@ public class RemoteScannerProperties {
         
         private int timeoutMinutes = 60;
         private boolean async = true;
-        
+
+        private int maxConcurrency = 10;
+
         /**
          * HTTP client configuration for this scanner.
          * 
@@ -198,7 +200,10 @@ public class RemoteScannerProperties {
         
         public boolean isAsync() { return async; }
         public void setAsync(boolean async) { this.async = async; }
-        
+
+        public int getMaxConcurrency() { return maxConcurrency; }
+        public void setMaxConcurrency(int maxConcurrency) { this.maxConcurrency = maxConcurrency; }
+
         public HttpConfig getHttp() { return http; }
         public void setHttp(HttpConfig http) { this.http = http; }
         

--- a/server/src/main/java/org/eclipse/openvsx/scanning/Scanner.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/Scanner.java
@@ -174,7 +174,13 @@ public interface Scanner {
      * Indicates if this scanner is asynchronous.
      */
     boolean isAsync();
-    
+
+    /**
+     * Returns the maximum concurrency this scanner can handle,
+     * <code>-1</code> indicates that there is no limit.
+     */
+    default int getMaxConcurrency() { return -1; }
+
     /**
      * Get the polling configuration for this async scanner.
      * Returns null to use defaults.


### PR DESCRIPTION
This PR adds a `maxConcurrency` setting for scanner implementations to control how many concurrent scan jobs can be run concurrently for a specific scanner implementation.

If the `maxConcurrency` is exceeded, the queued job is busy waiting.

We should make the pollingInterval and maxWaitingTime configurable per scanner I guess.