### PR TITLE
fix: ensure sequential execution of database insert commands

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -234,9 +234,9 @@ commands:
           # Execute SQL inserts
           echo "⚙️ Inserting user and PAT into OpenVSX database..."
           kubectl exec -n "$OPENVSX_NAMESPACE" "$POSTGRESQL_POD_NAME" -- bash -c \
-            "psql -d openvsx -c \"INSERT INTO user_data (id, login_name, role) VALUES (1001, '$OPENVSX_USER_NAME', 'privileged');\""
+            "psql -d openvsx -c \"INSERT INTO user_data (id, login_name, role) VALUES (1001, '$OPENVSX_USER_NAME', 'privileged');\"" &&
           kubectl exec -n "$OPENVSX_NAMESPACE" "$POSTGRESQL_POD_NAME" -- bash -c \
-            "psql -d openvsx -c \"INSERT INTO personal_access_token (id, user_data, value, active, created_timestamp, accessed_timestamp, description, notified) VALUES (1001, 1001, '$OPENVSX_USER_PAT', true, current_timestamp, current_timestamp, 'extensions publisher', false);\""
+            "psql -d openvsx -c \"INSERT INTO personal_access_token (id, user_data, value, active, created_timestamp, accessed_timestamp, description, notified) VALUES (1001, 1001, '$OPENVSX_USER_PAT', true, current_timestamp, current_timestamp, 'extensions publisher', false);\"" &&
           echo "✅ OpenVSX user and token inserted successfully."
 
   - id: enable-internal-openvsx


### PR DESCRIPTION
Add `&&` operator between `kubectl exec` commands to ensure that `user_data` insert completes successfully before attempting to insert `personal_access_token`, and that the PAT insert completes before the success message is displayed.
<img width="597" height="307" alt="image" src="https://github.com/user-attachments/assets/78847114-71bd-424d-b015-d9c6f0ca2043" />

This fixes the https://redhat.atlassian.net/browse/CRW-10925 issue