### PR TITLE
Fix: correctly sort versions returned by latest endpoint in semantic order

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
@@ -316,7 +316,7 @@ public class LocalVSCodeService implements IVSCodeService {
                 .max(Comparator.comparing(ExtensionVersion::isPreRelease).reversed().thenComparing(ExtensionVersion::getTimestamp));
 
         var queryVersions = versions.stream()
-                .sorted(ExtensionVersion.SORT_COMPARATOR.reversed())
+                .sorted(ExtensionVersion.SORT_COMPARATOR)
                 .map(ev -> toQueryVersion(ev, fileResources, FLAG_INCLUDE_ASSET_URI | FLAG_INCLUDE_VERSION_PROPERTIES))
                 .toList();
 


### PR DESCRIPTION
The versions as returned by the `/vscode/.../latest` endpoint were not sorted as expected by VSCode, leading to situations where not the latest version was installed.

This fixes #1861.