### PR TITLE
Fix: latest version cache deserialization

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
@@ -284,7 +284,7 @@ public class LocalVSCodeService implements IVSCodeService {
     @Cacheable(value = CacheService.CACHE_LATEST_EXTENSION_VERSION_VSCODE)
     public ExtensionQueryResult.Extension latest(String namespaceName, String extensionName) {
         if (BuiltInExtensionUtil.isBuiltIn(namespaceName)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, builtinExtensionMessage());
+            throw new NotFoundException();
         }
 
         var extension = repositories.findActiveExtension(extensionName, namespaceName);

--- a/server/src/main/java/org/eclipse/openvsx/cache/CacheConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/cache/CacheConfig.java
@@ -264,7 +264,13 @@ public class CacheConfig {
                 )
                 .withCacheConfiguration(
                         CACHE_LATEST_EXTENSION_VERSIONS_BY_PLATFORM,
-                        redisCacheConfig(new Jackson2JsonRedisSerializer<>(extensionVersionMapper, List.class), latestExtensionVersionsByPlatformTtl)
+                        redisCacheConfig(
+                                new Jackson2JsonRedisSerializer<>(
+                                        extensionVersionMapper,
+                                        extensionVersionMapper.getTypeFactory().constructParametricType(List.class, ExtensionVersion.class)
+                                ),
+                                latestExtensionVersionsByPlatformTtl
+                        )
                 )
                 .withCacheConfiguration(
                         CACHE_SITEMAP,

--- a/server/src/main/java/org/eclipse/openvsx/cache/LatestExtensionVersionsByPlatformCacheKeyGenerator.java
+++ b/server/src/main/java/org/eclipse/openvsx/cache/LatestExtensionVersionsByPlatformCacheKeyGenerator.java
@@ -41,6 +41,6 @@ public class LatestExtensionVersionsByPlatformCacheKeyGenerator implements KeyGe
     public String generate(Extension extension, boolean preReleases) {
         var extensionName = extension.getName();
         var namespaceName = extension.getNamespace().getName();
-        return NamingUtil.toFileFormat(namespaceName, extensionName, null, VersionAlias.LATEST) + ",pre-releases=" + preReleases;
+        return NamingUtil.toFileFormat(namespaceName, extensionName, VersionAlias.LATEST) + ",pre-releases=" + preReleases;
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/util/NamingUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/NamingUtil.java
@@ -32,13 +32,17 @@ public class NamingUtil {
         return toFileFormat(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
     }
 
+    public static String toFileFormat(String namespace, String extension, String version) {
+        return toExtensionId(namespace, extension) + "-" + version;
+    }
+
     public static String toFileFormat(String namespace, String extension, String targetPlatform, String version, String suffix) {
         return toFileFormat(namespace, extension, targetPlatform, version) + suffix;
     }
 
     public static String toFileFormat(String namespace, String extension, String targetPlatform, String version) {
         var name = toExtensionId(namespace, extension) + "-" + version;
-        if (targetPlatform != null && !TargetPlatform.isUniversal(targetPlatform)) {
+        if (!TargetPlatform.isUniversal(targetPlatform)) {
             name += "@" + targetPlatform;
         }
 


### PR DESCRIPTION
This fixes various things:

- return 404 when trying to get the latest version for a builtin extension instead of 400
- fix regression in NamingUtil.toFileFormat when a targetPlatform with value `null` is provided
- fix deserialization of generic list for redis cache