### PR TITLE
fix: validate that metadata in package.json matches manifest

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
@@ -259,6 +259,16 @@ public class ExtensionProcessor implements AutoCloseable {
         return extVersion;
     }
 
+    public PackageMetadata getPackageMetadata() {
+        loadPackageJson();
+        return new PackageMetadata(
+                packageJson.path("publisher").asText(),
+                packageJson.path("name").asText(),
+                packageJson.path("version").asText(),
+                packageJson.path("displayName").asText()
+        );
+    }
+
     public String getVersion() {
         return vsixManifest.path(MANIFEST_METADATA).path(MANIFEST_IDENTITY).path("Version").asText();
     }
@@ -546,4 +556,6 @@ public class ExtensionProcessor implements AutoCloseable {
 
         return false;
     }
+
+    public record PackageMetadata(String publisher, String name, String version, String displayName) {}
 }

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -18,6 +18,7 @@ import java.util.function.Predicate;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.eclipse.openvsx.ExtensionProcessor;
 import org.eclipse.openvsx.ExtensionService;
 import org.eclipse.openvsx.ExtensionValidator;
@@ -147,6 +148,11 @@ public class PublishExtensionVersionHandler {
         var displayName = extVersion.getDisplayName();
         validateExtensionName(namespaceName, extensionName, displayName, user);
 
+        // Check that the metadata contained in package.json matches the one extracted from extension.vsixmanifest
+        // Open VSX uses the metadata from extension.vsixmanifest as the source of truth, but VS Code
+        // actually uses package.json so we need to make sure they are both aligned to avoid differentials.
+        validatePackageMetadata(processor, namespaceName, extensionName, extVersion);
+
         extVersion.setTimestamp(timestamp);
         extVersion.setPublishedWith(token);
         extVersion.setActive(false);
@@ -198,8 +204,40 @@ public class PublishExtensionVersionHandler {
             throw new ErrorResultException(nameIssue.get().toString());
         }
 
-        if(isMalicious(namespaceName, extensionName)) {
+        if (isMalicious(namespaceName, extensionName)) {
             throw new ErrorResultException(NamingUtil.toExtensionId(namespaceName, extensionName) + " is a known malicious extension");
+        }
+    }
+
+    /**
+     * This method checks whether the metadata as contained in {@code extension.vsixmanifest} matches
+     * the data in {@code package.json}.
+     */
+    private void validatePackageMetadata(
+            ExtensionProcessor processor,
+            String namespaceName,
+            String extensionName,
+            ExtensionVersion extVersion
+    ) {
+        var packageMetadata = processor.getPackageMetadata();
+
+        // Do strict CS equality checks on these items, normally they should match,
+        // e.g. when the vsix extension package has been created by tools like vsce
+
+        if (!Strings.CS.equals(namespaceName, packageMetadata.publisher())) {
+            throw new ErrorResultException("Publisher in extension.vsixmanifest and package.json does not match.");
+        }
+
+        if (!Strings.CS.equals(extensionName, packageMetadata.name())) {
+            throw new ErrorResultException("Extension name in extension.vsixmanifest and package.json does not match.");
+        }
+
+        if (!Strings.CS.equals(extVersion.getVersion(), packageMetadata.version())) {
+            throw new ErrorResultException("Extension version in extension.vsixmanifest and package.json does not match.");
+        }
+
+        if (!Strings.CS.equals(extVersion.getDisplayName(), packageMetadata.displayName())) {
+            throw new ErrorResultException("Display name in extension.vsixmanifest and package.json does not match.");
         }
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -221,22 +221,22 @@ public class PublishExtensionVersionHandler {
     ) {
         var packageMetadata = processor.getPackageMetadata();
 
-        // Do strict CS equality checks on these items, normally they should match,
+        // Check for equality on these items, normally they should match,
         // e.g. when the vsix extension package has been created by tools like vsce
 
-        if (!Strings.CS.equals(namespaceName, packageMetadata.publisher())) {
+        if (!Strings.CI.equals(namespaceName, packageMetadata.publisher())) {
             throw new ErrorResultException("Publisher in extension.vsixmanifest and package.json does not match.");
         }
 
-        if (!Strings.CS.equals(extensionName, packageMetadata.name())) {
+        if (!Strings.CI.equals(extensionName, packageMetadata.name())) {
             throw new ErrorResultException("Extension name in extension.vsixmanifest and package.json does not match.");
         }
 
-        if (!Strings.CS.equals(extVersion.getVersion(), packageMetadata.version())) {
+        if (!Strings.CI.equals(extVersion.getVersion(), packageMetadata.version())) {
             throw new ErrorResultException("Extension version in extension.vsixmanifest and package.json does not match.");
         }
 
-        if (!Strings.CS.equals(extVersion.getDisplayName(), packageMetadata.displayName())) {
+        if (!Strings.CI.equals(extVersion.getDisplayName(), packageMetadata.displayName())) {
             throw new ErrorResultException("Display name in extension.vsixmanifest and package.json does not match.");
         }
     }

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -2528,7 +2528,8 @@ class RegistryAPITest {
         var packageJson = "{" +
                 "\"publisher\": \"foo\"," +
                 "\"name\": \"" + name + "\"," +
-                "\"version\": \"" + version + "\"" +
+                "\"version\": \"" + version + "\"," +
+                "\"displayName\": \"foo\"" +
                 (license == null ? "" : ",\"license\": \"" + license + "\"" ) +
             "}";
         archive.write(packageJson.getBytes());

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
@@ -275,6 +275,19 @@ class PublishExtensionVersionHandlerTest {
             assertThatThrownBy(() -> handler.createExtensionVersion(processor, token, LocalDateTime.now(), false))
                     .isInstanceOf(ErrorResultException.class)
                     .hasMessageContaining("Extension version in extension.vsixmanifest");
+
+            when(processor.getPackageMetadata()).thenReturn(
+                    new ExtensionProcessor.PackageMetadata(
+                            "publisher",
+                            "demo",
+                            "2.0.0",
+                            "Demo Not OK"
+                    )
+            );
+
+            assertThatThrownBy(() -> handler.createExtensionVersion(processor, token, LocalDateTime.now(), false))
+                    .isInstanceOf(ErrorResultException.class)
+                    .hasMessageContaining("Display name in extension.vsixmanifest");
         }
     }
 

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
@@ -26,10 +26,7 @@ import java.util.Optional;
 import org.eclipse.openvsx.ExtensionProcessor;
 import org.eclipse.openvsx.ExtensionValidator;
 import org.eclipse.openvsx.UserService;
-import org.eclipse.openvsx.entities.Extension;
-import org.eclipse.openvsx.entities.ExtensionVersion;
-import org.eclipse.openvsx.entities.Namespace;
-import org.eclipse.openvsx.entities.PersonalAccessToken;
+import org.eclipse.openvsx.entities.*;
 import org.eclipse.openvsx.extension_control.ExtensionControlService;
 import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.scanning.ExtensionScanService;
@@ -39,7 +36,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -112,7 +108,7 @@ class PublishExtensionVersionHandlerTest {
             when(processor.getBundledExtensions()).thenReturn(List.of());
 
             var namespace = buildNamespace("publisher");
-            var user = new org.eclipse.openvsx.entities.UserData();
+            var user = new UserData();
             var token = new PersonalAccessToken();
             token.setUser(user);
 
@@ -142,7 +138,7 @@ class PublishExtensionVersionHandlerTest {
         try (var processor = org.mockito.Mockito.mock(ExtensionProcessor.class)) {
             when(processor.getNamespace()).thenReturn("unknown");
 
-            var user = new org.eclipse.openvsx.entities.UserData();
+            var user = new UserData();
             var token = new PersonalAccessToken();
             token.setUser(user);
 
@@ -160,7 +156,7 @@ class PublishExtensionVersionHandlerTest {
             mockExtensionVersion("publisher", "demo", "2.0.0", "test.svg", processor);
 
             var namespace = buildNamespace("publisher");
-            var user = new org.eclipse.openvsx.entities.UserData();
+            var user = new UserData();
             var token = new PersonalAccessToken();
             token.setUser(user);
 
@@ -184,7 +180,7 @@ class PublishExtensionVersionHandlerTest {
             var metadata = mockExtensionVersion("publisher", "demo", "2.0.0", "test.svg", processor);
 
             var namespace = buildNamespace("publisher");
-            var user = new org.eclipse.openvsx.entities.UserData();
+            var user = new UserData();
             var token = new PersonalAccessToken();
             token.setUser(user);
 
@@ -197,6 +193,62 @@ class PublishExtensionVersionHandlerTest {
             assertThat(ev).isNotNull();
         } finally {
             config.setUnsupportedIconFormats(previousUnsupportedIconFormats);
+        }
+    }
+
+    @Test
+    void shouldFailWhenPackageJsonDoesNotMatchManifest() throws IOException {
+        try (var processor = org.mockito.Mockito.mock(ExtensionProcessor.class)) {
+            var metadata = mockExtensionVersion("publisher", "demo", "2.0.0", null, processor);
+
+            var namespace = buildNamespace("publisher");
+            var user = new UserData();
+            var token = new PersonalAccessToken();
+            token.setUser(user);
+
+            when(repositories.findNamespace("publisher")).thenReturn(namespace);
+            when(users.hasPublishPermission(user, namespace)).thenReturn(true);
+            when(validator.validateExtensionVersion(metadata.getVersion())).thenReturn(Optional.empty());
+            when(validator.validateExtensionName("demo")).thenReturn(Optional.empty());
+
+            when(processor.getPackageMetadata()).thenReturn(
+                    new ExtensionProcessor.PackageMetadata(
+                            "publisher1",
+                            "demo",
+                            "2.0.0",
+                            "Demo OK"
+                    )
+            );
+
+            assertThatThrownBy(() -> handler.createExtensionVersion(processor, token, LocalDateTime.now(), false))
+                    .isInstanceOf(ErrorResultException.class)
+                    .hasMessageContaining("Publisher in extension.vsixmanifest");
+
+            when(processor.getPackageMetadata()).thenReturn(
+                    new ExtensionProcessor.PackageMetadata(
+                            "publisher",
+                            "DemO",
+                            "2.0.0",
+                            "Demo OK"
+                    )
+            );
+
+            assertThatThrownBy(() -> handler.createExtensionVersion(processor, token, LocalDateTime.now(), false))
+                    .isInstanceOf(ErrorResultException.class)
+                    .hasMessageContaining("Extension name in extension.vsixmanifest");
+
+            when(processor.getPackageMetadata()).thenReturn(
+                    new ExtensionProcessor.PackageMetadata(
+                            "publisher",
+                            "demo",
+                            "9.9.9",
+                            "Demo OK"
+                    )
+            );
+
+            assertThatThrownBy(() -> handler.createExtensionVersion(processor, token, LocalDateTime.now(), false))
+                    .isInstanceOf(ErrorResultException.class)
+                    .hasMessageContaining("Extension version in extension.vsixmanifest");
         }
     }
 

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
@@ -106,6 +106,14 @@ class PublishExtensionVersionHandlerTest {
 
             when(processor.getExtensionDependencies()).thenReturn(List.of());
             when(processor.getBundledExtensions()).thenReturn(List.of());
+            when(processor.getPackageMetadata()).thenReturn(
+                    new ExtensionProcessor.PackageMetadata(
+                            "publisher",
+                            "demo",
+                            "2.0.0",
+                            "Demo OK"
+                    )
+            );
 
             var namespace = buildNamespace("publisher");
             var user = new UserData();
@@ -155,6 +163,15 @@ class PublishExtensionVersionHandlerTest {
         try (var processor = org.mockito.Mockito.mock(ExtensionProcessor.class)) {
             mockExtensionVersion("publisher", "demo", "2.0.0", "test.svg", processor);
 
+            when(processor.getPackageMetadata()).thenReturn(
+                    new ExtensionProcessor.PackageMetadata(
+                            "publisher",
+                            "demo",
+                            "2.0.0",
+                            "Demo OK"
+                    )
+            );
+
             var namespace = buildNamespace("publisher");
             var user = new UserData();
             var token = new PersonalAccessToken();
@@ -178,6 +195,15 @@ class PublishExtensionVersionHandlerTest {
             config.setUnsupportedIconFormats(List.of());
 
             var metadata = mockExtensionVersion("publisher", "demo", "2.0.0", "test.svg", processor);
+
+            when(processor.getPackageMetadata()).thenReturn(
+                    new ExtensionProcessor.PackageMetadata(
+                            "publisher",
+                            "demo",
+                            "2.0.0",
+                            "Demo OK"
+                    )
+            );
 
             var namespace = buildNamespace("publisher");
             var user = new UserData();
@@ -227,7 +253,7 @@ class PublishExtensionVersionHandlerTest {
             when(processor.getPackageMetadata()).thenReturn(
                     new ExtensionProcessor.PackageMetadata(
                             "publisher",
-                            "DemO",
+                            "DemO1",
                             "2.0.0",
                             "Demo OK"
                     )


### PR DESCRIPTION
This adds additional validation that relevant information in the `package.json` matches the same data in `extension.vsixmanifest`. Open VSX uses the latter as source of truth, while VS Code the former. To avoid any possible differential, we should validate the equality at publication time and reject if they differ substantially.

Do the checks case-insensitive for now to not break tests and the case does not matter when doing an api request.