### PR TITLE
fix: cache S3Presigner as singleton to prevent IRSA credential refresh failure

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
@@ -77,6 +77,7 @@ public class AwsStorageService implements IStorageService {
     boolean pathStyleAccess;
 
     private S3Client s3Client;
+    private S3Presigner s3Presigner;
 
     public AwsStorageService(FileCacheDurationConfig fileCacheDurationConfig, FilesCacheKeyGenerator filesCacheKeyGenerator) {
         this.fileCacheDurationConfig = fileCacheDurationConfig;
@@ -110,24 +111,27 @@ public class AwsStorageService implements IStorageService {
     }
 
     private S3Presigner getS3Presigner() {
-        var builder = S3Presigner.builder()
-                .region(Region.of(region))
-                .credentialsProvider(getCredentialsProvider());
-
-        if(StringUtils.isNotEmpty(serviceEndpoint)) {
-            var endpointParams = S3EndpointParams.builder()
-                    .endpoint(serviceEndpoint)
+        if (s3Presigner == null) {
+            var builder = S3Presigner.builder()
                     .region(Region.of(region))
-                    .build();
+                    .credentialsProvider(getCredentialsProvider());
 
-            var endpoint = S3EndpointProvider
-                    .defaultProvider()
-                    .resolveEndpoint(endpointParams).join();
+            if(StringUtils.isNotEmpty(serviceEndpoint)) {
+                var endpointParams = S3EndpointParams.builder()
+                        .endpoint(serviceEndpoint)
+                        .region(Region.of(region))
+                        .build();
 
-            builder = builder.endpointOverride(endpoint.url());
+                var endpoint = S3EndpointProvider
+                        .defaultProvider()
+                        .resolveEndpoint(endpointParams).join();
+
+                builder = builder.endpointOverride(endpoint.url());
+            }
+
+            s3Presigner = builder.build();
         }
-
-        return builder.build();
+        return s3Presigner;
     }
 
     private AwsCredentialsProvider getCredentialsProvider() {
@@ -240,10 +244,8 @@ public class AwsStorageService implements IStorageService {
                 .getObjectRequest(objectRequest)
                 .build();
 
-        try (var presigner = getS3Presigner()) {
-            var presignedRequest = presigner.presignGetObject(presignRequest);
-            return presignedRequest.httpRequest().getUri();
-        }
+        var presignedRequest = getS3Presigner().presignGetObject(presignRequest);
+        return presignedRequest.httpRequest().getUri();
     }
 
     @Override

--- a/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
@@ -7,9 +7,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
-
 package org.eclipse.openvsx.storage;
 
+import jakarta.annotation.Nullable;
+import jakarta.annotation.PreDestroy;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.openvsx.cache.FilesCacheKeyGenerator;
 import org.eclipse.openvsx.entities.FileResource;
@@ -76,62 +77,88 @@ public class AwsStorageService implements IStorageService {
     @Value("${ovsx.storage.aws.path-style-access:false}")
     boolean pathStyleAccess;
 
-    private S3Client s3Client;
-    private S3Presigner s3Presigner;
+    private volatile S3Client s3Client;
+    private volatile S3Presigner s3Presigner;
 
     public AwsStorageService(FileCacheDurationConfig fileCacheDurationConfig, FilesCacheKeyGenerator filesCacheKeyGenerator) {
         this.fileCacheDurationConfig = fileCacheDurationConfig;
         this.filesCacheKeyGenerator = filesCacheKeyGenerator;
     }
 
+    @PreDestroy
+    public void close() {
+        if (s3Presigner != null) {
+            try {
+                s3Presigner.close();
+            } catch (RuntimeException _) {}
+        }
+
+        if (s3Client != null) {
+            try {
+                s3Client.close();
+            } catch (RuntimeException _) {}
+        }
+    }
+
     public S3Client getS3Client() {
+        // lazily generates the s3 client using double-checked locking
         if (s3Client == null) {
-            var s3ClientBuilder = S3Client.builder()
-                    .defaultsMode(DefaultsMode.STANDARD)
-                    .forcePathStyle(pathStyleAccess)
-                    .region(Region.of(region))
-                    .credentialsProvider(getCredentialsProvider());
+            synchronized (this) {
+                if (s3Client == null) {
+                    var s3ClientBuilder = S3Client.builder()
+                            .defaultsMode(DefaultsMode.STANDARD)
+                            .forcePathStyle(pathStyleAccess)
+                            .region(Region.of(region))
+                            .credentialsProvider(getCredentialsProvider());
 
-            if(StringUtils.isNotEmpty(serviceEndpoint)) {
-                var endpointParams = S3EndpointParams.builder()
-                        .endpoint(serviceEndpoint)
-                        .region(Region.of(region))
-                        .build();
+                    var serviceEndpoint = getServiceEndpoint();
+                    if (serviceEndpoint != null) {
+                        s3ClientBuilder = s3ClientBuilder.endpointOverride(serviceEndpoint);
+                    }
 
-                var endpoint = S3EndpointProvider
-                        .defaultProvider()
-                        .resolveEndpoint(endpointParams).join();
-
-                s3ClientBuilder = s3ClientBuilder.endpointOverride(endpoint.url());
+                    s3Client = s3ClientBuilder.build();
+                }
             }
-
-            s3Client = s3ClientBuilder.build();
         }
         return s3Client;
     }
 
     private S3Presigner getS3Presigner() {
+        // lazily generates the s3 presigner using double-checked locking
         if (s3Presigner == null) {
-            var builder = S3Presigner.builder()
-                    .region(Region.of(region))
-                    .credentialsProvider(getCredentialsProvider());
+            synchronized (this) {
+                if (s3Presigner == null) {
+                    var builder = S3Presigner.builder()
+                            .region(Region.of(region))
+                            .credentialsProvider(getCredentialsProvider());
 
-            if(StringUtils.isNotEmpty(serviceEndpoint)) {
-                var endpointParams = S3EndpointParams.builder()
-                        .endpoint(serviceEndpoint)
-                        .region(Region.of(region))
-                        .build();
+                    var serviceEndpoint = getServiceEndpoint();
+                    if (serviceEndpoint != null) {
+                        builder = builder.endpointOverride(serviceEndpoint);
+                    }
 
-                var endpoint = S3EndpointProvider
-                        .defaultProvider()
-                        .resolveEndpoint(endpointParams).join();
-
-                builder = builder.endpointOverride(endpoint.url());
+                    s3Presigner = builder.build();
+                }
             }
-
-            s3Presigner = builder.build();
         }
         return s3Presigner;
+    }
+
+    private @Nullable URI getServiceEndpoint() {
+        if (StringUtils.isNotEmpty(serviceEndpoint)) {
+            var endpointParams = S3EndpointParams.builder()
+                    .endpoint(serviceEndpoint)
+                    .region(Region.of(region))
+                    .build();
+
+            var endpoint = S3EndpointProvider
+                    .defaultProvider()
+                    .resolveEndpoint(endpointParams).join();
+
+            return endpoint.url();
+        }
+
+        return null;
     }
 
     private AwsCredentialsProvider getCredentialsProvider() {
@@ -145,7 +172,6 @@ public class AwsStorageService implements IStorageService {
         return DefaultCredentialsProvider.create();
     }
 
-
     private boolean hasStaticCredentials() {
         return !StringUtils.isEmpty(accessKeyId) && !StringUtils.isEmpty(secretAccessKey);
     }
@@ -153,6 +179,7 @@ public class AwsStorageService implements IStorageService {
     private boolean hasSessionToken() {
         return !StringUtils.isEmpty(sessionToken);
     }
+
     @Override
     public boolean isEnabled() {
         // Require region and bucket to be configured

--- a/server/src/test/java/org/eclipse/openvsx/storage/AwsStorageServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/storage/AwsStorageServiceTest.java
@@ -253,4 +253,25 @@ class AwsStorageServiceTest {
         assertFalse((Boolean) ReflectionTestUtils.invokeMethod(storageService, "hasStaticCredentials"));
         assertFalse((Boolean) ReflectionTestUtils.invokeMethod(storageService, "hasSessionToken"));
     }
+
+    @Test
+    void testPresignerIsCachedAsSingleton() {
+        // Only region is needed to construct the presigner builder
+        ReflectionTestUtils.setField(storageService, "region", "us-east-1");
+        ReflectionTestUtils.setField(storageService, "serviceEndpoint", "");
+
+        var presigner1 = ReflectionTestUtils.invokeMethod(storageService, "getS3Presigner");
+        var presigner2 = ReflectionTestUtils.invokeMethod(storageService, "getS3Presigner");
+
+        assertNotNull(presigner1);
+        assertSame(presigner1, presigner2,
+                "S3Presigner must be cached as a singleton; recreating it on each call " +
+                "destroys the HTTP connection pool needed for IRSA credential refresh");
+    }
+
+    @Test
+    void testPresignerFieldInitiallyNull() {
+        assertNull(ReflectionTestUtils.getField(storageService, "s3Presigner"),
+                "S3Presigner should be lazily initialized");
+    }
 }


### PR DESCRIPTION
Fixes #1855

The `S3Presigner` was created and closed on every `getLocation()` call via try-with-resources. Closing the presigner destroys the HTTP connection pool that `DefaultCredentialsProvider` needs to refresh IRSA credentials via STS. After ~63 minutes when credentials expire, all presign operations fail with 500 errors.

This change caches the `S3Presigner` as a singleton field, matching the existing pattern used for `S3Client`. The presigner stays open for the application's lifetime, allowing credential refresh to work indefinitely.

## Changes
- Cache `S3Presigner` as a singleton field (lazy initialization)
- Remove try-with-resources in `getLocation()` since presigner is now long-lived
- Add unit tests verifying singleton caching behavior

## Testing
- Unit tests pass (`AwsStorageServiceTest`)
- Deployed on OpenShift (ROSA) with IRSA and S3 storage (no CDN)
- Pod ran for 3+ hours with continuous successful presigned URL generation
- Well past the previous 63-minute failure point where credentials would fail to refresh