### PR TITLE
Fix: make toSearchEntry fail-safe

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/admin/ChangeNamespaceService.java
+++ b/server/src/main/java/org/eclipse/openvsx/admin/ChangeNamespaceService.java
@@ -74,7 +74,7 @@ public class ChangeNamespaceService {
 
         cache.evictSitemap();
         cache.evictNamespaceDetails(oldNamespace);
-        search.updateSearchEntries(extensions.toList());
+        search.updateSearchEntries(extensions.filter(Extension::isActive).toList());
     }
 
     private void changeExtensionNamespace(Streamable<Extension> extensions, Namespace newNamespace) {

--- a/server/src/main/java/org/eclipse/openvsx/entities/Extension.java
+++ b/server/src/main/java/org/eclipse/openvsx/entities/Extension.java
@@ -13,6 +13,7 @@ import jakarta.persistence.*;
 import org.eclipse.openvsx.search.ExtensionSearch;
 import org.eclipse.openvsx.util.NamingUtil;
 
+import javax.annotation.Nonnull;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -66,7 +67,7 @@ public class Extension implements Serializable {
     /**
      * Convert to a search entity for Elasticsearch.
      */
-    public ExtensionSearch toSearch(ExtensionVersion latest, List<String> targetPlatforms) {
+    public ExtensionSearch toSearch(@Nonnull ExtensionVersion latest, List<String> targetPlatforms) {
         var search = new ExtensionSearch();
         search.setId(this.getId());
         search.setName(this.getName());

--- a/server/src/main/java/org/eclipse/openvsx/search/DatabaseSearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/DatabaseSearchService.java
@@ -23,10 +23,7 @@ import org.springframework.data.util.Streamable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static org.eclipse.openvsx.cache.CacheService.CACHE_AVERAGE_REVIEW_RATING;
@@ -41,12 +38,21 @@ public class DatabaseSearchService implements ISearchService {
     private final RelevanceService relevanceService;
     private final RepositoryService repositories;
 
+    private final Map<String, Comparator<ExtensionSearch>> comparators;
+
     @Value("${ovsx.databasesearch.enabled:false}")
     boolean enableSearch;
 
     public DatabaseSearchService(RelevanceService relevanceService, RepositoryService repositories) {
         this.relevanceService = relevanceService;
         this.repositories = repositories;
+
+        comparators = Map.of(
+                SortBy.RELEVANCE, new RelevanceComparator(),
+                SortBy.TIMESTAMP, new TimestampComparator(),
+                SortBy.RATING, new RatingComparator(),
+                SortBy.DOWNLOADS, new DownloadedCountComparator()
+        );
     }
 
     public boolean isEnabled() {
@@ -78,26 +84,21 @@ public class DatabaseSearchService implements ISearchService {
 
     private List<ExtensionSearch> sortExtensions(Options options, Streamable<Extension> matchingExtensions) {
         Stream<ExtensionSearch> searchEntries;
-        if(SortBy.RELEVANCE.equals(options.sortBy()) || SortBy.RATING.equals(options.sortBy())) {
+        if (SortBy.RELEVANCE.equals(options.sortBy()) || SortBy.RATING.equals(options.sortBy())) {
             var searchStats = new SearchStats(repositories);
-            searchEntries = matchingExtensions.stream().map(extension -> relevanceService.toSearchEntry(extension, searchStats));
+            searchEntries = matchingExtensions.stream()
+                    .map(extension -> relevanceService.toSearchEntry(extension, searchStats))
+                    .filter(Objects::nonNull);
         } else {
             searchEntries = matchingExtensions.stream().map(extension -> {
                 var latest = repositories.findLatestVersion(extension, null, false, true);
                 var targetPlatforms = repositories.findExtensionTargetPlatforms(extension);
-                return extension.toSearch(latest, targetPlatforms);
-            });
+                return latest != null ? extension.toSearch(latest, targetPlatforms) : null;
+            }).filter(Objects::nonNull);
         }
 
-        var comparators = Map.of(
-                SortBy.RELEVANCE, new RelevanceComparator(),
-                SortBy.TIMESTAMP, new TimestampComparator(),
-                SortBy.RATING, new RatingComparator(),
-                SortBy.DOWNLOADS, new DownloadedCountComparator()
-        );
-
         var comparator = comparators.get(options.sortBy());
-        if(comparator == null) {
+        if (comparator == null) {
             throw new ErrorResultException("sortBy parameter must be " + SortBy.OPTIONS + ".");
         }
         if ("desc".equals(options.sortOrder())) {
@@ -108,7 +109,7 @@ public class DatabaseSearchService implements ISearchService {
     }
 
     private Streamable<Extension> excludeByQueryString(Options options, Streamable<Extension> matchingExtensions) {
-        if(options.queryString() == null) {
+        if (options.queryString() == null) {
             return matchingExtensions;
         }
 
@@ -124,7 +125,7 @@ public class DatabaseSearchService implements ISearchService {
     }
 
     private Streamable<Extension> excludeByCategory(Options options, Streamable<Extension> matchingExtensions) {
-        if(options.category() == null) {
+        if (options.category() == null) {
             return matchingExtensions;
         }
 
@@ -135,7 +136,7 @@ public class DatabaseSearchService implements ISearchService {
     }
 
     private Streamable<Extension> excludeByTargetPlatform(Options options, Streamable<Extension> matchingExtensions) {
-        if(!TargetPlatform.isValid(options.targetPlatform())) {
+        if (!TargetPlatform.isValid(options.targetPlatform())) {
             return matchingExtensions;
         }
 
@@ -143,7 +144,7 @@ public class DatabaseSearchService implements ISearchService {
     }
 
     private Streamable<Extension> includeByNamespace(Options options, Streamable<Extension> matchingExtensions) {
-        if(options.namespace() == null) {
+        if (options.namespace() == null) {
             return matchingExtensions;
         }
 
@@ -151,7 +152,7 @@ public class DatabaseSearchService implements ISearchService {
     }
 
     private Streamable<Extension> excludeByNamespace(Options options, Streamable<Extension> matchingExtensions) {
-        if(options.namespacesToExclude() == null) {
+        if (options.namespacesToExclude() == null) {
             return matchingExtensions;
         }
 
@@ -199,7 +200,7 @@ public class DatabaseSearchService implements ISearchService {
     /**
      * Sort by download count
      */
-    class DownloadedCountComparator implements Comparator<ExtensionSearch> {
+    static class DownloadedCountComparator implements Comparator<ExtensionSearch> {
 
         @Override
         public int compare(ExtensionSearch ext1, ExtensionSearch ext2) {
@@ -211,7 +212,7 @@ public class DatabaseSearchService implements ISearchService {
     /**
      * Sort by averageRating
      */
-    class RatingComparator implements Comparator<ExtensionSearch> {
+    static class RatingComparator implements Comparator<ExtensionSearch> {
 
         @Override
         public int compare(ExtensionSearch ext1, ExtensionSearch ext2) {
@@ -228,7 +229,7 @@ public class DatabaseSearchService implements ISearchService {
     /**
      * Sort by timestamp
      */
-    class TimestampComparator implements Comparator<ExtensionSearch> {
+    static class TimestampComparator implements Comparator<ExtensionSearch> {
 
         @Override
         public int compare(ExtensionSearch ext1, ExtensionSearch ext2) {
@@ -240,7 +241,7 @@ public class DatabaseSearchService implements ISearchService {
     /**
      * Sort by relevance
      */
-    class RelevanceComparator implements Comparator<ExtensionSearch> {
+    static class RelevanceComparator implements Comparator<ExtensionSearch> {
 
         @Override
         public int compare(ExtensionSearch ext1, ExtensionSearch ext2) {

--- a/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
@@ -15,12 +15,14 @@ import co.elastic.clients.elasticsearch._types.mapping.FieldType;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import co.elastic.clients.util.ObjectBuilder;
+import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.migration.HandlerJobRequest;
 import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.search.RelevanceService.SearchStats;
 import org.eclipse.openvsx.util.ErrorResultException;
+import org.eclipse.openvsx.util.NamingUtil;
 import org.eclipse.openvsx.util.TargetPlatform;
 import org.jobrunr.scheduling.JobRequestScheduler;
 import org.jobrunr.scheduling.cron.Cron;
@@ -38,6 +40,7 @@ import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.query.DeleteQuery;
+import org.springframework.data.elasticsearch.core.query.IndexQuery;
 import org.springframework.data.elasticsearch.core.query.IndexQueryBuilder;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
@@ -174,11 +177,10 @@ public class ElasticSearchService implements ISearchService {
                 return;
             }
             var stats = new SearchStats(repositories);
-            var indexQueries = allExtensions.map(extension ->
-                new IndexQueryBuilder()
-                    .withObject(relevanceService.toSearchEntry(extension, stats))
-                    .build()
-            ).toList();
+            var indexQueries = allExtensions
+                    .map(extension -> buildIndexQuery(extension, stats))
+                    .filter(Objects::nonNull)
+                    .toList();
 
             if (!locked) {
                 // The write lock has not been acquired upfront, so do it just before submitting the index queries
@@ -208,11 +210,10 @@ public class ElasticSearchService implements ISearchService {
             rwLock.writeLock().lock();
             var indexOps = searchOperations.indexOps(ExtensionSearch.class);
             var stats = new SearchStats(repositories);
-            var indexQueries = extensions.stream().map(extension ->
-                    new IndexQueryBuilder()
-                            .withObject(relevanceService.toSearchEntry(extension, stats))
-                            .build()
-            ).collect(Collectors.toList());
+            var indexQueries = extensions.stream()
+                    .map(extension -> buildIndexQuery(extension, stats))
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
             searchOperations.bulkIndex(indexQueries, indexOps.getIndexCoordinates());
         } finally {
             rwLock.writeLock().unlock();
@@ -224,16 +225,29 @@ public class ElasticSearchService implements ISearchService {
         if (!isEnabled()) {
             return;
         }
+
         try {
             rwLock.writeLock().lock();
             var stats = new SearchStats(repositories);
-            var indexQuery = new IndexQueryBuilder()
-                    .withObject(relevanceService.toSearchEntry(extension, stats))
-                    .build();
-            var indexOps = searchOperations.indexOps(ExtensionSearch.class);
-            searchOperations.index(indexQuery, indexOps.getIndexCoordinates());
+            var indexQuery = buildIndexQuery(extension, stats);
+            if (indexQuery != null) {
+                var indexOps = searchOperations.indexOps(ExtensionSearch.class);
+                searchOperations.index(indexQuery, indexOps.getIndexCoordinates());
+            }
         } finally {
             rwLock.writeLock().unlock();
+        }
+    }
+
+    private @Nullable IndexQuery buildIndexQuery(Extension extension, SearchStats stats) {
+        var searchEntry = relevanceService.toSearchEntry(extension, stats);
+        if (searchEntry != null) {
+            return new IndexQueryBuilder()
+                    .withObject(searchEntry)
+                    .build();
+        } else {
+            logger.warn("Trying to update search entry for inactive extension '{}'",NamingUtil.toExtensionId(extension));
+            return null;
         }
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/search/RelevanceService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/RelevanceService.java
@@ -12,6 +12,7 @@ package org.eclipse.openvsx.search;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nullable;
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.ExtensionVersion;
 import org.eclipse.openvsx.repositories.RepositoryService;
@@ -51,8 +52,12 @@ public class RelevanceService {
         this.repositories = repositories;
     }
 
-    public ExtensionSearch toSearchEntry(Extension extension, SearchStats stats) {
-        var latest = repositories.findLatestVersion(extension,  null, false, true);
+    public @Nullable ExtensionSearch toSearchEntry(Extension extension, SearchStats stats) {
+        var latest = repositories.findLatestVersion(extension, null, false, true);
+        if (latest == null) {
+            return null;
+        }
+
         var targetPlatforms = repositories.findExtensionTargetPlatforms(extension);
         var entry = extension.toSearch(latest, targetPlatforms);
         entry.setRating(calculateRating(extension, stats));


### PR DESCRIPTION
It happens that sometimes there is an extension w/o any active version, but the `toSearchEntry` method is still called, leading to exceptions.

This PR makes the method fail-safe and adds logging in case this happens again.

Furthermore, places where it is known that potentially inactive extensions are passed on, only active ones are filtered before calling the relevant methods.