### PR TITLE
Fix: repo location and yarn version in deployment descriptors

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -18,21 +18,21 @@ RUN apt-get update \
   && apt-get install -y nodejs \
   && apt-get clean \
   && corepack enable \
-  && corepack prepare yarn@stable --activate
+  && corepack prepare yarn@4.9.1 --activate
 
 ARG OPENVSX_VERSION
 ENV VERSION=$OPENVSX_VERSION
 
-RUN git clone --branch ${VERSION} --depth 1 https://github.com/eclipse/openvsx.git /workdir
+RUN git clone --branch ${VERSION} --depth 1 https://github.com/eclipse-openvsx/openvsx.git /workdir
 COPY ./configuration /workdir/configuration
 
-RUN /usr/bin/yarn --cwd webui \
-  && /usr/bin/yarn --cwd webui build \
-  && /usr/bin/yarn --cwd webui build:default
-
+RUN cd webui \
+  && yarn install --immutable \
+  && yarn build \
+  && yarn build:default
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse/openvsx-server:${OPENVSX_VERSION}
+FROM ghcr.io/eclipse-openvsx/openvsx-server:${OPENVSX_VERSION}
 ARG OPENVSX_VERSION
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/webui/static/ BOOT-INF/classes/static/

--- a/deploy/docker/build.sh
+++ b/deploy/docker/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-OPENVSX_VERSION=$(curl -sSL https://api.github.com/repos/eclipse/openvsx/releases/latest | jq -r ".tag_name")
+OPENVSX_VERSION=$(curl -sSL https://api.github.com/repos/eclipse-openvsx/openvsx/releases/latest | jq -r ".tag_name")
 export OPENVSX_VERSION
 
 sudo docker build -t "openvsx:$OPENVSX_VERSION" --build-arg "OPENVSX_VERSION=$OPENVSX_VERSION" .

--- a/deploy/openshift/openvsx.Dockerfile
+++ b/deploy/openshift/openvsx.Dockerfile
@@ -25,10 +25,10 @@ ENV VERSION=$OPENVSX_VERSION
 
 RUN git clone --branch ${VERSION} --depth 1 https://github.com/eclipse/openvsx.git /workdir
 
-RUN yarn --version \
-  && yarn --cwd webui \
-  && yarn --cwd webui install \
-  && yarn --cwd webui build:default
+RUN cd webui \
+  && yarn --version \
+  && yarn install --immutable \
+  && yarn build:default
 
 # Main image derived from openvsx-server
 FROM ghcr.io/eclipse-openvsx/openvsx-server:${OPENVSX_VERSION}


### PR DESCRIPTION
This fixes #1878 .

There were a couple of things wrong:

 - repo location was not updated, we do not want to rely on the GH redirect
 - run yarn explicitly in the subdir to ensure the supported yarn version is executed

I tested this locally and it should solve the issue.