### PR TITLE
Remove pull request CodeQL trigger

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,6 @@ name: "CodeQL Advanced"
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '21 1 * * 1'
 


### PR DESCRIPTION
Speaking with Thomas, the pull request triggers creates a lot of noise that doesn't produce value due to false positives. While we evaluate the tool for future use, we will leave it only enabled on branch pushes only.