### PR TITLE
refactor(admin): updating admin dashboard sidepanel implementation

### DIFF
--- a/webui/CHANGELOG.md
+++ b/webui/CHANGELOG.md
@@ -4,6 +4,20 @@ This change log covers only the frontend library (webui) of Open VSX.
 
 ## [next] (unreleased)
 
+### Added
+
+- Persist open/closed state for the admin dashboard sidepanel ([#1782](https://github.com/eclipse-openvsx/openvsx/pull/1782))
+- Revamp admin dashboard welcome page ([#1782](https://github.com/eclipse-openvsx/openvsx/pull/1782))
+
+### Changed
+
+- Refactor admin dashboard sidepanel implementation ([#1782](https://github.com/eclipse-openvsx/openvsx/pull/1782))
+- Extract breadcrumbs into its own component in the admin dashboard ([#1782](https://github.com/eclipse-openvsx/openvsx/pull/1782))
+
+### Fixed
+
+- Fix scans layout breaking admin dashboard layout ([#1782](https://github.com/eclipse-openvsx/openvsx/pull/1782))
+
 ## [v0.20.1] (20/04/2026)
 
 ### Changed

--- a/webui/CHANGELOG.md
+++ b/webui/CHANGELOG.md
@@ -6,13 +6,13 @@ This change log covers only the frontend library (webui) of Open VSX.
 
 ### Added
 
-- Persist open/closed state for the admin dashboard sidepanel ([#1782](https://github.com/eclipse-openvsx/openvsx/pull/1782))
-- Revamp admin dashboard welcome page ([#1782](https://github.com/eclipse-openvsx/openvsx/pull/1782))
+- Persist open/closed state for the admin dashboard side-panel ([#1782](https://github.com/eclipse-openvsx/openvsx/pull/1782))
 
 ### Changed
 
-- Refactor admin dashboard sidepanel implementation ([#1782](https://github.com/eclipse-openvsx/openvsx/pull/1782))
+- Refactor admin dashboard side-panel implementation ([#1782](https://github.com/eclipse-openvsx/openvsx/pull/1782))
 - Extract breadcrumbs into its own component in the admin dashboard ([#1782](https://github.com/eclipse-openvsx/openvsx/pull/1782))
+- Revamp admin dashboard welcome page ([#1782](https://github.com/eclipse-openvsx/openvsx/pull/1782))
 
 ### Fixed
 

--- a/webui/src/components/sidepanel/navigation-item.tsx
+++ b/webui/src/components/sidepanel/navigation-item.tsx
@@ -16,7 +16,7 @@ import {
 import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import { useNavigate } from 'react-router';
-import { SidebarContext } from './sidepanel';
+import { SidebarContext } from './sidebar-context';
 
 const EXPANDED_CONTEXT = { collapsed: false };
 

--- a/webui/src/components/sidepanel/navigation-item.tsx
+++ b/webui/src/components/sidepanel/navigation-item.tsx
@@ -8,42 +8,99 @@
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
 
-import { FunctionComponent, PropsWithChildren, ReactNode, useState } from 'react';
-import { ListItemButton, ListItemText, Collapse, List, ListItemIcon } from '@mui/material';
+import { FunctionComponent, PropsWithChildren, ReactNode, useContext, useRef, useState } from 'react';
+import {
+    Collapse, List, ListItemButton, ListItemIcon, ListItemText,
+    Popover, Tooltip,
+} from '@mui/material';
 import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import { useNavigate } from 'react-router';
+import { SidebarContext } from './sidepanel';
+
+const EXPANDED_CONTEXT = { collapsed: false };
 
 export const NavigationItem: FunctionComponent<PropsWithChildren<NavigationProps>> = props => {
-    const [open, setOpen] = useState(false);
+    const [groupExpanded, setGroupExpanded] = useState(false);
+    const [popoverOpen, setPopoverOpen] = useState(false);
+    const anchorRef = useRef<HTMLDivElement>(null);
+    const { collapsed } = useContext(SidebarContext);
     const navigate = useNavigate();
 
+    const isGroup = !!props.children;
+
     const handleClick = () => {
-        if (props.children) {
-            setOpen(!open);
+        if (isGroup) {
+            if (collapsed) {
+                setPopoverOpen(true);
+            } else {
+                setGroupExpanded(prev => !prev);
+            }
         } else if (props.route) {
-            props.onOpenRoute?.call(this, props.route);
             navigate(props.route);
         }
     };
 
-    return (<>
-        <ListItemButton sx={ props.active ? { bgcolor: 'action.selected' } : null } onClick={handleClick}>
-            {
-                props.icon && <ListItemIcon>{props.icon}</ListItemIcon>
-            }
-            <ListItemText primary={props.label} />
-            {props.children && (open ? <ExpandLess /> : <ExpandMore />)}
+    const button = (
+        <ListItemButton
+            ref={anchorRef}
+            selected={props.active}
+            onClick={handleClick}
+            sx={{
+                minHeight: 48,
+                px: 2.5,
+                justifyContent: collapsed ? 'center' : 'initial',
+            }}
+        >
+            {props.icon && (
+                <ListItemIcon sx={{ minWidth: 0, mr: collapsed ? 'auto' : 3, justifyContent: 'center' }}>
+                    {props.icon}
+                </ListItemIcon>
+            )}
+            {!collapsed && <ListItemText primary={props.label} />}
+            {!collapsed && isGroup && (groupExpanded ? <ExpandLess /> : <ExpandMore />)}
         </ListItemButton>
-        {
-            props.children &&
-            <Collapse in={open} timeout='auto' unmountOnExit>
-                <List sx={{ pl: 4 }}>
-                    {props.children}
-                </List>
-            </Collapse>
-        }
-    </>);
+    );
+
+    return (
+        <>
+            {collapsed ? (
+                <Tooltip title={props.label} placement='right'>
+                    {button}
+                </Tooltip>
+            ) : (
+                button
+            )}
+
+            {/* Inline expand for groups when sidebar is open */}
+            {!collapsed && isGroup && (
+                <Collapse in={groupExpanded} timeout='auto' unmountOnExit>
+                    <List sx={{ pl: 2 }} disablePadding>
+                        {props.children}
+                    </List>
+                </Collapse>
+            )}
+
+            {/* Floating popover for groups when sidebar is collapsed */}
+            {isGroup && (
+                <Popover
+                    open={popoverOpen}
+                    anchorEl={anchorRef.current}
+                    onClose={() => setPopoverOpen(false)}
+                    anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+                    transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+                    disableRestoreFocus
+                    elevation={2}
+                >
+                    <SidebarContext.Provider value={EXPANDED_CONTEXT}>
+                        <List disablePadding onClick={() => setPopoverOpen(false)}>
+                            {props.children}
+                        </List>
+                    </SidebarContext.Provider>
+                </Popover>
+            )}
+        </>
+    );
 };
 
 export interface NavigationProps {
@@ -51,5 +108,4 @@ export interface NavigationProps {
     icon?: ReactNode;
     label: string;
     active?: boolean;
-    onOpenRoute?: (route: string) => void;
 }

--- a/webui/src/components/sidepanel/sidebar-context.tsx
+++ b/webui/src/components/sidepanel/sidebar-context.tsx
@@ -1,3 +1,16 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
 import { createContext } from 'react';
 
 

--- a/webui/src/components/sidepanel/sidebar-context.tsx
+++ b/webui/src/components/sidepanel/sidebar-context.tsx
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+
+
+export const SidebarContext = createContext<{ collapsed: boolean; }>({ collapsed: false });

--- a/webui/src/components/sidepanel/sidepanel.tsx
+++ b/webui/src/components/sidepanel/sidepanel.tsx
@@ -8,43 +8,72 @@
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
 
-import { FunctionComponent, PropsWithChildren } from 'react';
+import { createContext, FunctionComponent, PropsWithChildren, useMemo } from 'react';
 import { Divider, Drawer, IconButton, List } from '@mui/material';
+import { styled, Theme, CSSObject } from '@mui/material/styles';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { DrawerHeader } from './drawer-header';
 
-export const Sidepanel: FunctionComponent<PropsWithChildren<SidepanelProps>> = props => {
-    const width = props.width;
+export const DRAWER_WIDTH = 240;
+export const COLLAPSED_WIDTH = 57;
 
+export const SidebarContext = createContext<{ collapsed: boolean }>({ collapsed: false });
+
+const openedMixin = (theme: Theme): CSSObject => ({
+    width: DRAWER_WIDTH,
+    transition: theme.transitions.create('width', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.enteringScreen,
+    }),
+    overflowX: 'hidden',
+});
+
+const closedMixin = (theme: Theme): CSSObject => ({
+    width: COLLAPSED_WIDTH,
+    transition: theme.transitions.create('width', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen,
+    }),
+    overflowX: 'hidden',
+});
+
+const StyledDrawer = styled(Drawer, { shouldForwardProp: (prop) => prop !== 'open' })(
+    ({ theme, open }) => ({
+        width: DRAWER_WIDTH,
+        flexShrink: 0,
+        whiteSpace: 'nowrap',
+        boxSizing: 'border-box',
+        ...(open ? {
+            ...openedMixin(theme),
+            '& .MuiDrawer-paper': openedMixin(theme),
+        } : {
+            ...closedMixin(theme),
+            '& .MuiDrawer-paper': closedMixin(theme),
+        }),
+    })
+);
+
+export const Sidepanel: FunctionComponent<PropsWithChildren<SidepanelProps>> = ({ open, onToggle, children }) => {
+    const contextValue = useMemo(() => ({ collapsed: !open }), [open]);
     return (
-        <Drawer
-            sx={{
-                width: width,
-                flexShrink: 0,
-                '& .MuiDrawer-paper': {
-                    width: width,
-                    boxSizing: 'border-box',
-                },
-            }}
-            variant='persistent'
-            anchor='left'
-            open={props.open}
-        >
-            <DrawerHeader>
-                <IconButton onClick={props.handleDrawerClose}>
-                    <ChevronLeftIcon />
-                </IconButton>
-            </DrawerHeader>
-            <Divider />
-            <List>
-                {props.children}
-            </List>
-        </Drawer>
+        <SidebarContext.Provider value={contextValue}>
+            <StyledDrawer variant='permanent' anchor='left' open={open}>
+                <DrawerHeader>
+                    <IconButton onClick={onToggle} aria-label={open ? 'collapse sidebar' : 'expand sidebar'}>
+                        {open ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+                    </IconButton>
+                </DrawerHeader>
+                <Divider />
+                <List disablePadding>
+                    {children}
+                </List>
+            </StyledDrawer>
+        </SidebarContext.Provider>
     );
 };
 
-interface SidepanelProps {
-    width: number;
+export interface SidepanelProps {
     open: boolean;
-    handleDrawerClose: () => void;
+    onToggle: () => void;
 }

--- a/webui/src/components/sidepanel/sidepanel.tsx
+++ b/webui/src/components/sidepanel/sidepanel.tsx
@@ -8,17 +8,16 @@
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
 
-import { createContext, FunctionComponent, PropsWithChildren, useMemo } from 'react';
+import { FunctionComponent, PropsWithChildren, useMemo } from 'react';
 import { Divider, Drawer, IconButton, List } from '@mui/material';
 import { styled, Theme, CSSObject } from '@mui/material/styles';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { DrawerHeader } from './drawer-header';
+import { SidebarContext } from './sidebar-context';
 
 export const DRAWER_WIDTH = 240;
 export const COLLAPSED_WIDTH = 57;
-
-export const SidebarContext = createContext<{ collapsed: boolean }>({ collapsed: false });
 
 const openedMixin = (theme: Theme): CSSObject => ({
     width: DRAWER_WIDTH,

--- a/webui/src/hooks/use-local-storage.ts
+++ b/webui/src/hooks/use-local-storage.ts
@@ -1,0 +1,67 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react';
+
+/**
+ * Reads a value from localStorage and deserializes it.
+ * Returns `fallback` when the key is missing or the stored value cannot be parsed.
+ */
+function readStorage<T>(key: string, fallback: T): T {
+    try {
+        const raw = localStorage.getItem(key);
+        return raw === null ? fallback : (JSON.parse(raw) as T);
+    } catch {
+        return fallback;
+    }
+}
+
+/**
+ * A useState-compatible hook that persists its value in localStorage.
+ *
+ * - Initialises from localStorage (falling back to `initialValue`).
+ * - Keeps multiple tabs in sync by listening to the `storage` event.
+ * - The setter accepts both a direct value and an updater function, matching
+ *   the full useState API.
+ */
+export function useLocalStorage<T>(key: string, initialValue: T): [T, Dispatch<SetStateAction<T>>] {
+    const [state, setState] = useState<T>(() => readStorage(key, initialValue));
+
+    // Persist every state change to localStorage.
+    useEffect(() => {
+        try {
+            localStorage.setItem(key, JSON.stringify(state));
+        } catch {
+            // Quota exceeded or private-browsing restrictions — silently ignore.
+        }
+    }, [key, state]);
+
+    // Keep tabs in sync: when another tab writes to the same key, update state.
+    useEffect(() => {
+        const onStorage = (event: StorageEvent) => {
+            if (event.key !== key || event.storageArea !== localStorage) {
+                return;
+            }
+            setState(event.newValue === null ? initialValue : (JSON.parse(event.newValue) as T));
+        };
+
+        globalThis.addEventListener('storage', onStorage);
+        return () => globalThis.removeEventListener('storage', onStorage);
+    }, [key, initialValue]);
+
+    const setValue: Dispatch<SetStateAction<T>> = useCallback((action) => {
+        setState(prev => (typeof action === 'function' ? (action as (prev: T) => T)(prev) : action));
+    }, []);
+
+    return [state, setValue];
+}

--- a/webui/src/pages/admin-dashboard/admin-dashboard.tsx
+++ b/webui/src/pages/admin-dashboard/admin-dashboard.tsx
@@ -122,7 +122,7 @@ export const AdminDashboard: FunctionComponent<AdminDashboardProps> = props => {
                 <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
                     <AdminHeader routeNames={routeNames} onClose={toMainPage} />
                     <ScrollableContent>
-                        <Container sx={{ pt: 2, pb: 4, px: 3 }} maxWidth='xl'>
+                        <Container sx={{ pt: 3, pb: 4, px: 3 }} maxWidth='xl'>
                             <Suspense fallback={null}>
                                 <Routes>
                                     <Route path='/namespaces' element={<NamespaceAdmin/>} />

--- a/webui/src/pages/admin-dashboard/admin-dashboard.tsx
+++ b/webui/src/pages/admin-dashboard/admin-dashboard.tsx
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
 
-import { FunctionComponent, ReactNode, useContext, useState, lazy, Suspense } from 'react';
+import { FunctionComponent, ReactNode, useContext, lazy, Suspense } from 'react';
 import {
     Box,
     Container,
@@ -18,10 +18,9 @@ import {
     Breadcrumbs,
     LinkProps,
     Link,
-    Toolbar
+    Toolbar,
+    AppBar,
 } from '@mui/material';
-import MuiAppBar, { AppBarProps as MuiAppBarProps } from '@mui/material/AppBar';
-import { styled } from "@mui/material/styles";
 import { Link as RouterLink, Route, Routes, useNavigate, useLocation } from 'react-router-dom';
 import AccountBoxIcon from '@mui/icons-material/AccountBox';
 import AssignmentIndIcon from '@mui/icons-material/AssignmentInd';
@@ -29,18 +28,16 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import ExtensionSharpIcon from '@mui/icons-material/ExtensionSharp';
 import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import HistoryIcon from '@mui/icons-material/History';
-import MenuIcon from '@mui/icons-material/Menu';
 import PeopleIcon from '@mui/icons-material/People';
 import PersonIcon from '@mui/icons-material/Person';
 import SecurityIcon from '@mui/icons-material/Security';
 import SpeedIcon from '@mui/icons-material/Speed';
 import StarIcon from '@mui/icons-material/Star';
-import { DrawerHeader } from '../../components/sidepanel/drawer-header';
-import { Sidepanel } from "../../components/sidepanel/sidepanel";
 import { LoginComponent } from "../../default/login";
 import { MainContext } from '../../context';
-import { NavigationItem } from '../../components/sidepanel/navigation-item';
 import { AdminDashboardRoutes } from './admin-dashboard-routes';
+import { AdminSidepanel } from './admin-sidepanel';
+import { isNavGroup, NavEntry } from './nav-types';
 
 import { NamespaceAdmin } from './namespace-admin';
 import { PublisherAdmin } from './publisher-admin';
@@ -53,33 +50,6 @@ import { Welcome } from './welcome';
 
 const ExtensionAdmin = lazy(() => import('./extension-admin').then(m => ({ default: m.ExtensionAdmin })));
 const UsageStatsView = lazy(() => import('./usage-stats/usage-stats').then(m => ({ default: m.UsageStatsView })));
-
-const Message: FunctionComponent<{message: string}> = ({ message }) => {
-    return (<Box sx={{
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        width: '100%'
-    }}>
-        <Typography variant='h6'>{message}</Typography>
-    </Box>);
-};
-
-interface RouteEntry {
-    path: string;
-    name: string;
-    icon: ReactNode;
-}
-
-interface NavGroup {
-    name: string;
-    icon: ReactNode;
-    children: RouteEntry[];
-}
-
-type NavEntry = RouteEntry | NavGroup;
-
-const isNavGroup = (entry: NavEntry): entry is NavGroup => 'children' in entry;
 
 const navConfig: NavEntry[] = [
     { path: AdminDashboardRoutes.NAMESPACE_ADMIN, name: 'Namespaces', icon: <AssignmentIndIcon /> },
@@ -98,7 +68,6 @@ const navConfig: NavEntry[] = [
     { path: AdminDashboardRoutes.LOGS, name: 'Logs', icon: <HistoryIcon /> },
 ];
 
-// Flat name lookup for breadcrumbs
 const routeNames: { [key: string]: string } = {
     [AdminDashboardRoutes.MAIN]: 'Admin Dashboard',
     ...navConfig.reduce<{ [key: string]: string }>((acc, entry) => {
@@ -113,28 +82,16 @@ const routeNames: { [key: string]: string } = {
     }, {}),
 };
 
-const drawerWidth = 240;
-
-interface AppBarProps extends MuiAppBarProps {
-    open?: boolean;
-}
-
-const AppBar = styled(MuiAppBar, {
-    shouldForwardProp: (prop) => prop !== 'open',
-})<AppBarProps>(({ theme, open }) => ({
-    transition: theme.transitions.create(['margin', 'width'], {
-        easing: theme.transitions.easing.sharp,
-        duration: theme.transitions.duration.leavingScreen,
-    }),
-    ...(open && {
-        width: `calc(100% - ${drawerWidth}px)`,
-        marginLeft: `${drawerWidth}px`,
-        transition: theme.transitions.create(['margin', 'width'], {
-            easing: theme.transitions.easing.easeOut,
-            duration: theme.transitions.duration.enteringScreen,
-        }),
-    }),
-}));
+const Message: FunctionComponent<{message: string}> = ({ message }) => {
+    return (<Box sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%'
+    }}>
+        <Typography variant='h6'>{message}</Typography>
+    </Box>);
+};
 
 interface LinkRouterProps extends LinkProps {
     to: string;
@@ -148,7 +105,7 @@ const LinkRouter = (props: LinkRouterProps) => (
 const BreadcrumbsComponent = () => {
     const { pathname } = useLocation();
 
-    const pathnames = pathname.split("/").filter((segment) => segment);
+    const pathnames = pathname.split("/").filter(Boolean);
 
     return (
         <Breadcrumbs aria-label='breadcrumb' sx={{ pt: 2, pb: 2, px: 4 }} >
@@ -173,89 +130,33 @@ const BreadcrumbsComponent = () => {
     );
 };
 
-const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })<{
-    open?: boolean;
-}>(({ theme, open }) => ({
-    flexGrow: 1,
-    padding: theme.spacing(3),
-    transition: theme.transitions.create('margin', {
-        easing: theme.transitions.easing.sharp,
-        duration: theme.transitions.duration.leavingScreen,
-    }),
-    marginLeft: `-${drawerWidth}px`,
-    ...(open && {
-        transition: theme.transitions.create('margin', {
-            easing: theme.transitions.easing.easeOut,
-            duration: theme.transitions.duration.enteringScreen,
-        }),
-        marginLeft: 0,
-    }),
-}));
-
 export const AdminDashboard: FunctionComponent<AdminDashboardProps> = props => {
     const { user, loginProviders } = useContext(MainContext);
-    const [drawerOpen, setDrawerOpen] = useState(true);
 
     const navigate = useNavigate();
     const toMainPage = () => navigate('/');
 
-    const [currentPage, setCurrentPage] = useState<string | undefined>(useLocation().pathname);
-    const handleOpenRoute = (route: string) => {
-        setCurrentPage(route);
-    };
-
     let content: ReactNode = null;
     if (user?.role === 'admin') {
         content =
-            <Box sx={{ display: 'flex', width: '100%' }}>
+            <Box sx={{ display: 'flex', width: '100%', height: '100%' }}>
                 <CssBaseline />
-                <AppBar position='fixed' open={drawerOpen} color='default' enableColorOnDark elevation={0}>
-                    <Toolbar>
-                        <IconButton
-                            aria-label='open drawer'
-                            onClick={() => setDrawerOpen(true)}
-                            edge='start'
-                            sx={[{ mr: 2 }, drawerOpen && { display: 'none' }]}
-                        >
-                            <MenuIcon />
-                        </IconButton>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                            <BreadcrumbsComponent />
-                            <IconButton onClick={toMainPage} sx={{ mt: 1, mr: 1 }}>
-                                <HighlightOffIcon/>
-                            </IconButton>
-                        </Box>
-                    </Toolbar>
-                </AppBar>
-                <Sidepanel width={drawerWidth} open={drawerOpen} handleDrawerClose={() => setDrawerOpen(false)} >
-                    {navConfig.map((entry) => {
-                        if (isNavGroup(entry)) {
-                            return (
-                                <NavigationItem
-                                    key={entry.name}
-                                    label={entry.name}
-                                    icon={entry.icon}
-                                >
-                                    {entry.children.map((child) => (
-                                        <NavigationItem key={child.path} onOpenRoute={handleOpenRoute} active={currentPage?.startsWith(child.path)}
-                                                        label={child.name} icon={child.icon} route={child.path}/>
-                                    ))}
-                                </NavigationItem>
-                            );
-                        }
-                        return (
-                            <NavigationItem key={entry.path} onOpenRoute={handleOpenRoute} active={currentPage?.startsWith(entry.path)}
-                                            label={entry.name} icon={entry.icon} route={entry.path}/>
-                        );
-                    })}
-                </Sidepanel>
-                <Main open={drawerOpen} >
-                    <DrawerHeader />
+                <AdminSidepanel items={navConfig} />
+                <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
+                    <AppBar position='sticky' color='default' enableColorOnDark elevation={0}>
+                        <Toolbar>
+                            <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
+                                <BreadcrumbsComponent />
+                                <IconButton onClick={toMainPage} sx={{ mt: 1, mr: 1 }}>
+                                    <HighlightOffIcon />
+                                </IconButton>
+                            </Box>
+                        </Toolbar>
+                    </AppBar>
                     <Box
-                        overflow='auto'
-                        flex={1}
                         sx={{
-                            overflowY: 'scroll',
+                            flex: 1,
+                            overflowY: 'auto',
                             '&::-webkit-scrollbar': {
                                 width: '12px',
                             },
@@ -291,7 +192,7 @@ export const AdminDashboard: FunctionComponent<AdminDashboardProps> = props => {
                             </Suspense>
                         </Container>
                     </Box>
-                </Main>
+                </Box>
             </Box>;
     } else if (user) {
         content = <Message message='You are not authorized as administrator.'/>;

--- a/webui/src/pages/admin-dashboard/admin-dashboard.tsx
+++ b/webui/src/pages/admin-dashboard/admin-dashboard.tsx
@@ -15,18 +15,13 @@ import {
     CssBaseline,
     Typography,
     IconButton,
-    Breadcrumbs,
-    LinkProps,
-    Link,
-    Toolbar,
-    AppBar,
 } from '@mui/material';
-import { Link as RouterLink, Route, Routes, useNavigate, useLocation } from 'react-router-dom';
+import { styled } from '@mui/material/styles';
+import { Route, Routes, useNavigate } from 'react-router-dom';
 import AccountBoxIcon from '@mui/icons-material/AccountBox';
 import AssignmentIndIcon from '@mui/icons-material/AssignmentInd';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import ExtensionSharpIcon from '@mui/icons-material/ExtensionSharp';
-import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import HistoryIcon from '@mui/icons-material/History';
 import PeopleIcon from '@mui/icons-material/People';
 import PersonIcon from '@mui/icons-material/Person';
@@ -37,6 +32,7 @@ import { LoginComponent } from "../../default/login";
 import { MainContext } from '../../context';
 import { AdminDashboardRoutes } from './admin-dashboard-routes';
 import { AdminSidepanel } from './admin-sidepanel';
+import { AdminHeader } from './admin-header';
 import { isNavGroup, NavEntry } from './nav-types';
 
 import { NamespaceAdmin } from './namespace-admin';
@@ -82,6 +78,24 @@ const routeNames: { [key: string]: string } = {
     }, {}),
 };
 
+const ScrollableContent = styled(Box)(({ theme }) => ({
+    flex: 1,
+    overflowY: 'auto',
+    '&::-webkit-scrollbar': {
+        width: '12px',
+    },
+    '&::-webkit-scrollbar-track': {
+        backgroundColor: theme.palette.action.hover,
+    },
+    '&::-webkit-scrollbar-thumb': {
+        backgroundColor: theme.palette.action.selected,
+        borderRadius: '6px',
+        '&:hover': {
+            backgroundColor: theme.palette.action.focus,
+        },
+    },
+}));
+
 const Message: FunctionComponent<{message: string}> = ({ message }) => {
     return (<Box sx={{
         display: 'flex',
@@ -91,43 +105,6 @@ const Message: FunctionComponent<{message: string}> = ({ message }) => {
     }}>
         <Typography variant='h6'>{message}</Typography>
     </Box>);
-};
-
-interface LinkRouterProps extends LinkProps {
-    to: string;
-    replace?: boolean;
-}
-
-const LinkRouter = (props: LinkRouterProps) => (
-    <Link {...props} component={RouterLink as any} />
-);
-
-const BreadcrumbsComponent = () => {
-    const { pathname } = useLocation();
-
-    const pathnames = pathname.split("/").filter(Boolean);
-
-    return (
-        <Breadcrumbs aria-label='breadcrumb' sx={{ pt: 2, pb: 2, px: 4 }} >
-            <LinkRouter underline='hover' color='inherit' to='/'>
-                Home
-            </LinkRouter>
-            {pathnames.map((value, index) => {
-                const last = index === pathnames.length - 1;
-                const to = `/${pathnames.slice(0, index + 1).join("/")}`;
-
-                return last ? (
-                    <Typography color='text.primary' key={to}>
-                        {routeNames[to] ?? value}
-                    </Typography>
-                ) : (
-                    <LinkRouter underline='hover' color='inherit' to={to} key={to}>
-                        {routeNames[to]}
-                    </LinkRouter>
-                );
-            })}
-        </Breadcrumbs>
-    );
 };
 
 export const AdminDashboard: FunctionComponent<AdminDashboardProps> = props => {
@@ -143,35 +120,8 @@ export const AdminDashboard: FunctionComponent<AdminDashboardProps> = props => {
                 <CssBaseline />
                 <AdminSidepanel items={navConfig} />
                 <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
-                    <AppBar position='sticky' color='default' enableColorOnDark elevation={0}>
-                        <Toolbar>
-                            <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                                <BreadcrumbsComponent />
-                                <IconButton onClick={toMainPage} sx={{ mt: 1, mr: 1 }}>
-                                    <HighlightOffIcon />
-                                </IconButton>
-                            </Box>
-                        </Toolbar>
-                    </AppBar>
-                    <Box
-                        sx={{
-                            flex: 1,
-                            overflowY: 'auto',
-                            '&::-webkit-scrollbar': {
-                                width: '12px',
-                            },
-                            '&::-webkit-scrollbar-track': {
-                                backgroundColor: 'rgba(0, 0, 0, 0.2)',
-                            },
-                            '&::-webkit-scrollbar-thumb': {
-                                backgroundColor: 'rgba(255, 255, 255, 0.2)',
-                                borderRadius: '6px',
-                                '&:hover': {
-                                    backgroundColor: 'rgba(255, 255, 255, 0.3)',
-                                },
-                            },
-                        }}
-                    >
+                    <AdminHeader routeNames={routeNames} onClose={toMainPage} />
+                    <ScrollableContent>
                         <Container sx={{ pt: 2, pb: 4, px: 3 }} maxWidth='xl'>
                             <Suspense fallback={null}>
                                 <Routes>
@@ -191,7 +141,7 @@ export const AdminDashboard: FunctionComponent<AdminDashboardProps> = props => {
                                 </Routes>
                             </Suspense>
                         </Container>
-                    </Box>
+                    </ScrollableContent>
                 </Box>
             </Box>;
     } else if (user) {

--- a/webui/src/pages/admin-dashboard/admin-dashboard.tsx
+++ b/webui/src/pages/admin-dashboard/admin-dashboard.tsx
@@ -48,20 +48,20 @@ const ExtensionAdmin = lazy(() => import('./extension-admin').then(m => ({ defau
 const UsageStatsView = lazy(() => import('./usage-stats/usage-stats').then(m => ({ default: m.UsageStatsView })));
 
 const navConfig: NavEntry[] = [
-    { path: AdminDashboardRoutes.NAMESPACE_ADMIN, name: 'Namespaces', icon: <AssignmentIndIcon /> },
-    { path: AdminDashboardRoutes.EXTENSION_ADMIN, name: 'Extensions', icon: <ExtensionSharpIcon /> },
-    { path: AdminDashboardRoutes.PUBLISHER_ADMIN, name: 'Publisher', icon: <PersonIcon /> },
-    { path: AdminDashboardRoutes.SCANS_ADMIN, name: 'Scans', icon: <SecurityIcon /> },
+    { path: AdminDashboardRoutes.NAMESPACE_ADMIN, name: 'Namespaces', icon: <AssignmentIndIcon />, description: 'Manage user roles and create new namespaces' },
+    { path: AdminDashboardRoutes.EXTENSION_ADMIN, name: 'Extensions', icon: <ExtensionSharpIcon />, description: 'Search for extensions and remove certain versions' },
+    { path: AdminDashboardRoutes.PUBLISHER_ADMIN, name: 'Publisher', icon: <PersonIcon />, description: 'Search for publishers and revoke their contributions' },
+    { path: AdminDashboardRoutes.SCANS_ADMIN, name: 'Scans', icon: <SecurityIcon />, description: 'View security scan results and manage quarantined extensions' },
     {
         name: 'Rate Limiting',
         icon: <SpeedIcon />,
         children: [
-            { path: AdminDashboardRoutes.TIERS, name: 'Tiers', icon: <StarIcon /> },
-            { path: AdminDashboardRoutes.CUSTOMERS, name: 'Customers', icon: <PeopleIcon /> },
-            { path: AdminDashboardRoutes.USAGE_STATS, name: 'Usage Stats', icon: <BarChartIcon /> },
+            { path: AdminDashboardRoutes.TIERS, name: 'Tiers', icon: <StarIcon />, description: 'Manage rate-limit tiers' },
+            { path: AdminDashboardRoutes.CUSTOMERS, name: 'Customers', icon: <PeopleIcon />, description: 'Manage rate-limit customers' },
+            { path: AdminDashboardRoutes.USAGE_STATS, name: 'Usage Stats', icon: <BarChartIcon />, description: 'Show usage stats for customers' },
         ],
     },
-    { path: AdminDashboardRoutes.LOGS, name: 'Logs', icon: <HistoryIcon /> },
+    { path: AdminDashboardRoutes.LOGS, name: 'Logs', icon: <HistoryIcon />, description: 'Browse admin activity logs' },
 ];
 
 const routeNames: { [key: string]: string } = {
@@ -137,7 +137,7 @@ export const AdminDashboard: FunctionComponent<AdminDashboardProps> = props => {
                                     <Route path='/usage' element={<UsageStatsView/>} />
                                     <Route path='/usage/:customer' element={<UsageStatsView/>} />
                                     <Route path='/logs' element={<Logs/>} />
-                                    <Route path='*' element={<Welcome/>} />
+                                    <Route path='*' element={<Welcome items={navConfig} />} />
                                 </Routes>
                             </Suspense>
                         </Container>

--- a/webui/src/pages/admin-dashboard/admin-header.tsx
+++ b/webui/src/pages/admin-dashboard/admin-header.tsx
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+import { FunctionComponent } from 'react';
+import { AppBar, Breadcrumbs, IconButton, Link, Toolbar, Typography } from '@mui/material';
+import HighlightOffIcon from '@mui/icons-material/HighlightOff';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
+
+export interface AdminHeaderProps {
+    routeNames: Record<string, string>;
+    onClose: () => void;
+}
+
+const BreadcrumbsNav: FunctionComponent<{ routeNames: Record<string, string> }> = ({ routeNames }) => {
+    const { pathname } = useLocation();
+    const segments = pathname.split('/').filter(Boolean);
+
+    return (
+        <Breadcrumbs aria-label='breadcrumb' sx={{ pt: 2, pb: 2, px: 4 }}>
+            <Link component={RouterLink} to='/' underline='hover' color='inherit'>
+                Home
+            </Link>
+            {segments.map((value, index) => {
+                const to = `/${segments.slice(0, index + 1).join('/')}`;
+                const label = routeNames[to] ?? value;
+                const isLast = index === segments.length - 1;
+
+                return isLast ? (
+                    <Typography color='text.primary' key={to}>{label}</Typography>
+                ) : (
+                    <Link component={RouterLink} to={to} underline='hover' color='inherit' key={to}>
+                        {label}
+                    </Link>
+                );
+            })}
+        </Breadcrumbs>
+    );
+};
+
+export const AdminHeader: FunctionComponent<AdminHeaderProps> = ({ routeNames, onClose }) => (
+    <AppBar position='sticky' color='default' enableColorOnDark elevation={0}>
+        <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
+            <BreadcrumbsNav routeNames={routeNames} />
+            <IconButton onClick={onClose} aria-label='close admin dashboard' sx={{ mt: 1, mr: 1 }}>
+                <HighlightOffIcon />
+            </IconButton>
+        </Toolbar>
+    </AppBar>
+);

--- a/webui/src/pages/admin-dashboard/admin-header.tsx
+++ b/webui/src/pages/admin-dashboard/admin-header.tsx
@@ -1,12 +1,15 @@
-/********************************************************************************
- * Copyright (c) 2020 TypeFox and others
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
- ********************************************************************************/
+ *****************************************************************************/
 
 import { FunctionComponent } from 'react';
 import { AppBar, Breadcrumbs, IconButton, Link, Toolbar, Typography } from '@mui/material';

--- a/webui/src/pages/admin-dashboard/admin-sidepanel.tsx
+++ b/webui/src/pages/admin-dashboard/admin-sidepanel.tsx
@@ -1,12 +1,15 @@
-/********************************************************************************
- * Copyright (c) 2020 TypeFox and others
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
- ********************************************************************************/
+ *****************************************************************************/
 
 import { FunctionComponent } from 'react';
 import { useLocation } from 'react-router-dom';
@@ -20,7 +23,7 @@ export interface AdminSidepanelProps {
 }
 
 export const AdminSidepanel: FunctionComponent<AdminSidepanelProps> = ({ items }) => {
-    const [open, setOpen] = useLocalStorage('admin-sidepanel-open', true);
+    const [open, setOpen] = useLocalStorage('openvsx-admin-sidepanel-open', true);
     const { pathname } = useLocation();
 
     return (

--- a/webui/src/pages/admin-dashboard/admin-sidepanel.tsx
+++ b/webui/src/pages/admin-dashboard/admin-sidepanel.tsx
@@ -8,22 +8,19 @@
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
 
-import { FunctionComponent, useState } from 'react';
+import { FunctionComponent } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Sidepanel } from '../../components/sidepanel/sidepanel';
 import { NavigationItem } from '../../components/sidepanel/navigation-item';
 import { isNavGroup, NavEntry } from './nav-types';
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
+import { useLocalStorage } from '../../hooks/use-local-storage';
 
 export interface AdminSidepanelProps {
     items: NavEntry[];
 }
 
 export const AdminSidepanel: FunctionComponent<AdminSidepanelProps> = ({ items }) => {
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useLocalStorage('admin-sidepanel-open', true);
     const { pathname } = useLocation();
 
     return (

--- a/webui/src/pages/admin-dashboard/admin-sidepanel.tsx
+++ b/webui/src/pages/admin-dashboard/admin-sidepanel.tsx
@@ -1,0 +1,59 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+import { FunctionComponent, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { Sidepanel } from '../../components/sidepanel/sidepanel';
+import { NavigationItem } from '../../components/sidepanel/navigation-item';
+import { isNavGroup, NavEntry } from './nav-types';
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface AdminSidepanelProps {
+    items: NavEntry[];
+}
+
+export const AdminSidepanel: FunctionComponent<AdminSidepanelProps> = ({ items }) => {
+    const [open, setOpen] = useState(true);
+    const { pathname } = useLocation();
+
+    return (
+        <Sidepanel open={open} onToggle={() => setOpen(prev => !prev)}>
+            {items.map((entry) => {
+                if (isNavGroup(entry)) {
+                    return (
+                        <NavigationItem key={entry.name} label={entry.name} icon={entry.icon}>
+                            {entry.children.map((child) => (
+                                <NavigationItem
+                                    key={child.path}
+                                    active={pathname.startsWith(child.path)}
+                                    label={child.name}
+                                    icon={child.icon}
+                                    route={child.path}
+                                />
+                            ))}
+                        </NavigationItem>
+                    );
+                }
+                return (
+                    <NavigationItem
+                        key={entry.path}
+                        active={pathname.startsWith(entry.path)}
+                        label={entry.name}
+                        icon={entry.icon}
+                        route={entry.path}
+                    />
+                );
+            })}
+        </Sidepanel>
+    );
+};

--- a/webui/src/pages/admin-dashboard/nav-types.ts
+++ b/webui/src/pages/admin-dashboard/nav-types.ts
@@ -14,6 +14,7 @@ export interface RouteEntry {
     path: string;
     name: string;
     icon: ReactNode;
+    description?: string;
 }
 
 export interface NavGroup {

--- a/webui/src/pages/admin-dashboard/nav-types.ts
+++ b/webui/src/pages/admin-dashboard/nav-types.ts
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2020 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+import { ReactNode } from 'react';
+
+export interface RouteEntry {
+    path: string;
+    name: string;
+    icon: ReactNode;
+}
+
+export interface NavGroup {
+    name: string;
+    icon: ReactNode;
+    children: RouteEntry[];
+}
+
+export type NavEntry = RouteEntry | NavGroup;
+
+export const isNavGroup = (entry: NavEntry): entry is NavGroup => 'children' in entry;

--- a/webui/src/pages/admin-dashboard/nav-types.ts
+++ b/webui/src/pages/admin-dashboard/nav-types.ts
@@ -1,12 +1,15 @@
-/********************************************************************************
- * Copyright (c) 2020 TypeFox and others
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
- ********************************************************************************/
+ *****************************************************************************/
 
 import { ReactNode } from 'react';
 

--- a/webui/src/pages/admin-dashboard/scan-admin.tsx
+++ b/webui/src/pages/admin-dashboard/scan-admin.tsx
@@ -45,14 +45,11 @@ const ScanAdminContent: FunctionComponent = () => {
 
     return (
         <Box sx={{
-            width: 'min(1500px, 100vw - 280px)',
-            maxWidth: 'none',
+            width: '100%',
+            maxWidth: 1500,
             mx: 'auto',
             px: 2,
             pb: 3,
-            position: 'relative',
-            left: '50%',
-            transform: 'translateX(-50%)',
         }}>
             <Typography variant='h5' gutterBottom sx={{ mb: 2 }}>
                 Extension Scans

--- a/webui/src/pages/admin-dashboard/welcome.tsx
+++ b/webui/src/pages/admin-dashboard/welcome.tsx
@@ -9,54 +9,86 @@
  ********************************************************************************/
 
 import { FunctionComponent } from 'react';
-import { Typography, Grid, Paper } from '@mui/material';
-import { styled, Theme } from '@mui/material/styles';
-import { Link } from 'react-router-dom';
-import { AdminDashboardRoutes } from './admin-dashboard-routes';
+import { Box, Card, CardActionArea, CardContent, Divider, Grid, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { isNavGroup, NavEntry, RouteEntry } from './nav-types';
 
-export const Welcome: FunctionComponent = props => {
-    return <Grid container direction='column' spacing={2} sx={{ height: '100%' }}>
-        <Grid item container direction='column' alignItems='center' justifyContent='flex-end'>
-            <Paper elevation={3} sx={{ p: 4 }}>
-                <Typography sx={{ mb: 2 }} align='center' variant='h5'>Welcome to the Admin Dashboard!</Typography>
-                <Typography align='center'>You can switch pages in the sidepanel menu on the left side.</Typography>
-                <Typography align='center'>
-                    Choose between administration for
-                </Typography>
-                <Grid container justifyContent='center' alignItems='center' sx={{ mt: 2 }}>
-                    <WelcomeLinkItem route={AdminDashboardRoutes.NAMESPACE_ADMIN} label='Namespaces' description='Manage user roles, create new namespaces' />
-                    <WelcomeLinkItem route={AdminDashboardRoutes.EXTENSION_ADMIN} label='Extensions' description='Search for extensions and remove certain versions' />
-                    <WelcomeLinkItem route={AdminDashboardRoutes.PUBLISHER_ADMIN} label='Publishers' description='Search for publishers and revoke their contributions' />
-                    <WelcomeLinkItem route={AdminDashboardRoutes.SCANS_ADMIN} label='Scans' description='View security scan results and manage quarantined extensions' />
-                    <WelcomeLinkItem route={AdminDashboardRoutes.TIERS} label='Tiers' description='Manage rate-limit tiers' />
-                    <WelcomeLinkItem route={AdminDashboardRoutes.CUSTOMERS} label='Customers' description='Manage rate-limit customers' />
-                    <WelcomeLinkItem route={AdminDashboardRoutes.USAGE_STATS} label='Usage Stats' description='Show usage stats for customers' />
-                    <WelcomeLinkItem route={AdminDashboardRoutes.LOGS} label='Logs' description='Browse admin logs' />
-                </Grid>
-            </Paper>
-        </Grid>
-    </Grid>;
+interface NavSection {
+    groupName?: string;
+    entries: RouteEntry[];
+}
+
+/** Preserve the original group structure: ungrouped items come first as a section without a title. */
+function buildSections(items: NavEntry[]): NavSection[] {
+    const ungrouped: RouteEntry[] = items.filter((e): e is RouteEntry => !isNavGroup(e));
+    const groups: NavSection[] = items
+        .filter(isNavGroup)
+        .map(group => ({ groupName: group.name, entries: group.children }));
+
+    return ungrouped.length > 0 ? [{ entries: ungrouped }, ...groups] : groups;
+}
+
+const NavCard: FunctionComponent<{ entry: RouteEntry }> = ({ entry }) => {
+    const navigate = useNavigate();
+    return (
+        <Card variant='outlined' sx={{ height: '100%' }}>
+            <CardActionArea
+                onClick={() => navigate(entry.path)}
+                sx={{ height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', py: 3, px: 2 }}
+            >
+                <Box sx={{ fontSize: 40, color: 'primary.main', mb: 1, display: 'flex' }}>
+                    {entry.icon}
+                </Box>
+                <CardContent sx={{ textAlign: 'center', p: 1 }}>
+                    <Typography variant='h6' gutterBottom>{entry.name}</Typography>
+                    {entry.description && (
+                        <Typography variant='body2' color='text.secondary'>
+                            {entry.description}
+                        </Typography>
+                    )}
+                </CardContent>
+            </CardActionArea>
+        </Card>
+    );
 };
 
-const StyledLink = styled(Link)(({ theme }: { theme: Theme }) => ({
-    color: theme.palette.secondary.main,
-    textDecoration: 'none',
-    '&:hover': {
-        textDecoration: 'underline'
-    }
-}));
+export interface WelcomeProps {
+    items: NavEntry[];
+}
 
-const WelcomeLinkItem: FunctionComponent<{ route: string, label: string, description: string }> = props => {
-    return <Grid container item xs={8} sx={{ mb: 2 }}>
-        <Grid container alignItems='center' item xs={12} md={4}>
-            <Typography>
-                <StyledLink to={props.route}>
-                    {props.label}
-                </StyledLink>
+export const Welcome: FunctionComponent<WelcomeProps> = ({ items }) => {
+    const sections = buildSections(items);
+
+    return (
+        <Box sx={{ py: 4, px: 2 }}>
+            <Typography variant='h5' gutterBottom>
+                Welcome to the Admin Dashboard
             </Typography>
-        </Grid>
-        <Grid item xs={12} md={8}>
-            <Typography variant='body1' style={{ lineHeight: 1.5 }}>{props.description}</Typography>
-        </Grid>
-    </Grid>;
+            <Typography variant='body1' color='text.secondary' sx={{ mb: 4 }}>
+                Select a section below to get started
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+                {sections.map((section, i) => (
+                    <Box key={section.groupName ?? '__root__'}>
+                        {section.groupName && (
+                            <>
+                                <Typography variant='overline' color='text.secondary' sx={{ mb: 1, display: 'block' }}>
+                                    {section.groupName}
+                                </Typography>
+                                <Divider sx={{ mb: 2 }} />
+                            </>
+                        )}
+                        {!section.groupName && i > 0 && <Divider sx={{ mb: 2 }} />}
+                        <Grid container spacing={3}>
+                            {section.entries.map(entry => (
+                                <Grid item key={entry.path} xs={12} sm={6} md={4} lg={3}>
+                                    <NavCard entry={entry} />
+                                </Grid>
+                            ))}
+                        </Grid>
+                    </Box>
+                ))}
+            </Box>
+        </Box>
+    );
 };


### PR DESCRIPTION
This PR is updating the collapsible sidepanel implementation, making it not fully hidden when collapsed, like in the home assistant UI.

The open state is persisted in the local storage, plus it's handled in real-time, meaning that any update in other tabs to the open state value will be reflected in all tabs at the same time.

I'm also cleaning up a bit the admin-dashboard component.

Assisted-By: anthropic:claude-sonnet-4-6