### PR TITLE
fix: add proper cache control headers for all public endpoints

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
@@ -101,8 +101,12 @@ public class RegistryAPI {
                 // Try the next registry
             }
         }
+
         var json = NamespaceJson.error("Namespace not found: " + namespace);
-        return new ResponseEntity<>(json, HttpStatus.NOT_FOUND);
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .body(json);
     }
 
     @GetMapping(
@@ -135,7 +139,10 @@ public class RegistryAPI {
             return ResponseEntity.ok(local.verifyToken(namespace, token));
         } catch (NotFoundException exc) {
             var json = ResultJson.error("Namespace not found: " + namespace);
-            return new ResponseEntity<>(json, HttpStatus.NOT_FOUND);
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                    .body(json);
         } catch (ErrorResultException exc) {
             return exc.toResponseEntity(ResultJson.class);
         }
@@ -163,14 +170,17 @@ public class RegistryAPI {
         for (var registry : getRegistries()) {
             try {
                 return ResponseEntity.ok()
-                        .cacheControl(CacheControl.noCache().cachePublic())
+                        .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic())
                         .body(registry.getNamespaceDetails(namespace));
             } catch (NotFoundException exc) {
                 // Try the next registry
             }
         }
         var json = NamespaceDetailsJson.error(namespaceNotFoundMessage(namespace));
-        return new ResponseEntity<>(json, HttpStatus.NOT_FOUND);
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .body(json);
     }
 
     private String extensionNotFoundMessage(String extension) {
@@ -221,7 +231,10 @@ public class RegistryAPI {
             }
         }
 
-        throw new NotFoundException();
+        return ResponseEntity
+                .notFound()
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .build();
     }
 
     @GetMapping(
@@ -248,14 +261,17 @@ public class RegistryAPI {
         for (var registry : getRegistries()) {
             try {
                 return ResponseEntity.ok()
-                        .cacheControl(CacheControl.noCache().cachePublic())
+                        .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic())
                         .body(registry.getExtension(namespace, extension, null));
             } catch (NotFoundException exc) {
                 // Try the next registry
             }
         }
         var json = ExtensionJson.error(extensionNotFoundMessage(NamingUtil.toExtensionId(namespace, extension)));
-        return new ResponseEntity<>(json, HttpStatus.NOT_FOUND);
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .body(json);
     }
 
     @GetMapping(
@@ -302,7 +318,10 @@ public class RegistryAPI {
             }
         }
         var json = ExtensionJson.error(extensionNotFoundMessage(NamingUtil.toLogFormat(namespace, extension, targetPlatform.toString(), null)));
-        return new ResponseEntity<>(json, HttpStatus.NOT_FOUND);
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .body(json);
     }
 
     @GetMapping(
@@ -331,14 +350,17 @@ public class RegistryAPI {
         for (var registry : getRegistries()) {
             try {
                 return ResponseEntity.ok()
-                        .cacheControl(CacheControl.noCache().cachePublic())
+                        .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic())
                         .body(registry.getExtension(namespace, extension, null, version));
             } catch (NotFoundException exc) {
                 // Try the next registry
             }
         }
         var json = ExtensionJson.error(extensionNotFoundMessage(NamingUtil.toLogFormat(namespace, extension, version)));
-        return new ResponseEntity<>(json, HttpStatus.NOT_FOUND);
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .body(json);
     }
 
     @GetMapping(
@@ -387,7 +409,10 @@ public class RegistryAPI {
             }
         }
         var json = ExtensionJson.error(extensionNotFoundMessage(NamingUtil.toLogFormat(namespace, extension, targetPlatform, version)));
-        return new ResponseEntity<>(json, HttpStatus.NOT_FOUND);
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .body(json);
     }
 
     @GetMapping(
@@ -482,7 +507,10 @@ public class RegistryAPI {
             }
         }
         var json = VersionsJson.error(extensionNotFoundMessage(NamingUtil.toLogFormat(namespace, extension, targetPlatform)));
-        return new ResponseEntity<>(json, HttpStatus.NOT_FOUND);
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .body(json);
     }
 
     @GetMapping(
@@ -577,7 +605,10 @@ public class RegistryAPI {
             }
         }
         var json = VersionReferencesJson.error(extensionNotFoundMessage(NamingUtil.toLogFormat(namespace, extension, targetPlatform)));
-        return new ResponseEntity<>(json, HttpStatus.NOT_FOUND);
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .body(json);
     }
 
     @GetMapping("/api/{namespace}/{extension}/{version:" + VERSION_PATH_PARAM_REGEX + "}/file/**")
@@ -619,7 +650,11 @@ public class RegistryAPI {
                 // Try the next registry
             }
         }
-        throw new NotFoundException();
+
+        return ResponseEntity
+                .notFound()
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .build();
     }
 
     @GetMapping("/api/{namespace}/{extension}/{targetPlatform:" + TargetPlatform.NAMES_PATH_PARAM_REGEX + "}/{version:" + VERSION_PATH_PARAM_REGEX + "}/file/**")
@@ -674,7 +709,11 @@ public class RegistryAPI {
                 // Try the next registry
             }
         }
-        throw new NotFoundException();
+
+        return ResponseEntity
+                .notFound()
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .build();
     }
 
     @GetMapping(
@@ -701,14 +740,17 @@ public class RegistryAPI {
         for (var registry : getRegistries()) {
             try {
                 return ResponseEntity.ok()
-                        .cacheControl(CacheControl.noCache().cachePublic())
+                        .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic())
                         .body(registry.getReviews(namespace, extension));
             } catch (NotFoundException exc) {
                 // Try the next registry
             }
         }
         var json = ReviewListJson.error(extensionNotFoundMessage(NamingUtil.toExtensionId(namespace, extension)));
-        return new ResponseEntity<>(json, HttpStatus.NOT_FOUND);
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .body(json);
     }
 
     @GetMapping(
@@ -805,7 +847,7 @@ public class RegistryAPI {
         result.setTotalSize(resultSize);
         result.setExtensions(resultExtensions);
         return ResponseEntity.ok()
-                .cacheControl(CacheControl.noCache().cachePublic())
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic())
                 .body(result);
     }
 
@@ -1388,7 +1430,10 @@ public class RegistryAPI {
             }
         }
 
-        return ResponseEntity.notFound().build();
+        return ResponseEntity
+                .notFound()
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .build();
     }
 
     @GetMapping(path = "/api/version", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
@@ -210,7 +210,7 @@ public class VSCodeAPI {
         for (var service : getVSCodeServices()) {
             try {
                 var itemUrl = service.getItemUrl(namespace, extension);
-                return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
+                return ResponseEntity.status(HttpStatus.FOUND)
                         .cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS).cachePublic())
                         .location(URI.create(itemUrl))
                         .build();
@@ -269,7 +269,7 @@ public class VSCodeAPI {
         for (var service : getVSCodeServices()) {
             try {
                 var downloadUrl = service.download(namespaceName, extensionName, version, targetPlatform);
-                return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
+                return ResponseEntity.status(HttpStatus.FOUND)
                         .cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS).cachePublic())
                         .location(URI.create(downloadUrl))
                         .build();

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
@@ -28,17 +28,13 @@ import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import java.net.URI;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import static org.eclipse.openvsx.adapter.ExtensionQueryParam.*;
 import static org.eclipse.openvsx.adapter.ExtensionQueryResult.ExtensionFile.*;
 import static org.eclipse.openvsx.util.TargetPlatform.*;
 
@@ -165,7 +161,11 @@ public class VSCodeAPI {
                     // Try the next registry
                 }
             }
-            return ResponseEntity.notFound().build();
+
+            return ResponseEntity
+                    .notFound()
+                    .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                    .build();
         } catch (ErrorResultException ex) {
             logger.error(ex.getMessage());
             return ResponseEntity.internalServerError().build();
@@ -195,15 +195,14 @@ public class VSCodeAPI {
             description = "The specified item could not be found",
             content = @Content()
     )
-    public ModelAndView getItemUrl(
+    public ResponseEntity<String> getItemUrl(
             @RequestParam
             @Parameter(description = "Identifier in the format {publisher}.{name}", example = "foo.bar")
-            String itemName,
-            ModelMap model
+            String itemName
     ) {
         var dotIndex = itemName.indexOf('.');
         if (dotIndex < 0) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Expecting an item of the form `{publisher}.{name}`");
+            return ResponseEntity.badRequest().body("Expecting an item of the form `{publisher}.{name}`");
         }
 
         var namespace = itemName.substring(0, dotIndex);
@@ -211,13 +210,19 @@ public class VSCodeAPI {
         for (var service : getVSCodeServices()) {
             try {
                 var itemUrl = service.getItemUrl(namespace, extension);
-                return new ModelAndView("redirect:" + itemUrl, model);
+                return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
+                        .cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS).cachePublic())
+                        .location(URI.create(itemUrl))
+                        .build();
             } catch (NotFoundException exc) {
                 // Try the next registry
             }
         }
 
-        return new ModelAndView(null, HttpStatus.NOT_FOUND);
+        return ResponseEntity
+                .notFound()
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .build();
     }
 
     @GetMapping("/vscode/gallery/publishers/{namespaceName}/vsextensions/{extensionName}/{version}/vspackage")
@@ -243,7 +248,7 @@ public class VSCodeAPI {
             description = "The specified package could not be found",
             content = @Content()
     )
-    public ModelAndView download(
+    public ResponseEntity<String> download(
             @PathVariable @Parameter(description = "Extension namespace", example = "JFrog") String namespaceName,
             @PathVariable @Parameter(description = "Extension name", example = "jfrog-vscode-extension") String extensionName,
             @PathVariable @Parameter(description = "Extension version", example = "2.11.7") String version,
@@ -259,19 +264,24 @@ public class VSCodeAPI {
                             NAME_WEB, NAME_UNIVERSAL
                     })
             )
-            String targetPlatform,
-            ModelMap model
+            String targetPlatform
     ) {
         for (var service : getVSCodeServices()) {
             try {
                 var downloadUrl = service.download(namespaceName, extensionName, version, targetPlatform);
-                return new ModelAndView("redirect:" + downloadUrl, model);
+                return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
+                        .cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS).cachePublic())
+                        .location(URI.create(downloadUrl))
+                        .build();
             } catch (NotFoundException exc) {
                 // Try the next registry
             }
         }
 
-        return new ModelAndView(null, HttpStatus.NOT_FOUND);
+        return ResponseEntity
+                .notFound()
+                .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                .build();
     }
 
     @Observed
@@ -321,7 +331,11 @@ public class VSCodeAPI {
                     // Try the next registry
                 }
             }
-            return ResponseEntity.notFound().build();
+
+            return ResponseEntity
+                    .notFound()
+                    .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                    .build();
         } catch (ErrorResultException ex) {
             logger.error(ex.getMessage());
             return ResponseEntity.internalServerError().build();
@@ -358,7 +372,11 @@ public class VSCodeAPI {
                     // Try the next registry
                 }
             }
-            return ResponseEntity.notFound().build();
+
+            return ResponseEntity
+                    .notFound()
+                    .cacheControl(CacheControl.maxAge(10, TimeUnit.MINUTES).cachePublic().mustRevalidate())
+                    .build();
         } catch (ErrorResultException ex) {
             logger.error(ex.getMessage());
             return ResponseEntity.internalServerError().build();

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
@@ -29,6 +29,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import java.net.URI;
@@ -202,7 +203,7 @@ public class VSCodeAPI {
     ) {
         var dotIndex = itemName.indexOf('.');
         if (dotIndex < 0) {
-            return ResponseEntity.badRequest().body("Expecting an item of the form `{publisher}.{name}`");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Expecting an item of the form `{publisher}.{name}`");
         }
 
         var namespace = itemName.substring(0, dotIndex);


### PR DESCRIPTION
Previously, some endpoints did not include proper or inconsistent cache control headers.

This leads to the situation that responses can not be cached on the CDN level as it honors the cache control headers returned by the application.

This PR sets the cache control headers consistently for all public API endpoints:

 - set a consistent max-age for all endpoints which did not have it already
 - set max-age of 10m also for 404 responses and add mustRevalidate in such cases
 - the VSCode adapter api mostly just redirects to the regular api, add proper cache control there as well to let the CDN / reverse proxy properly cache the redirect to avoid duplicate requests

Currently for the majority of the endpoints we set 10min as max-age which is reasonable (changes will be reflected after max 10 min afaict), but this should be configurable.