### PR TITLE
fix(admin): dashboard breadcrumbs are not decoded

### DIFF
--- a/webui/CHANGELOG.md
+++ b/webui/CHANGELOG.md
@@ -4,6 +4,10 @@ This change log covers only the frontend library (webui) of Open VSX.
 
 ## [next] (unreleased)
 
+### Fixed
+
+- Fix admin dashboard breadcrumbs not being URL-decoded ([#1781](https://github.com/eclipse-openvsx/openvsx/pull/1781))
+
 ## [v0.20.1] (20/04/2026)
 
 ### Changed

--- a/webui/src/pages/admin-dashboard/admin-dashboard.tsx
+++ b/webui/src/pages/admin-dashboard/admin-dashboard.tsx
@@ -161,11 +161,11 @@ const BreadcrumbsComponent = () => {
 
                 return last ? (
                     <Typography color='text.primary' key={to}>
-                        {routeNames[to] ?? value}
+                        {routeNames[to] ?? decodeURIComponent(value)}
                     </Typography>
                 ) : (
                     <LinkRouter underline='hover' color='inherit' to={to} key={to}>
-                        {routeNames[to]}
+                        {routeNames[to] ?? decodeURIComponent(value)}
                     </LinkRouter>
                 );
             })}


### PR DESCRIPTION
This PR fixes breadcrumb spaces or special characters being shown in a URI-encoded manner.

<img width="1010" height="238" alt="image" src="https://github.com/user-attachments/assets/bde163c5-56ba-4292-98be-5c28a4a80360" />
