### PR TITLE
Add scanner deep links and summary extraction to scan admin dashboard

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/admin/ScanAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/admin/ScanAPI.java
@@ -20,6 +20,8 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.eclipse.openvsx.entities.*;
 import org.eclipse.openvsx.json.*;
 import org.eclipse.openvsx.repositories.RepositoryService;
@@ -61,19 +63,25 @@ public class ScanAPI {
     private final LogService logs;
     private final StorageUtilService storageUtil;
     private final org.eclipse.openvsx.scanning.ExtensionScanCompletionService completionService;
+    private final org.eclipse.openvsx.scanning.ScannerRegistry scannerRegistry;
+    private final org.eclipse.openvsx.repositories.ScannerJobRepository scanJobRepository;
 
     public ScanAPI(
             RepositoryService repositories,
             AdminService admins,
             LogService logs,
             StorageUtilService storageUtil,
-            org.eclipse.openvsx.scanning.ExtensionScanCompletionService completionService
+            org.eclipse.openvsx.scanning.ExtensionScanCompletionService completionService,
+            org.eclipse.openvsx.scanning.ScannerRegistry scannerRegistry,
+            org.eclipse.openvsx.repositories.ScannerJobRepository scanJobRepository
     ) {
         this.repositories = repositories;
         this.admins = admins;
         this.logs = logs;
         this.storageUtil = storageUtil;
         this.completionService = completionService;
+        this.scannerRegistry = scannerRegistry;
+        this.scanJobRepository = scanJobRepository;
     }
 
     /**
@@ -871,7 +879,34 @@ public class ScanAPI {
         json.setSummary(checkResult.getSummary());
         json.setErrorMessage(checkResult.getErrorMessage());
         json.setRequired(checkResult.getRequired());
+        json.setExternalUrl(buildExternalScannerUrl(checkResult));
+
         return json;
+    }
+
+    /**
+     * Look up the ScannerJob for a SCANNER_JOB check result and ask its scanner
+     * to build a dashboard URL. Returns null for publish checks, jobs without an
+     * external id, or scanners that don't configure a url template.
+     */
+    @Nullable
+    private String buildExternalScannerUrl(@Nonnull ScanCheckResult checkResult) {
+        if (checkResult.getCategory() != ScanCheckResult.CheckCategory.SCANNER_JOB) {
+            return null;
+        }
+        Long jobId = checkResult.getScannerJobId();
+        if (jobId == null) {
+            return null;
+        }
+        var job = scanJobRepository.findById(jobId).orElse(null);
+        if (job == null || job.getExternalJobId() == null) {
+            return null;
+        }
+        var scanner = scannerRegistry.getScanner(job.getScannerType());
+        if (scanner == null) {
+            return null;
+        }
+        return scanner.buildExternalUrl(job.getExternalJobId());
     }
 
     /**

--- a/server/src/main/java/org/eclipse/openvsx/json/CheckResultJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/CheckResultJson.java
@@ -15,6 +15,7 @@ package org.eclipse.openvsx.json;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 
 /**
  * JSON representation of a scan check execution result.
@@ -59,6 +60,11 @@ public class CheckResultJson {
 
     @Schema(description = "Whether this check was required (errors block publishing). Null for scanner jobs.")
     private Boolean required;
+
+    @Schema(description = "Deep link to the external scanner's own dashboard for this job. " +
+        "Only populated for SCANNER_JOB rows whose scanner configures external-url-template.")
+    @Nullable
+    private String externalUrl;
 
     // Getters and setters
 
@@ -148,5 +154,14 @@ public class CheckResultJson {
 
     public void setRequired(Boolean required) {
         this.required = required;
+    }
+
+    @Nullable
+    public String getExternalUrl() {
+        return externalUrl;
+    }
+
+    public void setExternalUrl(@Nullable String externalUrl) {
+        this.externalUrl = externalUrl;
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/scanning/ExtensionScanPersistenceService.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/ExtensionScanPersistenceService.java
@@ -417,6 +417,12 @@ public class ExtensionScanPersistenceService {
                 summary = String.format("Found %d threat(s) - not enforced", threatCount);
             }
         }
+
+        // If the scanner provided its own human-readable summary, prefer it
+        // over our auto-generated text.
+        if (result.getSummary() != null && !result.getSummary().isBlank()) {
+            summary = result.getSummary();
+        }
         
         // Record scanner job result for audit trail
         recordScannerJobResult(

--- a/server/src/main/java/org/eclipse/openvsx/scanning/RemoteScanner.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/RemoteScanner.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -92,6 +93,21 @@ public class RemoteScanner implements Scanner {
     @Override
     public RemoteScannerProperties.PollConfig getPollConfig() {
         return config.getPolling();
+    }
+
+    /**
+     * Build a dashboard URL for a scanner job by substituting {jobId} in the
+     * configured external-url-template. Returns null if no template is
+     * configured or externalJobId is null.
+     */
+    @Override
+    @Nullable
+    public String buildExternalUrl(@Nullable String externalJobId) {
+        String template = config.getExternalUrlTemplate();
+        if (template == null || externalJobId == null) {
+            return null;
+        }
+        return template.replace("{jobId}", externalJobId);
     }
     
     /**
@@ -376,11 +392,20 @@ public class RemoteScanner implements Scanner {
             }
         }
         
+        String summary = null;
+        if (responseConfig.getSummaryPath() != null) {
+            summary = responseExtractor.extractString(
+                response,
+                responseConfig.getFormat(),
+                responseConfig.getSummaryPath()
+            );
+        }
+
         // Extract threats
         String threatsPath = responseConfig.getThreatsPath();
         if (threatsPath == null) {
             // No threats path - assume clean
-            return Scanner.Result.clean();
+            return Scanner.Result.clean(summary);
         }
         
         List<Map<String, Object>> threatObjects = responseExtractor.extractList(
@@ -393,9 +418,9 @@ public class RemoteScanner implements Scanner {
         List<Scanner.Threat> threats = mapThreats(threatObjects, responseConfig);
         
         if (threats.isEmpty()) {
-            return Scanner.Result.clean();
+            return Scanner.Result.clean(summary);
         } else {
-            return Scanner.Result.withThreats(threats);
+            return Scanner.Result.withThreats(threats, summary);
         }
     }
     

--- a/server/src/main/java/org/eclipse/openvsx/scanning/RemoteScannerProperties.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/RemoteScannerProperties.java
@@ -12,6 +12,7 @@
  ********************************************************************************/
 package org.eclipse.openvsx.scanning;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -188,6 +189,19 @@ public class RemoteScannerProperties {
          */
         @Valid
         private PollConfig polling = new PollConfig();
+
+        /**
+         * Optional template for a user-facing URL pointing at the scanner's own
+         * dashboard for this scan. Supports the {jobId} placeholder which is
+         * replaced with the scanner's externalJobId.
+         *
+         * Example: "https://app.example.com/scans/{jobId}"
+         *
+         * When set, the scan admin dashboard renders a "View in <scanner>" link
+         * for each scanner job that has a known externalJobId.
+         */
+        @Nullable
+        private String externalUrlTemplate;
         
         // Operation configurations
         @NotNull(message = "Start operation must be configured")
@@ -233,6 +247,10 @@ public class RemoteScannerProperties {
         
         public PollConfig getPolling() { return polling; }
         public void setPolling(PollConfig polling) { this.polling = polling; }
+
+        @Nullable
+        public String getExternalUrlTemplate() { return externalUrlTemplate; }
+        public void setExternalUrlTemplate(@Nullable String externalUrlTemplate) { this.externalUrlTemplate = externalUrlTemplate; }
         
         public HttpOperation getStart() { return start; }
         public void setStart(HttpOperation start) { this.start = start; }
@@ -346,6 +364,10 @@ public class RemoteScannerProperties {
         // For extracting threats (result operation)
         private String threatsPath;  // JSONPath to array of threats
         private ThreatMapping threatMapping;
+
+        // For extracting a scanner-provided summary string (result operation).
+        // Surfaced verbatim in ScanCheckResult.summary when present
+        private String summaryPath;
         
         // For error detection
         private String errorPath;  // Path to error message
@@ -369,7 +391,10 @@ public class RemoteScannerProperties {
         
         public ThreatMapping getThreatMapping() { return threatMapping; }
         public void setThreatMapping(ThreatMapping threatMapping) { this.threatMapping = threatMapping; }
-        
+
+        public String getSummaryPath() { return summaryPath; }
+        public void setSummaryPath(String summaryPath) { this.summaryPath = summaryPath; }
+
         public String getErrorPath() { return errorPath; }
         public void setErrorPath(String errorPath) { this.errorPath = errorPath; }
         

--- a/server/src/main/java/org/eclipse/openvsx/scanning/Scanner.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/Scanner.java
@@ -68,20 +68,32 @@ public interface Scanner {
     class Result {
         private final boolean clean;
         private final List<Threat> threats;
-        
-        private Result(boolean clean, List<Threat> threats) {
+        private final String summary;
+
+        private Result(boolean clean, List<Threat> threats, String summary) {
             this.clean = clean;
             this.threats = new ArrayList<>(threats);
+            this.summary = summary;
         }
         
         @Nonnull
         public static Result clean() {
-            return new Result(true, Collections.emptyList());
+            return new Result(true, Collections.emptyList(), null);
         }
-        
+
+        @Nonnull
+        public static Result clean(@Nullable String summary) {
+            return new Result(true, Collections.emptyList(), summary);
+        }
+
         @Nonnull
         public static Result withThreats(@Nonnull List<Threat> threats) {
-            return new Result(false, threats);
+            return new Result(false, threats, null);
+        }
+
+        @Nonnull
+        public static Result withThreats(@Nonnull List<Threat> threats, @Nullable String summary) {
+            return new Result(false, threats, summary);
         }
         
         public boolean isClean() {
@@ -91,6 +103,12 @@ public interface Scanner {
         @Nonnull
         public List<Threat> getThreats() {
             return Collections.unmodifiableList(threats);
+        }
+
+        /** Scanner-provided summary text, or null if not supplied. */
+        @Nullable
+        public String getSummary() {
+            return summary;
         }
     }
     
@@ -181,6 +199,20 @@ public interface Scanner {
      * which promotes QUEUED jobs in FIFO order.
      */
     default int getMaxConcurrency() { return -1; }
+
+    /**
+     * Build a user-facing URL pointing at the scanner's own dashboard for a
+     * given external job id. Used by the admin UI to deep-link from a scan
+     * check result to the scanner service's UI for debugging / detail.
+     * <p>
+     * Default returns null — scanners that don't have an external UI
+     * (internal checks, self-hosted services without a web UI) simply don't
+     * contribute a link.
+     */
+    @Nullable
+    default String buildExternalUrl(@Nullable String externalJobId) {
+        return null;
+    }
 
     /**
      * Maximum time (minutes) a concurrency-limited job may wait in QUEUED status

--- a/server/src/main/java/org/eclipse/openvsx/scanning/ScannerException.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/ScannerException.java
@@ -20,11 +20,11 @@ import jakarta.annotation.Nullable;
  * Exception thrown when a scan operation fails.
  */
 public class ScannerException extends Exception {
-    
+
     public ScannerException(@Nonnull String message) {
         super(message);
     }
-    
+
     public ScannerException(@Nonnull String message, @Nullable Throwable cause) {
         super(message, cause);
     }

--- a/server/src/test/java/org/eclipse/openvsx/admin/ScanAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/admin/ScanAPITest.java
@@ -67,6 +67,12 @@ class ScanAPITest {
     @MockitoBean
     org.eclipse.openvsx.scanning.ExtensionScanCompletionService completionService;
 
+    @MockitoBean
+    org.eclipse.openvsx.scanning.ScannerRegistry scannerRegistry;
+
+    @MockitoBean
+    org.eclipse.openvsx.repositories.ScannerJobRepository scanJobRepository;
+
     @Test
     void getScans_filters_sorting_and_pagination_are_applied() throws Exception {
         // Always allow the request to pass the admin gate in this test setup.

--- a/server/src/test/java/org/eclipse/openvsx/scanning/RemoteScannerPropertiesTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/scanning/RemoteScannerPropertiesTest.java
@@ -57,6 +57,23 @@ class RemoteScannerPropertiesTest {
         assertFalse(config.isAsync());
     }
 
+    @Test
+    void scannerConfig_externalUrlTemplateDefaultsToNull() {
+        // Scanners without an external dashboard should not contribute a deep
+        // link. The absence of a template is the signal for that.
+        var config = new RemoteScannerProperties.ScannerConfig();
+
+        assertNull(config.getExternalUrlTemplate());
+    }
+
+    @Test
+    void scannerConfig_externalUrlTemplateSetterWorks() {
+        var config = new RemoteScannerProperties.ScannerConfig();
+        config.setExternalUrlTemplate("https://app.example.com/scans/{jobId}");
+
+        assertEquals("https://app.example.com/scans/{jobId}", config.getExternalUrlTemplate());
+    }
+
     // === HttpOperation defaults ===
 
     @Test
@@ -127,6 +144,7 @@ class RemoteScannerPropertiesTest {
         response.setThreatsPath("$.threats[*]");
         response.setErrorPath("$.error");
         response.setErrorCondition("$.status == 'error'");
+        response.setSummaryPath("$.verdictData.summary");
 
         assertEquals("xml", response.getFormat());
         assertEquals("$.scan.id", response.getJobIdPath());
@@ -135,6 +153,7 @@ class RemoteScannerPropertiesTest {
         assertEquals("$.threats[*]", response.getThreatsPath());
         assertEquals("$.error", response.getErrorPath());
         assertEquals("$.status == 'error'", response.getErrorCondition());
+        assertEquals("$.verdictData.summary", response.getSummaryPath());
     }
 
     // === ThreatMapping tests ===

--- a/server/src/test/java/org/eclipse/openvsx/scanning/ScannerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/scanning/ScannerTest.java
@@ -92,6 +92,48 @@ class ScannerTest {
                 result.getThreats().clear());
     }
 
+    @Test
+    void result_cleanWithoutSummaryReturnsNullSummary() {
+        var result = Scanner.Result.clean();
+
+        assertNull(result.getSummary());
+    }
+
+    @Test
+    void result_cleanWithSummaryStoresIt() {
+        var result = Scanner.Result.clean("Extension looks benign.");
+
+        assertTrue(result.isClean());
+        assertEquals("Extension looks benign.", result.getSummary());
+    }
+
+    @Test
+    void result_withThreatsAndSummaryStoresBoth() {
+        var threat = new Scanner.Threat("malware", "found", "HIGH");
+        var result = Scanner.Result.withThreats(List.of(threat), "Verdict: malicious");
+
+        assertFalse(result.isClean());
+        assertEquals(1, result.getThreats().size());
+        assertEquals("Verdict: malicious", result.getSummary());
+    }
+
+    // === Scanner default methods ===
+
+    @Test
+    void scanner_buildExternalUrlDefaultsToNull() {
+        // The default is used by scanners that have no external UI (internal
+        // checks, self-hosted services without a dashboard). They simply don't
+        // contribute a "View in scanner" deep link.
+        Scanner scanner = new Scanner() {
+            @Override public @jakarta.annotation.Nonnull String getScannerType() { return "TEST"; }
+            @Override public boolean isAsync() { return false; }
+            @Override public @jakarta.annotation.Nonnull Scanner.Invocation startScan(@jakarta.annotation.Nonnull Command command) { throw new UnsupportedOperationException(); }
+        };
+
+        assertNull(scanner.buildExternalUrl("any-job-id"));
+        assertNull(scanner.buildExternalUrl(null));
+    }
+
     // === Threat class tests ===
 
     @Test

--- a/webui/src/components/scan-admin/scan-card/scan-card-expanded-content.tsx
+++ b/webui/src/components/scan-admin/scan-card/scan-card-expanded-content.tsx
@@ -12,7 +12,8 @@
  ********************************************************************************/
 
 import { FC } from 'react';
-import { Box, Typography, Collapse, Chip } from '@mui/material';
+import { Box, Typography, Collapse, Chip, Link } from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { useTheme, Theme } from '@mui/material/styles';
 import { ScanResult, Threat, ValidationFailure, CheckResult } from '../../../context/scan-admin';
 import { ScanDetailCard } from './scan-detail-card';
@@ -127,17 +128,22 @@ const CheckResultItem: FC<CheckResultItemProps> = ({ checkResult }) => {
     // Non-required errors get striped styling to indicate they didn't block publishing
     const isOptionalError = isError && checkResult.required === false;
 
+    // Scanner rows often carry long verdict text while publish checks just show
+    // short statuses like "No issues found"
+    const isScannerJob = checkResult.category === 'SCANNER_JOB';
+    const showSummaryInMiddle = isScannerJob && !!checkResult.summary;
+
     return (
         <Box sx={{
             display: 'flex',
             alignItems: 'center',
-            justifyContent: 'space-between',
+            gap: 2,
             p: 1.5,
             borderRadius: 1,
             bgcolor: isPassed ? 'action.hover' : 'transparent',
             border: isPassed ? 'none' : `1px solid ${theme.palette.divider}`,
         }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexShrink: 0 }}>
                 <Chip
                     label={checkResult.result}
                     size='small'
@@ -162,11 +168,50 @@ const CheckResultItem: FC<CheckResultItemProps> = ({ checkResult }) => {
                     sx={{ fontSize: '0.65rem', height: 18 }}
                 />
             </Box>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, color: 'text.secondary' }}>
-                {checkResult.summary && (
+            {showSummaryInMiddle && (
+                <Typography
+                    variant='caption'
+                    sx={{
+                        flex: 1,
+                        minWidth: 0,
+                        lineHeight: 1.5,
+                        color: 'text.secondary',
+                    }}
+                >
+                    {checkResult.summary}
+                </Typography>
+            )}
+            <Box sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 2,
+                ml: 'auto',
+                color: 'text.secondary',
+                flexShrink: 0,
+            }}>
+                {!showSummaryInMiddle && checkResult.summary && (
                     <Typography variant='caption'>
                         {checkResult.summary}
                     </Typography>
+                )}
+                {checkResult.externalUrl && (
+                    <Link
+                        href={checkResult.externalUrl}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        onClick={(e) => e.stopPropagation()}
+                        sx={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            gap: 0.25,
+                            fontSize: '0.7rem',
+                            fontWeight: 500,
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        View in scanner
+                        <OpenInNewIcon sx={{ fontSize: '0.85rem' }} />
+                    </Link>
                 )}
                 {checkResult.durationMs !== null && (
                     <Typography variant='caption' sx={{ minWidth: 50, textAlign: 'right' }}>

--- a/webui/src/context/scan-admin/scan-api-effects.ts
+++ b/webui/src/context/scan-admin/scan-api-effects.ts
@@ -211,6 +211,7 @@ export const useScansEffect = (
                             summary: result.summary || null,
                             errorMessage: result.errorMessage || null,
                             required: result.required ?? null,
+                            externalUrl: result.externalUrl || null,
                         })),
                         extensionIcon: scan.extensionIcon,
                         downloadUrl: scan.downloadUrl || null,

--- a/webui/src/context/scan-admin/scan-types.ts
+++ b/webui/src/context/scan-admin/scan-types.ts
@@ -58,6 +58,8 @@ export interface CheckResult {
     errorMessage: string | null;
     /** Whether this check was required (errors block publishing). Null for scanner jobs. */
     required: boolean | null;
+    /** Deep link to the external scanner's dashboard for this job. Null if not applicable. */
+    externalUrl: string | null;
 }
 
 export interface ScanResult {


### PR DESCRIPTION
Adds a link from each scan job to the scanner’s own dashboard, so admins can jump straight from our UI to the external view of that same job. It’s set per scanner using an external-url-template in YAML (with a {jobId} placeholder). If there’s no template or no externalJobId nothing shows up.

Also lets scanners provide their own human-readable summary via a new response.summary-path config. When that’s present, it replaces the default “No threats found” / “Found N threats” text in the audit log.