### PR TITLE
Fix: gracefully handle case of file resources without extension version

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/storage/log/DownloadCountProcessor.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/log/DownloadCountProcessor.java
@@ -69,6 +69,15 @@ public class DownloadCountProcessor {
     public Map<Long, Integer> processDownloadCounts(String storageType, Map<String, Integer> files) {
         return Observation.createNotStarted("DownloadCountProcessor#processDownloadCounts", observations).observe(() -> repositories.findDownloadsByStorageTypeAndName(storageType, files.keySet()).stream()
                 .map(fileResource -> Map.entry(fileResource, files.get(fileResource.getName().toUpperCase())))
+                .filter(fileResource -> {
+                    var ev = fileResource.getKey().getExtension();
+                    if (ev == null) {
+                        logger.warn("no extension version found for download {}, skipping", fileResource.getKey().getName());
+                        return false;
+                    } else {
+                        return true;
+                    }
+                })
                 .collect(Collectors.groupingBy(
                         e -> e.getKey().getExtension().getExtension().getId(),
                         Collectors.summingInt(Map.Entry::getValue)


### PR DESCRIPTION
In some rare cases it happens that while processing the log files, a download was found for which there exists a `FileResource` entity while there is no `ExtensionVersion` associated with it.

Its not clear yet how this happened, but this PR makes the `DownloadCountProcessor` fail-safe and log the problematic file for inspection.

Could be a corrupted database entry or a race condition, the log will help us identify the problem.