### PR TITLE
Fix duplicate scan job key

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/scanning/ExtensionScanService.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/ExtensionScanService.java
@@ -21,6 +21,7 @@ import org.eclipse.openvsx.util.TempFile;
 import org.jobrunr.scheduling.JobRequestScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 import jakarta.annotation.Nonnull;
@@ -216,6 +217,12 @@ public class ExtensionScanService {
 
         for (Scanner scanner : scanners) {
             String scannerType = scanner.getScannerType();
+            var existingJob = scanJobRepository.findByScanIdAndScannerType(scanId, scannerType);
+            if (existingJob.isPresent()) {
+                logger.debug("Skipping duplicate ScanJob creation: {} for {} (scanId={}), existingJobId={}",
+                    scannerType, NamingUtil.toLogFormat(extVersion), scanId, existingJob.get().getId());
+                continue;
+            }
 
             ScannerJob job = new ScannerJob();
             job.setScanId(scanId);

--- a/server/src/test/java/org/eclipse/openvsx/scanning/ExtensionScanServiceEnforcementTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/scanning/ExtensionScanServiceEnforcementTest.java
@@ -25,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -370,5 +371,41 @@ class ExtensionScanServiceEnforcementTest {
 
         // Assert: all 3 findings recorded
         verify(persistenceService, times(3)).recordValidationFailure(eq(scan), eq("CHECK_1"), any(), any(), eq(false));
+    }
+
+    @Test
+    void submitScannerJobs_skipsWhenJobAlreadyExists_forSameScanAndScannerType() {
+        // Arrange
+        Namespace namespace = new Namespace();
+        namespace.setName("ns");
+        Extension extension = new Extension();
+        extension.setNamespace(namespace);
+        extension.setName("ext");
+
+        ExtensionVersion extVersion = new ExtensionVersion();
+        extVersion.setId(456L);
+        extVersion.setExtension(extension);
+        extVersion.setVersion("1.0.0");
+        extVersion.setTargetPlatform("universal");
+        when(config.isEnabled()).thenReturn(true);
+
+        Scanner scanner = mock(Scanner.class);
+        when(scanner.getScannerType()).thenReturn("CLAMAV_REST");
+        when(scannerRegistry.getAllScanners()).thenReturn(List.of(scanner));
+
+        ScannerJob existingJob = new ScannerJob();
+        existingJob.setId(999L);
+        existingJob.setScanId("123");
+        existingJob.setScannerType("CLAMAV_REST");
+        when(scanJobRepository.findByScanIdAndScannerType("123", "CLAMAV_REST"))
+            .thenReturn(Optional.of(existingJob));
+
+        // Act
+        boolean submitted = svc.submitScannerJobs(scan, extVersion);
+
+        // Assert
+        assertThat(submitted).isTrue();
+        verify(scanJobRepository, never()).save(any(ScannerJob.class));
+        verify(jobScheduler, never()).enqueue(any(ScannerInvocationRequest.class));
     }
 }


### PR DESCRIPTION
If the server restarts during scan job submission the scan recovery service attempts to retry scan job creation for all scanners, even though a scanner job may have already been submitted. This caused a DataIntegrityViolationException when trying to insert a duplicate (scan_id, scanner_type) row, violating the unique constraint on scan_job.

Fixes #1652 