### PR TITLE
feat: Add logged in user identity cache key

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ratelimit/IdentityService.java
+++ b/server/src/main/java/org/eclipse/openvsx/ratelimit/IdentityService.java
@@ -12,8 +12,10 @@
  *****************************************************************************/
 package org.eclipse.openvsx.ratelimit;
 
-import com.giffing.bucket4j.spring.boot.starter.context.ExpressionParams;
-import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.openvsx.UserService;
 import org.eclipse.openvsx.accesstoken.AccessTokenService;
 import org.eclipse.openvsx.ratelimit.config.RateLimitConfig;
 import org.eclipse.openvsx.ratelimit.config.RateLimitProperties;
@@ -26,7 +28,9 @@ import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
+import com.giffing.bucket4j.spring.boot.starter.context.ExpressionParams;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 @Service
 @ConditionalOnBean(RateLimitConfig.class)
@@ -41,6 +45,7 @@ public class IdentityService {
     private final CustomerService customerService;
     private final AccessTokenService tokenService;
     private final RateLimitProperties rateLimitProperties;
+    private final UserService userService;
 
     public IdentityService(
             ExpressionParser expressionParser,
@@ -48,7 +53,8 @@ public class IdentityService {
             TierService tierService,
             CustomerService customerService,
             AccessTokenService tokenService,
-            RateLimitProperties rateLimitProperties
+            RateLimitProperties rateLimitProperties,
+            UserService userService
     ) {
         this.expressionParser = expressionParser;
         this.beanFactory = beanFactory;
@@ -56,6 +62,7 @@ public class IdentityService {
         this.customerService = customerService;
         this.tokenService = tokenService;
         this.rateLimitProperties = rateLimitProperties;
+        this.userService = userService;
     }
 
     public ResolvedIdentity resolveIdentity(HttpServletRequest request) {
@@ -71,6 +78,15 @@ public class IdentityService {
             if (tokenEntity != null) {
                 // if a valid token is present we use it as a cache key
                 cacheKey = "token_" + token.hashCode();
+            }
+        }
+
+        // if we don't have a valid token, we check if the user is logged in to generate a cache key
+        // we want to only do this if we don't have a valid token to avoid unnecessary database calls
+        if (cacheKey == null) {
+            var user = userService.findLoggedInUser();
+            if (user != null && StringUtils.isNotBlank(user.getAuthId())) {
+                cacheKey = "user_" + user.getAuthId();
             }
         }
 

--- a/server/src/main/java/org/eclipse/openvsx/ratelimit/IdentityService.java
+++ b/server/src/main/java/org/eclipse/openvsx/ratelimit/IdentityService.java
@@ -69,24 +69,23 @@ public class IdentityService {
         String ipAddress = getIPAddress(request);
         String cacheKey = null;
 
-        var token = request.getParameter("token");
-        if (token != null) {
-            // This will update the database with the time the token is last accessed,
-            // but we need to ensure that we only take valid tokens into account for rate limiting.
-            // If this turns out to be a bottleneck, we need to cache the token hashcode.
-            var tokenEntity = tokenService.useAccessToken(token);
-            if (tokenEntity != null) {
-                // if a valid token is present we use it as a cache key
-                cacheKey = "token_" + token.hashCode();
-            }
+        // check first for user session to ensure that users can't extend their rate limit through tokens
+        var user = userService.findLoggedInUser();
+        if (user != null && StringUtils.isNotBlank(user.getAuthId())) {
+            cacheKey = "user_" + user.getAuthId();
         }
 
-        // if we don't have a valid token, we check if the user is logged in to generate a cache key
-        // we want to only do this if we don't have a valid token to avoid unnecessary database calls
         if (cacheKey == null) {
-            var user = userService.findLoggedInUser();
-            if (user != null && StringUtils.isNotBlank(user.getAuthId())) {
-                cacheKey = "user_" + user.getAuthId();
+            var token = request.getParameter("token");
+            if (token != null) {
+                // This will update the database with the time the token is last accessed,
+                // but we need to ensure that we only take valid tokens into account for rate limiting.
+                // If this turns out to be a bottleneck, we need to cache the token hashcode.
+                var tokenEntity = tokenService.useAccessToken(token);
+                if (tokenEntity != null) {
+                    // if a valid token is present we use it as a cache key
+                    cacheKey = "token_" + token.hashCode();
+                }
             }
         }
 

--- a/server/src/test/java/org/eclipse/openvsx/ratelimit/IdentityServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/ratelimit/IdentityServiceTest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2026 Eclipse Foundation AISBL
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.openvsx.ratelimit;
+
+import java.util.Optional;
+
+import org.eclipse.openvsx.UserService;
+import org.eclipse.openvsx.accesstoken.AccessTokenService;
+import org.eclipse.openvsx.entities.UserData;
+import org.eclipse.openvsx.ratelimit.config.RateLimitProperties;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@ExtendWith(SpringExtension.class)
+@MockitoBean(types = {
+    ConfigurableBeanFactory.class,
+    AccessTokenService.class
+})
+public class IdentityServiceTest {
+
+    @MockitoBean
+    CustomerService customerService;
+
+    @MockitoBean
+    UserService users;
+
+    @MockitoBean
+    TierService tierService;
+
+    @Autowired
+    IdentityService service;
+
+    @Test
+    public void testResolveIdentityAuthenticatedUser() {
+        var request = mockRequest();
+        var userData = mockUserData();
+
+        Mockito.when(customerService.getCustomerByIpAddress(ArgumentMatchers.anyString())).thenReturn(Optional.empty());
+        Mockito.when(tierService.getFreeTier()).thenReturn(Optional.empty());
+        Mockito.when(tierService.getSafetyTier()).thenReturn(Optional.empty());
+
+        var resolvedIdentity = service.resolveIdentity(request);
+
+        assertTrue(resolvedIdentity.cacheKey().startsWith("user_"), "Cache key should start with 'user_'");
+        assertEquals("user_" + userData.getAuthId(), resolvedIdentity.cacheKey(), "Cache key should be based on user auth ID");
+    }
+
+    private HttpServletRequest mockRequest() {
+        var request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getParameter("token")).thenReturn(null);
+        return request;
+    }
+
+    private UserData mockUserData() {
+        var userData = new UserData();
+        userData.setLoginName("test_user");
+        userData.setFullName("Test User");
+        userData.setAuthId("test_auth_id");
+        userData.setProviderUrl("http://example.com/test");
+        Mockito.doReturn(userData).when(users).findLoggedInUser();
+        return userData;
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        public IdentityService identityService(
+                ExpressionParser expressionParser,
+                ConfigurableBeanFactory beanFactory,
+                TierService tierService,
+                CustomerService customerService,
+                AccessTokenService tokenService,
+                RateLimitProperties rateLimitProperties,
+                UserService userService
+        ) {
+            return new IdentityService(expressionParser, beanFactory, tierService, customerService, tokenService, rateLimitProperties, userService);
+        }
+
+        @Bean
+        public ExpressionParser expressionParser() {
+            return new SpelExpressionParser();
+        }
+
+        @Bean
+        public RateLimitProperties rateLimitProperties() {
+            return new RateLimitProperties();
+        }
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/ratelimit/IdentityServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/ratelimit/IdentityServiceTest.java
@@ -53,7 +53,7 @@ public class IdentityServiceTest {
 
     @Test
     public void testResolveIdentityAuthenticatedUser() {
-        var request = mockRequest();
+        var request = Mockito.mock(HttpServletRequest.class);
         var userData = mockUserData();
 
         Mockito.when(customerService.getCustomerByIpAddress(ArgumentMatchers.anyString())).thenReturn(Optional.empty());
@@ -64,12 +64,6 @@ public class IdentityServiceTest {
 
         assertTrue(resolvedIdentity.cacheKey().startsWith("user_"), "Cache key should start with 'user_'");
         assertEquals("user_" + userData.getAuthId(), resolvedIdentity.cacheKey(), "Cache key should be based on user auth ID");
-    }
-
-    private HttpServletRequest mockRequest() {
-        var request = Mockito.mock(HttpServletRequest.class);
-        Mockito.when(request.getParameter("token")).thenReturn(null);
-        return request;
     }
 
     private UserData mockUserData() {


### PR DESCRIPTION
To cover logged in user sessions more cleanly when resolving identities, a new cachekey prefix was added to IdentityService.resoveIdentity. This "user_" prefix is used when there is an identifiable user session for the current request.

Resolves https://github.com/EclipseFdn/open-vsx.org/issues/8954