### PR TITLE
Change: check authId when logging in via an oauth2 provider

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/UserAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/UserAPI.java
@@ -81,7 +81,7 @@ public class UserAPI {
     public ResponseEntity<LoginProvidersJson> login() {
         var json = new LoginProvidersJson();
         var providers = users.getLoginProviders();
-        if(!providers.isEmpty()) {
+        if (!providers.isEmpty()) {
             json.setLoginProviders(providers);
         } else {
             json.setSuccess("No login providers available.");

--- a/server/src/main/java/org/eclipse/openvsx/UserService.java
+++ b/server/src/main/java/org/eclipse/openvsx/UserService.java
@@ -30,6 +30,8 @@ import org.eclipse.openvsx.security.IdPrincipal;
 import org.eclipse.openvsx.security.OAuth2AttributesConfig;
 import org.eclipse.openvsx.storage.StorageUtilService;
 import org.eclipse.openvsx.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.security.authentication.AuthenticationServiceException;
@@ -48,6 +50,8 @@ import static org.eclipse.openvsx.cache.CacheService.CACHE_NAMESPACE_DETAILS_JSO
 
 @Component
 public class UserService {
+
+    private final Logger logger = LoggerFactory.getLogger(UserService.class);
 
     private final EntityManager entityManager;
     private final RepositoryService repositories;
@@ -76,7 +80,7 @@ public class UserService {
     }
 
     public UserData findLoggedInUser() {
-        if(!canLogin()) {
+        if (!canLogin()) {
             return null;
         }
 
@@ -168,22 +172,22 @@ public class UserService {
             throw new ErrorResultException(message);
         }
 
-        if(!Objects.equals(details.getDisplayName(), namespace.getDisplayName())) {
+        if (!Objects.equals(details.getDisplayName(), namespace.getDisplayName())) {
             namespace.setDisplayName(details.getDisplayName());
         }
-        if(!Objects.equals(details.getDescription(), namespace.getDescription())) {
+        if (!Objects.equals(details.getDescription(), namespace.getDescription())) {
             namespace.setDescription(details.getDescription());
         }
-        if(!Objects.equals(details.getWebsite(), namespace.getWebsite())) {
+        if (!Objects.equals(details.getWebsite(), namespace.getWebsite())) {
             namespace.setWebsite(details.getWebsite());
         }
-        if(!Objects.equals(details.getSupportLink(), namespace.getSupportLink())) {
+        if (!Objects.equals(details.getSupportLink(), namespace.getSupportLink())) {
             namespace.setSupportLink(details.getSupportLink());
         }
-        if(!Objects.equals(details.getSocialLinks(), namespace.getSocialLinks())) {
+        if (!Objects.equals(details.getSocialLinks(), namespace.getSocialLinks())) {
             namespace.setSocialLinks(details.getSocialLinks());
         }
-        if(StringUtils.isEmpty(details.getLogo()) && StringUtils.isNotEmpty(namespace.getLogoName())) {
+        if (StringUtils.isEmpty(details.getLogo()) && StringUtils.isNotEmpty(namespace.getLogoName())) {
             storageUtil.removeNamespaceLogo(namespace);
             namespace.setLogoName(null);
             namespace.setLogoStorageType(null);
@@ -212,7 +216,7 @@ public class UserService {
             var detectedType = tika.detect(file.getInputStream(), file.getOriginalFilename());
             var logoType = MimeTypes.getDefaultMimeTypes().getRegisteredMimeType(detectedType);
             var expectedLogoTypes = List.of(MediaType.image("png"), MediaType.image("jpg"));
-            if(logoType == null || !expectedLogoTypes.contains(logoType.getType())) {
+            if (logoType == null || !expectedLogoTypes.contains(logoType.getType())) {
                 throw new ErrorResultException("Namespace logo should be a png or jpg file");
             }
 
@@ -220,7 +224,7 @@ public class UserService {
             file.getInputStream().transferTo(out);
             logoFile.setNamespace(namespace);
             storageUtil.uploadNamespaceLogo(logoFile);
-            if(StringUtils.isNotEmpty(oldNamespace.getLogoName())) {
+            if (StringUtils.isNotEmpty(oldNamespace.getLogoName())) {
                 storageUtil.removeNamespaceLogo(oldNamespace);
             }
         } catch (IOException | MimeTypeException e) {
@@ -234,6 +238,15 @@ public class UserService {
         return !getLoginProviders().isEmpty();
     }
 
+    /**
+     * Creates or updates a user after a successful OAuth2 dance.
+     * <p>
+     * The provided user must have an {code authId} being set.
+     *
+     * @param newUser the user data as mapped from the provided oauth2 attributes
+     * @return a new persisted user object if no user with the same login is present, otherwise
+     * an updated user object with information from the oauth2 attributes
+     */
     @Transactional
     public UserData upsertUser(UserData newUser) {
         var userData = repositories.findUserByLoginName(newUser.getProvider(), newUser.getLoginName());
@@ -241,12 +254,19 @@ public class UserService {
             entityManager.persist(newUser);
             userData = newUser;
         } else {
-            // check that the existing auth ID matches the newly passed one to prevent account takeover attacks
+            // check that the existing auth ID matches the newly passed one to prevent account takeover attempts
             if (!userData.getAuthId().equals(newUser.getAuthId())) {
-                throw new AuthenticationServiceException("The GitHub ID setting in your profile ("
-                        + newUser.getAuthId()
-                        + ") does not match your original authentication ("
-                        + userData.getAuthId() + ").");
+                logger.error(
+                        "Login attempt by user '{}' with authId '{}' which does not match existing authId '{}'," +
+                        "potential account takeover attempt, disallowing login",
+                        newUser.getLoginName(),
+                        newUser.getAuthId(),
+                        userData.getAuthId()
+                );
+                throw new AuthenticationServiceException(
+                        "Could not login due to an existing user account with the same name. " +
+                        "Please contact support for details."
+                );
             }
             var updated = false;
             if (!Strings.CS.equals(userData.getLoginName(), newUser.getLoginName())) {
@@ -278,7 +298,7 @@ public class UserService {
     }
 
     public Map<String, String> getLoginProviders() {
-        if(clientRegistrationRepository == null) {
+        if (clientRegistrationRepository == null) {
             return Collections.emptyMap();
         }
 

--- a/server/src/main/java/org/eclipse/openvsx/UserService.java
+++ b/server/src/main/java/org/eclipse/openvsx/UserService.java
@@ -32,6 +32,7 @@ import org.eclipse.openvsx.storage.StorageUtilService;
 import org.eclipse.openvsx.util.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.stereotype.Component;
@@ -240,6 +241,13 @@ public class UserService {
             entityManager.persist(newUser);
             userData = newUser;
         } else {
+            // check that the existing auth ID matches the newly passed one to prevent account takeover attacks
+            if (!userData.getAuthId().equals(newUser.getAuthId())) {
+                throw new AuthenticationServiceException("The GitHub ID setting in your profile ("
+                        + newUser.getAuthId()
+                        + ") does not match your original authentication ("
+                        + userData.getAuthId() + ").");
+            }
             var updated = false;
             if (!Strings.CS.equals(userData.getLoginName(), newUser.getLoginName())) {
                 userData.setLoginName(newUser.getLoginName());

--- a/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseProfile.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseProfile.java
@@ -40,9 +40,6 @@ public class EclipseProfile {
     @JsonProperty("full_name")
     private String fullName;
 
-    @JsonProperty("github_id")
-    private Optional<String> githubId;
-
     @JsonProperty("github_handle")
     private String githubHandle;
 
@@ -115,14 +112,6 @@ public class EclipseProfile {
 
     public void setGithubHandle(String githubHandle) {
         this.githubHandle = githubHandle;
-    }
-
-    public Optional<String> getGithubId() {
-      return githubId;
-    }
-
-    public void setGithubId(Optional<String> githubId) {
-      this.githubId = githubId;
     }
 
     public String getTwitterHandle() {

--- a/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseProfile.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseProfile.java
@@ -40,6 +40,9 @@ public class EclipseProfile {
     @JsonProperty("full_name")
     private String fullName;
 
+    @JsonProperty("github_id")
+    private Optional<String> githubId;
+
     @JsonProperty("github_handle")
     private String githubHandle;
 
@@ -112,6 +115,14 @@ public class EclipseProfile {
 
     public void setGithubHandle(String githubHandle) {
         this.githubHandle = githubHandle;
+    }
+
+    public Optional<String> getGithubId() {
+      return githubId;
+    }
+
+    public void setGithubId(Optional<String> githubId) {
+      this.githubId = githubId;
     }
 
     public String getTwitterHandle() {

--- a/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseTokenService.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseTokenService.java
@@ -25,7 +25,6 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType;
 import org.springframework.security.oauth2.core.OAuth2RefreshToken;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.LinkedMultiValueMap;

--- a/server/src/main/java/org/eclipse/openvsx/security/OAuth2AttributesConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/security/OAuth2AttributesConfig.java
@@ -39,7 +39,7 @@ public record OAuth2AttributesConfig(Map<String, OAuth2AttributesMapping> attrib
 
     public List<String> getProviders() {
         var providers = new ArrayList<>(DEFAULT_MAPPINGS.keySet());
-        if(attributeNames != null) {
+        if (attributeNames != null) {
             providers.addAll(attributeNames.keySet());
         }
 

--- a/server/src/main/java/org/eclipse/openvsx/security/OAuth2UserServices.java
+++ b/server/src/main/java/org/eclipse/openvsx/security/OAuth2UserServices.java
@@ -99,7 +99,7 @@ public class OAuth2UserServices {
         var registrationId = userRequest.getClientRegistration().getRegistrationId();
         var mapping = attributesConfig.getAttributeMapping(registrationId);
         if(mapping == null) {
-            throw new CodedAuthException("Unsupported registration: " + registrationId ,UNSUPPORTED_REGISTRATION);
+            throw new CodedAuthException("Unsupported registration: " + registrationId, UNSUPPORTED_REGISTRATION);
         }
 
         var oauth2User = userRequest instanceof OidcUserRequest oidcRequest

--- a/server/src/main/java/org/eclipse/openvsx/security/OAuth2UserServices.java
+++ b/server/src/main/java/org/eclipse/openvsx/security/OAuth2UserServices.java
@@ -129,6 +129,14 @@ public class OAuth2UserServices {
         try {
             var accessToken = userRequest.getAccessToken().getTokenValue();
             var profile = eclipse.getUserProfile(accessToken);
+            var githubIdOpt = profile.getGithubId();
+            if (githubIdOpt.isPresent() && StringUtils.isNotBlank(githubIdOpt.get())
+                    && !githubIdOpt.get().equalsIgnoreCase(userData.getAuthId()))
+                throw new CodedAuthException("The GitHub ID setting in your Eclipse profile ("
+                        + githubIdOpt.get()
+                        + ") does not match your GitHub authentication ("
+                        + userData.getAuthId() + ").",
+                        ECLIPSE_MISMATCH_GITHUB_ID);
             if (StringUtils.isEmpty(profile.getGithubHandle()))
                 throw new CodedAuthException("Your Eclipse profile is missing a GitHub username.",
                         ECLIPSE_MISSING_GITHUB_ID);

--- a/server/src/main/java/org/eclipse/openvsx/security/OAuth2UserServices.java
+++ b/server/src/main/java/org/eclipse/openvsx/security/OAuth2UserServices.java
@@ -129,14 +129,6 @@ public class OAuth2UserServices {
         try {
             var accessToken = userRequest.getAccessToken().getTokenValue();
             var profile = eclipse.getUserProfile(accessToken);
-            var githubIdOpt = profile.getGithubId();
-            if (githubIdOpt.isPresent() && StringUtils.isNotBlank(githubIdOpt.get())
-                    && !githubIdOpt.get().equalsIgnoreCase(userData.getAuthId()))
-                throw new CodedAuthException("The GitHub ID setting in your Eclipse profile ("
-                        + githubIdOpt.get()
-                        + ") does not match your GitHub authentication ("
-                        + userData.getAuthId() + ").",
-                        ECLIPSE_MISMATCH_GITHUB_ID);
             if (StringUtils.isEmpty(profile.getGithubHandle()))
                 throw new CodedAuthException("Your Eclipse profile is missing a GitHub username.",
                         ECLIPSE_MISSING_GITHUB_ID);

--- a/server/src/test/java/org/eclipse/openvsx/UserServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/UserServiceTest.java
@@ -1,0 +1,92 @@
+/** ******************************************************************************
+ * Copyright (c) 2020 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************* */
+package org.eclipse.openvsx;
+
+import static org.mockito.ArgumentMatchers.anyString;
+
+import org.eclipse.openvsx.cache.CacheService;
+import org.eclipse.openvsx.entities.UserData;
+import org.eclipse.openvsx.repositories.RepositoryService;
+import org.eclipse.openvsx.security.OAuth2AttributesConfig;
+import org.eclipse.openvsx.storage.StorageUtilService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import jakarta.persistence.EntityManager;
+
+@ExtendWith(SpringExtension.class)
+@MockitoBean(types = {
+    EntityManager.class, StorageUtilService.class, CacheService.class, ExtensionValidator.class, OAuth2AttributesConfig.class
+})
+class UserServiceTest {
+
+    @MockitoBean
+    RepositoryService repositories;
+
+    @Autowired
+    UserService users;
+
+    @Test
+    void testUpsertUserMatchingAuthId() {
+        var testAuthId = "test-login-name";
+        Mockito.when(repositories.findUserByLoginName(anyString(), anyString())).thenReturn(mockUser(testAuthId));
+
+        var updated = mockUser(testAuthId);
+        Assertions.assertEquals(updated, users.upsertUser(updated), "Should succeed as there were no changes to the entity");
+    }
+
+    @Test
+    void testUpsertUserNonMatchingAuthId() {
+        var testAuthId = "test-login-name";
+        Mockito.when(repositories.findUserByLoginName(anyString(), anyString())).thenReturn(mockUser(testAuthId));
+
+        var updated = mockUser("some-other-id");
+        var exception = Assertions.assertThrows(AuthenticationServiceException.class, () -> users.upsertUser(updated),
+                "Should succeed as there were no changes to the entity");
+        Assertions.assertTrue(exception.getMessage().startsWith("The GitHub ID setting in your profile"),
+                "Exception should pertain to mismatch of GitHub ID");
+    }
+
+    private UserData mockUser(String authId) {
+        var userData = new UserData();
+        userData.setLoginName("test_user");
+        userData.setFullName("Test User");
+        userData.setAuthId(authId);
+        userData.setProvider("sample");
+        userData.setProviderUrl("http://example.com/test");
+        return userData;
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        UserService userService(
+                EntityManager entityManager,
+                RepositoryService repositories,
+                StorageUtilService storageUtil,
+                CacheService cache,
+                ExtensionValidator validator,
+                @Autowired(required = false) ClientRegistrationRepository clientRegistrationRepository,
+                OAuth2AttributesConfig attributesConfig
+        ) {
+            return new UserService(entityManager, repositories, storageUtil, cache, validator, clientRegistrationRepository, attributesConfig);
+        }
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/UserServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/UserServiceTest.java
@@ -1,14 +1,18 @@
-/** ******************************************************************************
- * Copyright (c) 2020 TypeFox and others
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
- ******************************************************************************* */
+ *****************************************************************************/
 package org.eclipse.openvsx;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 
 import org.eclipse.openvsx.cache.CacheService;
@@ -16,7 +20,6 @@ import org.eclipse.openvsx.entities.UserData;
 import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.security.OAuth2AttributesConfig;
 import org.eclipse.openvsx.storage.StorageUtilService;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -44,32 +47,37 @@ class UserServiceTest {
 
     @Test
     void testUpsertUserMatchingAuthId() {
-        var testAuthId = "test-login-name";
+        var testAuthId = "test-auth-id";
         Mockito.when(repositories.findUserByLoginName(anyString(), anyString())).thenReturn(mockUser(testAuthId));
 
         var updated = mockUser(testAuthId);
-        Assertions.assertEquals(updated, users.upsertUser(updated), "Should succeed as there were no changes to the entity");
+        assertEquals(updated, users.upsertUser(updated), "Should succeed as there were no changes to the entity");
     }
 
     @Test
     void testUpsertUserNonMatchingAuthId() {
-        var testAuthId = "test-login-name";
+        var testAuthId = "test-auth-id";
         Mockito.when(repositories.findUserByLoginName(anyString(), anyString())).thenReturn(mockUser(testAuthId));
 
         var updated = mockUser("some-other-id");
-        var exception = Assertions.assertThrows(AuthenticationServiceException.class, () -> users.upsertUser(updated),
+        var exception = assertThrows(AuthenticationServiceException.class, () -> users.upsertUser(updated),
                 "Should succeed as there were no changes to the entity");
-        Assertions.assertTrue(exception.getMessage().startsWith("The GitHub ID setting in your profile"),
+        assertTrue(exception.getMessage().startsWith("Could not login due to an existing"),
                 "Exception should pertain to mismatch of GitHub ID");
     }
 
     private UserData mockUser(String authId) {
+        return mockUser(1, "test_user", authId);
+    }
+
+    private UserData mockUser(long id, String loginName, String authId) {
         var userData = new UserData();
-        userData.setLoginName("test_user");
+        userData.setId(id);
+        userData.setLoginName(loginName);
         userData.setFullName("Test User");
         userData.setAuthId(authId);
-        userData.setProvider("sample");
-        userData.setProviderUrl("http://example.com/test");
+        userData.setProvider("example");
+        userData.setProviderUrl("http://example.com/test_user");
         return userData;
     }
 

--- a/server/src/test/java/org/eclipse/openvsx/cache/CacheServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/cache/CacheServiceTest.java
@@ -390,8 +390,8 @@ class CacheServiceTest {
 
         var user = new UserData();
         user.setLoginName("user");
-        user.setAuthId("123-456");
         user.setFullName("User");
+        user.setAuthId("123-456");
         user.setAvatarUrl("https://github.com/user/avatar");
         user.setProviderUrl("https://github.com");
         user.setProvider("github");

--- a/server/src/test/java/org/eclipse/openvsx/cache/CacheServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/cache/CacheServiceTest.java
@@ -112,6 +112,7 @@ class CacheServiceTest {
             updatedUser.setProvider("github");
             updatedUser.setLoginName("user");
             updatedUser.setFullName("User2");
+            updatedUser.setAuthId("123-456");
             updatedUser.setProviderUrl("https://user2.github.io");
             updatedUser.setAvatarUrl("https://github.com/user2/avatar");
 
@@ -389,6 +390,7 @@ class CacheServiceTest {
 
         var user = new UserData();
         user.setLoginName("user");
+        user.setAuthId("123-456");
         user.setFullName("User");
         user.setAvatarUrl("https://github.com/user/avatar");
         user.setProviderUrl("https://github.com");


### PR DESCRIPTION
Previously, the `authId` field of a user was only populated with the name of the OAuth2User object that is created during the OAuth2 dance. In the case of GitHub OAuth provider this corresponds to the numeric GH id.

This PR adds a change to check during login if the `authId` as provided by current user matches the one as expected from the persisted user object. If there is a mismatch it is a potential account takeover attempt and login is rejected.

In the long term we should use `authId` as primary key and enforce it to be unique, however that will require some major changes.