### PR TITLE
chore: update devfile commands to use OpenVSX v0.33.0

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -145,8 +145,8 @@ commands:
       component: tool
       workingDir: ${PROJECTS_ROOT}/openvsx/deploy/openshift
       commandLine: |
-          read -p "Please enter the value for OPENVSX_VERSION (default: v0.32.3): " OPENVSX_VERSION
-          OPENVSX_VERSION=${OPENVSX_VERSION:-v0.32.3}
+          read -p "Please enter the value for OPENVSX_VERSION (default: v0.33.0): " OPENVSX_VERSION
+          OPENVSX_VERSION=${OPENVSX_VERSION:-v0.33.0}
           export OPENVSX_VERSION
           echo "OPENVSX_VERSION is set to $OPENVSX_VERSION"
           podman build -t "openvsx:$OPENVSX_VERSION" --build-arg "OPENVSX_VERSION=$OPENVSX_VERSION" -f openvsx.Dockerfile .&&
@@ -236,7 +236,7 @@ commands:
           kubectl exec -n "$OPENVSX_NAMESPACE" "$POSTGRESQL_POD_NAME" -- bash -c \
             "psql -d openvsx -c \"INSERT INTO user_data (id, login_name, role) VALUES (1001, '$OPENVSX_USER_NAME', 'privileged');\""
           kubectl exec -n "$OPENVSX_NAMESPACE" "$POSTGRESQL_POD_NAME" -- bash -c \
-            "psql -d openvsx -c \"INSERT INTO personal_access_token (id, user_data, value, active, created_timestamp, accessed_timestamp, description) VALUES (1001, 1001, '$OPENVSX_USER_PAT', true, current_timestamp, current_timestamp, 'extensions publisher');\""
+            "psql -d openvsx -c \"INSERT INTO personal_access_token (id, user_data, value, active, created_timestamp, accessed_timestamp, description, notified) VALUES (1001, 1001, '$OPENVSX_USER_PAT', true, current_timestamp, current_timestamp, 'extensions publisher', false);\""
           echo "✅ OpenVSX user and token inserted successfully."
 
   - id: enable-internal-openvsx

--- a/deploy/openshift/openvsx.Dockerfile
+++ b/deploy/openshift/openvsx.Dockerfile
@@ -28,14 +28,13 @@ RUN git clone --branch ${VERSION} --depth 1 https://github.com/eclipse/openvsx.g
 RUN yarn --version \
   && yarn --cwd webui \
   && yarn --cwd webui install \
-  && yarn --cwd webui build \
   && yarn --cwd webui build:default
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse/openvsx-server:${OPENVSX_VERSION}
+FROM ghcr.io/eclipse-openvsx/openvsx-server:${OPENVSX_VERSION}
 ARG OPENVSX_VERSION
 
-COPY --from=builder --chown=openvsx:openvsx /workdir/webui/static/ BOOT-INF/classes/static/
+COPY --from=builder --chown=openvsx:openvsx /workdir/webui/dist/ BOOT-INF/classes/static/
 COPY /application.yml config/
 
 USER root


### PR DESCRIPTION
- Bump default OPENVSX_VERSION from v0.32.3 to v0.33.0 in devfile commands
- Update the Docker base image registry from ghcr.io/eclipse/openvsx-server to ghcr.io/eclipse-openvsx/openvsx-server to match the new upstream location
- Fix the COPY source path from webui/static/ to webui/dist/ to reflect the updated build output directory
- Add missing notified column (set to false) in the personal_access_token SQL insert to match the v0.33.0 schema