### PR TITLE
fix: validate that all file resources are available

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
@@ -473,8 +473,9 @@ public class ExtensionProcessor implements AutoCloseable {
         return null;
     }
 
-    public @Nullable TempFile getIcon(ExtensionVersion extVersion) throws IOException {
+    public @Nullable String getIconPath() {
         var iconPath = tryGetAssetPath(ExtensionQueryResult.ExtensionFile.FILE_ICON);
+
         if (StringUtils.isEmpty(iconPath)) {
             loadPackageJson();
             var iconPathNode = packageJson.get("icon");
@@ -487,6 +488,15 @@ public class ExtensionProcessor implements AutoCloseable {
             }
 
             iconPath = "extension/" + iconPath;
+        }
+
+        return iconPath;
+    }
+
+    public @Nullable TempFile getIcon(ExtensionVersion extVersion) throws IOException {
+        var iconPath = getIconPath();
+        if (iconPath == null) {
+            return null;
         }
 
         var entryFile = ArchiveUtil.readEntry(zipFile, iconPath);

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -115,7 +115,7 @@ public class PublishExtensionVersionHandler {
                     .map(id -> parseExtensionId(id, "extensionDependencies"))
                     .toList();
 
-            if(!parsedDependencies.isEmpty()) {
+            if (!parsedDependencies.isEmpty()) {
                 checkDependencies(parsedDependencies);
             }
             bundledExtensions.forEach(id -> parseExtensionId(id, "extensionPack"));
@@ -123,7 +123,7 @@ public class PublishExtensionVersionHandler {
 
         extVersion.setDependencies(dependencies);
         extVersion.setBundledExtensions(bundledExtensions);
-        if(integrityService.isEnabled()) {
+        if (integrityService.isEnabled()) {
             extVersion.setSignatureKeyPair(repositories.findActiveKeyPair());
         }
 
@@ -179,6 +179,7 @@ public class PublishExtensionVersionHandler {
 
         validateLicense(processor, extVersion);
         validateIcon(processor, extVersion);
+        validateFileResources(processor, extVersion);
         validateMetadata(extVersion);
         entityManager.persist(extVersion);
         return extVersion;
@@ -228,6 +229,16 @@ public class PublishExtensionVersionHandler {
             }
         } catch (IOException e) {
             throw new ServerErrorException("Failed to read icon file", e);
+        }
+    }
+
+    private void validateFileResources(ExtensionProcessor processor, ExtensionVersion extVersion) {
+        try {
+            // validate that all file resources are readable/accessible during synchronous publishing
+            // to avoid failing during async publishing and report errors directly back to publishers
+            processor.getFileResources(extVersion, _ -> {});
+        } catch (ErrorResultException exc) {
+            throw new ErrorResultException("Validation failed: " + exc.getMessage());
         }
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -10,7 +10,6 @@
 package org.eclipse.openvsx.publish;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.function.Consumer;
@@ -65,7 +64,7 @@ public class PublishExtensionVersionHandler {
     private final ExtensionControlService extensionControl;
     private final ExtensionScanService scanService;
 
-    private final Predicate<Path> unsupportedIconExtensions;
+    private final Predicate<String> unsupportedIconExtensions;
 
     public PublishExtensionVersionHandler(
             PublishingConfig config,
@@ -95,7 +94,7 @@ public class PublishExtensionVersionHandler {
                 return false;
             }
 
-            var fileExtension = FilenameUtils.getExtension(path.toString());
+            var fileExtension = FilenameUtils.getExtension(path);
             return config.getUnsupportedIconFormats().stream().anyMatch(ext -> ext.equalsIgnoreCase(fileExtension));
         };
     }
@@ -178,7 +177,7 @@ public class PublishExtensionVersionHandler {
         extVersion.setExtension(extension);
 
         validateLicense(processor, extVersion);
-        validateIcon(processor, extVersion);
+        validateIcon(processor);
         validateFileResources(processor, extVersion);
         validateMetadata(extVersion);
         entityManager.persist(extVersion);
@@ -222,20 +221,19 @@ public class PublishExtensionVersionHandler {
         }
     }
 
-    private void validateIcon(ExtensionProcessor processor, ExtensionVersion extVersion) {
-        try (var iconFile = processor.getIcon(extVersion)) {
-            if (iconFile != null && unsupportedIconExtensions.test(iconFile.getPath())) {
-                throw new ErrorResultException("This extension cannot be accepted as it uses an unsupported icon format.");
-            }
-        } catch (IOException e) {
-            throw new ServerErrorException("Failed to read icon file", e);
+    private void validateIcon(ExtensionProcessor processor) {
+        var iconPath = processor.getIconPath();
+        if (iconPath != null && unsupportedIconExtensions.test(iconPath)) {
+            throw new ErrorResultException("This extension cannot be accepted as it uses an unsupported icon format.");
         }
     }
 
     private void validateFileResources(ExtensionProcessor processor, ExtensionVersion extVersion) {
         try {
-            // validate that all file resources are readable/accessible during synchronous publishing
-            // to avoid failing during async publishing and report errors directly back to publishers
+            // Validate that all file resources are readable/accessible during synchronous publishing
+            // to avoid failing during async publishing and report errors directly back to publishers.
+            // This creates unnecessary temp files, however these are usually small and thus it is
+            // acceptable in this case.
             processor.getFileResources(extVersion, _ -> {});
         } catch (ErrorResultException exc) {
             throw new ErrorResultException("Validation failed: " + exc.getMessage());

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +34,6 @@ import org.eclipse.openvsx.extension_control.ExtensionControlService;
 import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.scanning.ExtensionScanService;
 import org.eclipse.openvsx.util.ErrorResultException;
-import org.eclipse.openvsx.util.TempFile;
 import org.jobrunr.scheduling.JobRequestScheduler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -207,7 +205,7 @@ class PublishExtensionVersionHandlerTest {
         when(processor.getExtensionName()).thenReturn(name);
         when(processor.getVersion()).thenReturn(version);
         if (iconPath != null) {
-            when(processor.getIcon(ArgumentMatchers.any())).thenReturn(new TempFile(Path.of(iconPath)));
+            when(processor.getIconPath()).thenReturn(iconPath);
         }
 
         var ev = new ExtensionVersion();


### PR DESCRIPTION
This fixes #1762 .

Previously, file resources are only accessed during async publishing. If something fails, the extension version is created and activation fails and thus leaves a dangling extension version.

To prevent that, it is already validated during the synchronous publishing validation that all file resources are accessible / readable and report back any error to the publisher to be able to fix these errors.