### PR TITLE
Remove Content-Length header from forwarded http header options

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/util/HttpHeadersUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/HttpHeadersUtil.java
@@ -22,9 +22,9 @@ public class HttpHeadersUtil {
                 var header = it.nextElement();
                 headers.add(header, request.getHeader(header));
             }
-
         } catch (IllegalStateException _) {}
         headers.remove(HttpHeaders.HOST);
+        headers.remove(HttpHeaders.CONTENT_LENGTH);
         return headers;
     }
 


### PR DESCRIPTION
This fixes #1653 .

This is a quick fix to support using the vscode API also in mirror mode, however cleaned up in a separate PR.