### PR TITLE
Feat: add config to permit additional routes

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/security/SecurityConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/security/SecurityConfig.java
@@ -30,6 +30,9 @@ public class SecurityConfig {
     @Value("${ovsx.webui.frontendRoutes:/extension/**,/namespace/**,/user-settings/**,/admin-dashboard/**}")
     String[] frontendRoutes;
 
+    @Value("${ovsx.webui.additional-routes:}")
+    String[] additionalRoutes;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, OAuth2UserServices userServices) throws Exception {
         var filterChain = http.authorizeHttpRequests(
@@ -43,6 +46,8 @@ public class SecurityConfig {
                         .requestMatchers(pathMatchers("/admin/**"))
                             .hasAuthority("ROLE_ADMIN")
                         .requestMatchers(pathMatchers(frontendRoutes))
+                            .permitAll()
+                        .requestMatchers(pathMatchers(additionalRoutes))
                             .permitAll()
                         .anyRequest()
                             .authenticated()


### PR DESCRIPTION
This is needed to support routes like `/.well-known/security.txt` to be served as static content.

Right now this will be rejected with a `403` error as the security config only permits certain routes from being served. The existing config option `frontendRoutes` can also not be used but that will be redirected to `/index.html` which we dont want in such a case.