### PR TITLE
Change(webui): remove max-width setting for admin dashboard

### DIFF
--- a/webui/CHANGELOG.md
+++ b/webui/CHANGELOG.md
@@ -4,6 +4,10 @@ This change log covers only the frontend library (webui) of Open VSX.
 
 ## [next] (unreleased)
 
+### Changed
+
+- Disabled max-width setting for admin dashboard pages to let content grow as needed
+
 ### Fixed
 
 - Fix admin dashboard breadcrumbs not being URL-decoded due to #1782 ([#1806](https://github.com/eclipse-openvsx/openvsx/pull/1806))

--- a/webui/CHANGELOG.md
+++ b/webui/CHANGELOG.md
@@ -6,7 +6,7 @@ This change log covers only the frontend library (webui) of Open VSX.
 
 ### Changed
 
-- Disabled max-width setting for admin dashboard pages to let content grow as needed
+- Disabled max-width setting for admin dashboard pages to let content grow as needed ([#1809](https://github.com/eclipse-openvsx/openvsx/pull/1809))
 
 ### Fixed
 

--- a/webui/src/pages/admin-dashboard/admin-dashboard.tsx
+++ b/webui/src/pages/admin-dashboard/admin-dashboard.tsx
@@ -122,7 +122,7 @@ export const AdminDashboard: FunctionComponent<AdminDashboardProps> = props => {
                 <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
                     <AdminHeader routeNames={routeNames} onClose={toMainPage} />
                     <ScrollableContent>
-                        <Container sx={{ pt: 3, pb: 4, px: 3 }} maxWidth='xl'>
+                        <Container sx={{ pt: 3, pb: 4, px: 3 }} maxWidth={false}>
                             <Suspense fallback={null}>
                                 <Routes>
                                     <Route path='/namespaces' element={<NamespaceAdmin/>} />

--- a/webui/src/pages/admin-dashboard/welcome.tsx
+++ b/webui/src/pages/admin-dashboard/welcome.tsx
@@ -60,34 +60,36 @@ export const Welcome: FunctionComponent<WelcomeProps> = ({ items }) => {
     const sections = buildSections(items);
 
     return (
-        <Box sx={{ py: 4, px: 2 }}>
-            <Typography variant='h5' gutterBottom>
-                Welcome to the Admin Dashboard
-            </Typography>
-            <Typography variant='body1' color='text.secondary' sx={{ mb: 4 }}>
-                Select a section below to get started
-            </Typography>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-                {sections.map((section, i) => (
-                    <Box key={section.groupName ?? '__root__'}>
-                        {section.groupName && (
-                            <>
-                                <Typography variant='overline' color='text.secondary' sx={{ mb: 1, display: 'block' }}>
-                                    {section.groupName}
-                                </Typography>
-                                <Divider sx={{ mb: 2 }} />
-                            </>
-                        )}
-                        {!section.groupName && i > 0 && <Divider sx={{ mb: 2 }} />}
-                        <Grid container spacing={3}>
-                            {section.entries.map(entry => (
-                                <Grid item key={entry.path} xs={12} sm={6} md={4} lg={3}>
-                                    <NavCard entry={entry} />
-                                </Grid>
-                            ))}
-                        </Grid>
-                    </Box>
-                ))}
+        <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+            <Box sx={{ py: 4, px: 2 }} maxWidth='xl'>
+                <Typography variant='h5' gutterBottom>
+                    Welcome to the Admin Dashboard
+                </Typography>
+                <Typography variant='body1' color='text.secondary' sx={{ mb: 4 }}>
+                    Select a section below to get started
+                </Typography>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+                    {sections.map((section, i) => (
+                        <Box key={section.groupName ?? '__root__'}>
+                            {section.groupName && (
+                                <>
+                                    <Typography variant='overline' color='text.secondary' sx={{ mb: 1, display: 'block' }}>
+                                        {section.groupName}
+                                    </Typography>
+                                    <Divider sx={{ mb: 2 }} />
+                                </>
+                            )}
+                            {!section.groupName && i > 0 && <Divider sx={{ mb: 2 }} />}
+                            <Grid container spacing={3}>
+                                {section.entries.map(entry => (
+                                    <Grid item key={entry.path} xs={12} sm={6} md={4} lg={3}>
+                                        <NavCard entry={entry} />
+                                    </Grid>
+                                ))}
+                            </Grid>
+                        </Box>
+                    ))}
+                </Box>
             </Box>
         </Box>
     );


### PR DESCRIPTION
This removes the max-width setting for content displayed in the admin dashboard to let content grow as needed.

This is mainly needed for the scan admin content, as this is wider than the maximum breakpoint.

Adjusted the welcome page for stylistic reasons.