### PR TITLE
chore(deps): pin opentelemetry version to 1.63.0

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -24,6 +24,7 @@ ext['junit-jupiter.version'] = libs.versions.junit.get()
 
 ext['postgresql.version'] = '42.7.11'
 ext['netty.version'] = '4.1.133.Final'
+ext['opentelemetry.version'] = '1.63.0'
 
 java {
     sourceCompatibility = libs.versions.java.get()


### PR DESCRIPTION
Pin OpenTelemetry to version 1.63.0 to address CVE-2026-45292.