### PR TITLE
chore: adapt .devfile.yaml to the recent changes

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tool
     container:
-      image: quay.io/devfile/universal-developer-image:ubi9-latest
+      image: quay.io/devfile/universal-developer-image:ubi10-latest
       memoryRequest: 256Mi
       memoryLimit: 8Gi
       cpuRequest: 100m
@@ -83,7 +83,6 @@ commands:
       workingDir: ${PROJECTS_ROOT}/openvsx/webui
       commandLine: |
         yarn install &&
-        yarn build &&
         yarn build:default
 
   - id: build-server
@@ -92,6 +91,8 @@ commands:
       component: tool
       workingDir: ${PROJECTS_ROOT}/openvsx
       commandLine: |
+        JAVA_25_DIR="$(basename "$JAVA_HOME_25")" &&
+        sdk use java "$JAVA_25_DIR" &&
         server/gradlew -p server assemble downloadTestExtensions
 
   - id: run-server
@@ -100,6 +101,8 @@ commands:
       component: tool
       workingDir: ${PROJECTS_ROOT}/openvsx/server
       commandLine: |
+        JAVA_25_DIR="$(basename "$JAVA_HOME_25")" &&
+        sdk use java "$JAVA_25_DIR" &&
         ./scripts/generate-properties.sh &&
         sed -i 's/localhost:5432\/postgres/localhost:5432\/openvsx/g' src/dev/resources/application.yml &&
         sed -i 's/username: gitpod/username: openvsx/g' src/dev/resources/application.yml &&
@@ -124,9 +127,9 @@ commands:
         export OVSX_REGISTRY_URL=http://localhost:8080
         export OVSX_PAT=super_token
         export PUBLISHERS="DotJoshJohnson eamodio felixfbecker formulahendry HookyQR ms-azuretools ms-mssql ms-python ms-vscode octref redhat ritwickdey sburg vscode vscodevim Wscats"
-        for pub in $PUBLISHERS; do cli/lib/ovsx create-namespace $pub; done
-        find server/build/test-extensions-builtin -name '*.vsix' -exec cli/lib/ovsx publish '{}' \;
-        find server/build/test-extensions -name '*.vsix' -exec cli/lib/ovsx publish '{}' \;
+        for pub in $PUBLISHERS; do cli/bin/ovsx create-namespace $pub; done
+        find server/build/test-extensions-builtin -name '*.vsix' -exec cli/bin/ovsx publish '{}' \;
+        find server/build/test-extensions -name '*.vsix' -exec cli/bin/ovsx publish '{}' \;
 
 # Commands to deploy OpenVSX to OpenShift
   - id: create-namespace
@@ -142,8 +145,8 @@ commands:
       component: tool
       workingDir: ${PROJECTS_ROOT}/openvsx/deploy/openshift
       commandLine: |
-          read -p "Please enter the value for OPENVSX_VERSION (default: v0.27.0): " OPENVSX_VERSION
-          OPENVSX_VERSION=${OPENVSX_VERSION:-v0.27.0}
+          read -p "Please enter the value for OPENVSX_VERSION (default: v0.32.3): " OPENVSX_VERSION
+          OPENVSX_VERSION=${OPENVSX_VERSION:-v0.32.3}
           export OPENVSX_VERSION
           echo "OPENVSX_VERSION is set to $OPENVSX_VERSION"
           podman build -t "openvsx:$OPENVSX_VERSION" --build-arg "OPENVSX_VERSION=$OPENVSX_VERSION" -f openvsx.Dockerfile .&&
@@ -158,8 +161,8 @@ commands:
       component: tool
       workingDir: ${PROJECTS_ROOT}/openvsx/deploy/openshift
       commandLine: |
-          read -p "Please enter the value for OVSX_VERSION (default: 0.10.5): " OVSX_VERSION
-          OVSX_VERSION=${OVSX_VERSION:-0.10.5}
+          read -p "Please enter the value for OVSX_VERSION (default: 0.10.9): " OVSX_VERSION
+          OVSX_VERSION=${OVSX_VERSION:-0.10.9}
           export OVSX_VERSION
           echo "OVSX_VERSION is set to $OVSX_VERSION"
           podman build -t "openvsx-cli:$OVSX_VERSION" --build-arg "OVSX_VERSION=$OVSX_VERSION" -f cli.Dockerfile .&&

--- a/deploy/openshift/README.md
+++ b/deploy/openshift/README.md
@@ -14,11 +14,11 @@ Creates a namespace on the OpenShift cluster for deploying OpenVSX (default: ope
 
 * 2.2. Build and Publish OpenVSX Image
 
-Build the OpenVSX image and push it to the OpenShift internal registry. You'll ask to enter the OpenVSX version to deploy (default is v0.27.0).
+Build the OpenVSX image and push it to the OpenShift internal registry. You'll ask to enter the OpenVSX version to deploy (default is v0.32.3).
 
 * 2.3. Build and Publish OpenVSX CLI Image
 
-Build the OpenVSX CLI image and push it to the OpenShift internal registry. You'll ask to enter the `ovsx` version to deploy (default is 0.10.5).
+Build the OpenVSX CLI image and push it to the OpenShift internal registry. You'll ask to enter the `ovsx` version to deploy (default is 0.10.9).
 
 * 2.4. Deploy OpenVSX
 


### PR DESCRIPTION
Updates .devfile.yaml so the devfile matches recent project and tooling changes.

**Base image**
Switched dev container from quay.io/devfile/universal-developer-image:ubi9-latest to ubi10-latest.

**Web UI build**
Removed the extra yarn build step before yarn build:default in the web UI build command so only yarn build:default runs.

**Java 25 for server**
In build-server and run-server, added an explicit Java 25 selection via SDKMAN (JAVA_25_DIR and sdk use java) so the server build and run use Java 25.

**CLI invocation**
Replaced cli/lib/ovsx with cli/bin/ovsx for create-namespace and publish in the seed-extensions command (3 calls) to use the correct CLI entrypoint.

**Default versions**
OPENVSX_VERSION: default prompt value updated from v0.27.0 to v0.32.3 (create-namespace/deploy flow).
OVSX_VERSION (CLI): default prompt value updated from 0.10.5 to 0.10.9 (CLI image build).