### PR TITLE
fix: exclude displayName check in package.json validation

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -236,9 +236,11 @@ public class PublishExtensionVersionHandler {
             throw new ErrorResultException("Extension version in extension.vsixmanifest and package.json does not match.");
         }
 
-        if (!Strings.CI.equals(extVersion.getDisplayName(), packageMetadata.displayName())) {
-            throw new ErrorResultException("Display name in extension.vsixmanifest and package.json does not match.");
-        }
+        // Do not check if the displayName property is equal as it is not fully understood yet how VS Code / vsce processes
+        // that property. There are some projects, where the value is `%displayName%` and publication will fail.
+        // if (!Strings.CI.equals(extVersion.getDisplayName(), packageMetadata.displayName())) {
+        //    throw new ErrorResultException("Display name in extension.vsixmanifest and package.json does not match.");
+        // }
     }
 
     private void validateLicense(ExtensionProcessor processor, ExtensionVersion extVersion) {

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
@@ -275,19 +275,6 @@ class PublishExtensionVersionHandlerTest {
             assertThatThrownBy(() -> handler.createExtensionVersion(processor, token, LocalDateTime.now(), false))
                     .isInstanceOf(ErrorResultException.class)
                     .hasMessageContaining("Extension version in extension.vsixmanifest");
-
-            when(processor.getPackageMetadata()).thenReturn(
-                    new ExtensionProcessor.PackageMetadata(
-                            "publisher",
-                            "demo",
-                            "2.0.0",
-                            "Demo Not OK"
-                    )
-            );
-
-            assertThatThrownBy(() -> handler.createExtensionVersion(processor, token, LocalDateTime.now(), false))
-                    .isInstanceOf(ErrorResultException.class)
-                    .hasMessageContaining("Display name in extension.vsixmanifest");
         }
     }
 


### PR DESCRIPTION
This PR excludes the `displayName` from the `package.json` validation as it fails for some extensions:

 - https://github.com/zowe/zowe-explorer-vscode
 - https://github.com/Microsoft/vscode-pull-request-github

they define `%displayName%` as value for `displayName` in their `package.json`. The vsce tool converts that to a proper `displayName` during the build. How it does that is not clear yet.
