### PR TITLE
chore[devfile]: revert postgresql image in devfile

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -50,7 +50,7 @@ components:
           value: 'false'
   - name: postgresql
     container:
-      image: 'image-registry.openshift-image-registry.svc:5000/openshift/postgresql:16-el8'
+      image: 'quay.io/sclorg/postgresql-16-c9s:20260319'
       memoryRequest: 256Mi
       memoryLimit: 2Gi
       cpuRequest: 100m


### PR DESCRIPTION
Revert the PostgreSQL image to image-registry.openshift-image-registry.svc:5000/openshift/postgresql:15-el8, as image-registry.openshift-image-registry.svc:5000/openshift/postgresql:16-el8 is not available in the OpenShift image registry and we have ImagPullBackOff when starting a workspace.