### PR TITLE
Fix: avoid loading extension data multiple times

### DIFF
--- a/webui/src/pages/extension-detail/extension-detail-changes.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-changes.tsx
@@ -22,12 +22,9 @@ export const ExtensionDetailChanges: FunctionComponent<ExtensionDetailChangesPro
     const abortController = useRef<AbortController>(new AbortController());
 
     useEffect(() => {
-        return () => abortController.current.abort();
-    }, []);
-
-    useEffect(() => {
         setLoading(true);
         updateChanges();
+        return () => abortController.current.abort();
     }, [props.extension.namespace, props.extension.name, props.extension.version]);
 
     const updateChanges = async (): Promise<void> => {

--- a/webui/src/pages/extension-detail/extension-detail-changes.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-changes.tsx
@@ -22,7 +22,6 @@ export const ExtensionDetailChanges: FunctionComponent<ExtensionDetailChangesPro
     const abortController = useRef<AbortController>(new AbortController());
 
     useEffect(() => {
-        updateChanges();
         return () => abortController.current.abort();
     }, []);
 

--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -79,12 +79,9 @@ export const ExtensionDetailOverview: FunctionComponent<ExtensionDetailOverviewP
     }, [props.extension.downloads]);
 
     useEffect(() => {
-        return () => abortController.current.abort();
-    }, []);
-
-    useEffect(() => {
         setLoading(true);
         updateReadme();
+        return () => abortController.current.abort();
     }, [props.extension.namespace, props.extension.name, props.extension.version]);
 
     const updateReadme = async (): Promise<void> => {

--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -79,10 +79,7 @@ export const ExtensionDetailOverview: FunctionComponent<ExtensionDetailOverviewP
     }, [props.extension.downloads]);
 
     useEffect(() => {
-        updateReadme();
-        return () => {
-            abortController.current.abort();
-        };
+        return () => abortController.current.abort();
     }, []);
 
     useEffect(() => {

--- a/webui/src/pages/extension-detail/extension-detail.tsx
+++ b/webui/src/pages/extension-detail/extension-detail.tsx
@@ -61,8 +61,11 @@ export const ExtensionDetail: FunctionComponent = () => {
     const { handleError, pageSettings, service } = useContext(MainContext);
 
     const abortController = useRef<AbortController>(new AbortController());
+
     useEffect(() => {
-        updateExtension();
+        if (extension === undefined) {
+            updateExtension();
+        }
         return () => {
             abortController.current.abort();
             if (icon) {
@@ -91,14 +94,13 @@ export const ExtensionDetail: FunctionComponent = () => {
             const icon = await updateIcon(extension);
             setExtension(extension);
             setIcon(icon);
-            setLoading(false);
         } catch (err) {
             if (err && err.status === 404) {
                 setNotFoundError(`Extension Not Found: ${namespace}.${name}`);
-                setLoading(false);
             } else {
                 handleError(err);
             }
+        } finally {
             setLoading(false);
         }
     };


### PR DESCRIPTION
Due to the use of multiple `useEffect` in the extension detail components, the relevant data was loaded always multiple times.