### PR TITLE
Fix: add download url for errroed extension scans

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/admin/ScanAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/admin/ScanAPI.java
@@ -914,6 +914,7 @@ public class ScanAPI {
         json.setDisplayName(version.getDisplayName());
 
         var isQuarantined = scanStatus == ScanStatus.QUARANTINED;
+        var isErrored = scanStatus == ScanStatus.ERRORED;
         var fileTypes = isQuarantined ?
                 new String[] { FileResource.ICON } :
                 new String[] { FileResource.ICON, FileResource.DOWNLOAD };
@@ -931,9 +932,10 @@ public class ScanAPI {
                 json.setExtensionIcon(iconUrl);
             }
 
-            // if the extension is quarantined,
+            // if the extension is quarantined or errored,
             // resolve the download location as the api endpoint will return 404.
-            if (isQuarantined) {
+            // TODO: this does not work when using local storage as in this case always an api url is returned
+            if (isQuarantined || isErrored) {
                 var downloadResource = repositories.findFileByType(version, FileResource.DOWNLOAD);
                 if (downloadResource != null) {
                     var url = storageUtil.getLocation(downloadResource);

--- a/webui/src/components/scan-admin/scan-card/scan-card-expanded-content.tsx
+++ b/webui/src/components/scan-admin/scan-card/scan-card-expanded-content.tsx
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
 
-import { FC } from "react";
+import { FC } from 'react';
 import { Box, Typography, Collapse, Chip } from '@mui/material';
 import { useTheme, Theme } from '@mui/material/styles';
 import { ScanResult, Threat, ValidationFailure, CheckResult } from '../../../context/scan-admin';
@@ -63,7 +63,7 @@ const ThreatItem: FC<ThreatItemProps> = ({ threat }) => {
 /**
  * A single validation failure item in the expanded content.
  */
-const ValidationFailureItem: React.FC<ValidationFailureItemProps> = ({ failure }) => {
+const ValidationFailureItem: FC<ValidationFailureItemProps> = ({ failure }) => {
     const theme = useTheme();
     const isUnenforced = !failure.enforcedFlag;
 
@@ -119,7 +119,7 @@ const formatDuration = (ms: number | null): string | undefined => {
 /**
  * A single check result item showing what check was run and its outcome.
  */
-const CheckResultItem: React.FC<CheckResultItemProps> = ({ checkResult }) => {
+const CheckResultItem: FC<CheckResultItemProps> = ({ checkResult }) => {
     const theme = useTheme();
     const colors = getCheckResultColor(checkResult.result, theme);
     const isPassed = checkResult.result === 'PASSED';
@@ -182,7 +182,7 @@ const CheckResultItem: React.FC<CheckResultItemProps> = ({ checkResult }) => {
  * The expanded content section showing threats, validation failures, and check results.
  * Each item's enforcedFlag controls its individual striping effect.
  */
-export const ScanCardExpandedContent: React.FC<ScanCardExpandedContentProps> = ({ scan, expanded, onCollapseComplete }) => {
+export const ScanCardExpandedContent: FC<ScanCardExpandedContentProps> = ({ scan, expanded, onCollapseComplete }) => {
     const theme = useTheme();
     const hasThreats = scan.threats.length > 0;
     const hasValidationFailures = scan.validationFailures.length > 0;

--- a/webui/src/components/scan-admin/scan-card/utils.ts
+++ b/webui/src/components/scan-admin/scan-card/utils.ts
@@ -189,7 +189,7 @@ export const shouldShowExpandButton = (scan: ScanResult): boolean => {
 };
 
 export const hasDownload = (scan: ScanResult): boolean => {
-    return scan.status === 'PASSED' || scan.status === 'QUARANTINED';
+    return scan.status === 'PASSED' || scan.status === 'QUARANTINED' || scan.status === 'ERROR';
 };
 
 export const getFileName = (url?: string): string => {


### PR DESCRIPTION
When an extension scan failed for some reason, the extension version might still be there together with the extension file but is not activated.

To easily get the extension file, add the download url in such a case.

Ideally we should also have a retry button, but this will be handled in another PR

This is part of #1741 .