### PR TITLE
Change: add check for unsafe paths to MaliciousZipCheckService

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/scanning/BlocklistCheckService.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/BlocklistCheckService.java
@@ -143,7 +143,6 @@ public class BlocklistCheckService implements PublishCheck {
 
             var hashableEntries = entries.stream()
                     .filter(entry -> !entry.isDirectory())
-                    .filter(entry -> ArchiveUtil.isSafePath(entry.getName()))
                     .toList();
 
             List<CompletableFuture<Void>> futures = new ArrayList<>(hashableEntries.size());

--- a/server/src/main/java/org/eclipse/openvsx/scanning/MaliciousZipCheckService.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/MaliciousZipCheckService.java
@@ -12,6 +12,7 @@
  ********************************************************************************/
 package org.eclipse.openvsx.scanning;
 
+import org.eclipse.openvsx.util.ArchiveUtil;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 
@@ -30,6 +31,8 @@ public class MaliciousZipCheckService implements PublishCheck {
     private static final String EXTRA_FIELDS_MESSAGE = "extension file contains zip entries with potentially harmful extra fields";
     private static final String DUPLICATE_ENTRIES_RULE = "DUPLICATE_NORMALIZED_ENTRIES";
     private static final String DUPLICATE_ENTRIES_MESSAGE = "extension file contains duplicate zip entries after path normalization";
+    private static final String UNSAFE_PATH_RULE = "UNSAFE_PATH_DETECTED";
+    private static final String UNSAFE_PATH_MESSAGE = "extension file contains zip entries with a suspicious path";
 
     @Override
     public String getCheckType() {
@@ -49,7 +52,7 @@ public class MaliciousZipCheckService implements PublishCheck {
     @Override
     public PublishCheck.Result check(Context context) {
         try (var zipFile = new ZipFile(context.extensionFile().getPath().toFile())) {
-            return checkForExtraFields(zipFile).and(checkForDuplicateEntries(zipFile));
+            return checkForExtraFields(zipFile).and(checkForDuplicateEntries(zipFile)).and(checkForUnsafePaths(zipFile));
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read extension zip file", e);
         }
@@ -77,6 +80,17 @@ public class MaliciousZipCheckService implements PublishCheck {
             var normalizedName = Path.of(name).normalize().toString().replaceAll("\\\\+", "/");
             if (!seen.add(normalizedName)) {
                 return PublishCheck.Result.fail(DUPLICATE_ENTRIES_RULE, DUPLICATE_ENTRIES_MESSAGE);
+            }
+        }
+        return PublishCheck.Result.pass();
+    }
+
+    private PublishCheck.Result checkForUnsafePaths(ZipFile zipFile) {
+        var entries = zipFile.entries();
+        while (entries.hasMoreElements()) {
+            var name = entries.nextElement().getName();
+            if (!ArchiveUtil.isSafePath(name)) {
+                return PublishCheck.Result.fail(UNSAFE_PATH_RULE, UNSAFE_PATH_MESSAGE);
             }
         }
         return PublishCheck.Result.pass();

--- a/server/src/main/java/org/eclipse/openvsx/scanning/SecretDetector.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/SecretDetector.java
@@ -115,10 +115,6 @@ class SecretDetector {
             return false;
         }
 
-        if (!ArchiveUtil.isSafePath(filePath)) {
-            return false;
-        }
-
         if (entry.getSize() < 0 && entry.getCompressedSize() < 0) {
             return false;
         }

--- a/server/src/main/java/org/eclipse/openvsx/util/ArchiveUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/ArchiveUtil.java
@@ -102,19 +102,52 @@ public final class ArchiveUtil {
     }
 
     /**
-     * Reject zip entries that attempt path traversal or absolute paths.
+     * Returns whether the given path is considered to be a safe path for a zip entry.
+     * <p>
+     * The following paths are not considered to be safe:
+     * <ul>
+     *     <li>paths containing a null byte</li>
+     *     <li>absolute paths</li>
+     *     <li>paths containing traversal patterns</li>
+     * </ul>
      */
     public static boolean isSafePath(String filePath) {
+        // 1. Null byte injection
+        if (filePath.contains("\0")) {
+            return false;
+        }
+
+        // 2. Absolute paths (Unix and Windows)
+        if (filePath.startsWith("/") || filePath.startsWith("\\")) {
+            return false;
+        }
+
+        // 3. Windows drive letters (e.g. C:\, D:/)
+        if (filePath.length() >= 2 && Character.isLetter(filePath.charAt(0)) && filePath.charAt(1) == ':') {
+            return false;
+        }
+
         try {
-            if (filePath.startsWith("/") || filePath.startsWith("\\")) {
+            // 4. Resolve and check confinement (catches ../, encoded, and Unicode tricks)
+            Path tmpDir = Path.of("/tmp");
+            Path resolved = tmpDir.resolve(filePath).normalize();
+            if (!resolved.startsWith(tmpDir)) {
                 return false;
             }
 
-            Path normalized = Paths.get(filePath).normalize();
+            Path entryPath = Path.of(filePath);
 
-            return !(normalized.isAbsolute() || normalized.startsWith("..") || normalized.toString().startsWith(".."));
+            // 5. Suspicious segments (defense-in-depth, catches obfuscated variants)
+            for (Path segment : entryPath) {
+                String seg = segment.toString();
+                if (seg.equals("..")) {
+                    return false;
+                }
+            }
         } catch (InvalidPathException e) {
             return false;
         }
+
+        return true;
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/util/ArchiveUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/ArchiveUtil.java
@@ -140,7 +140,7 @@ public final class ArchiveUtil {
             // 5. Suspicious segments (defense-in-depth, catches obfuscated variants)
             for (Path segment : entryPath) {
                 String seg = segment.toString();
-                if (seg.equals("..")) {
+                if (seg.equals("..") || seg.startsWith("..\\") || seg.startsWith("../")) {
                     return false;
                 }
             }

--- a/server/src/test/java/org/eclipse/openvsx/scanning/MaliciousZipCheckServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/scanning/MaliciousZipCheckServiceTest.java
@@ -125,8 +125,35 @@ class MaliciousZipCheckServiceTest {
         var result = service.check(createContext(extensionFile));
 
         assertFalse(result.passed());
-        assertEquals(1, result.failures().size());
+        assertEquals(2, result.failures().size());
         assertEquals("DUPLICATE_NORMALIZED_ENTRIES", result.failures().getFirst().ruleName());
+        assertEquals("UNSAFE_PATH_DETECTED", result.failures().getLast().ruleName());
+    }
+
+    // --- Unsafe paths checks ---
+
+    @Test
+    void check_failsWhenAbsolutePathIsFound() throws Exception {
+        TempFile extensionFile = createZipWithEntries("extra.vsix", "/etc/passwd");
+
+        var result = service.check(createContext(extensionFile));
+
+        assertFalse(result.passed());
+        assertEquals(1, result.failures().size());
+        assertEquals("UNSAFE_PATH_DETECTED", result.failures().getFirst().ruleName());
+        assertTrue(result.failures().getFirst().reason().contains("extension file contains zip entries with a suspicious path"));
+    }
+
+    @Test
+    void check_failsWhenPathTraversalIsFound() throws Exception {
+        TempFile extensionFile = createZipWithEntries("extra.vsix", "abc/../../test.txt");
+
+        var result = service.check(createContext(extensionFile));
+
+        assertFalse(result.passed());
+        assertEquals(1, result.failures().size());
+        assertEquals("UNSAFE_PATH_DETECTED", result.failures().getFirst().ruleName());
+        assertTrue(result.failures().getFirst().reason().contains("extension file contains zip entries with a suspicious path"));
     }
 
     // --- Helper methods ---

--- a/server/src/test/java/org/eclipse/openvsx/scanning/SecretDetectorServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/scanning/SecretDetectorServiceTest.java
@@ -53,17 +53,6 @@ class SecretDetectorServiceTest {
     }
 
     @Test
-    void isSafePath_rejectsTraversalAndAbsolute() {
-        assertFalse(ArchiveUtil.isSafePath("../evil"));
-        assertFalse(ArchiveUtil.isSafePath("/abs/path"));
-    }
-
-    @Test
-    void isSafePath_allowsNormalRelative() {
-        assertTrue(ArchiveUtil.isSafePath("folder/file.txt"));
-    }
-
-    @Test
     void recordFinding_respectsGlobalCap() throws Exception {
         SecretCheckService service = buildServiceWithLimits(10, 100, 1);
         List<SecretDetector.Finding> findings = new ArrayList<>();

--- a/server/src/test/java/org/eclipse/openvsx/util/ArchiveUtilTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/util/ArchiveUtilTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 class ArchiveUtilTest {
 
     @Test
-    public void testTodoTree() throws Exception {
+    void testTodoTree() throws Exception {
         var packageUrl = getClass().getResource("todo-tree.zip");
 
         assertThat(packageUrl).isNotNull();
@@ -39,7 +39,7 @@ class ArchiveUtilTest {
     }
 
     @Test
-    public void testExceedMaxEntrySize() throws IOException {
+    void testExceedMaxEntrySize() throws IOException {
         // an artificially crafted zip file with a file whose size is set lower as its actual content
         var packageUrl = getClass().getResource("wrong-size.zip");
 
@@ -58,7 +58,7 @@ class ArchiveUtilTest {
     }
 
     @Test
-    public void testSafePath() {
+    void testSafePath() {
         // restricted path patterns
         assertThat(ArchiveUtil.isSafePath("\0")).isEqualTo(false);
         assertThat(ArchiveUtil.isSafePath("abc\0")).isEqualTo(false);
@@ -68,6 +68,7 @@ class ArchiveUtilTest {
         assertThat(ArchiveUtil.isSafePath("../test.xt")).isEqualTo(false);
         assertThat(ArchiveUtil.isSafePath("abc/../test.txt")).isEqualTo(false);
         assertThat(ArchiveUtil.isSafePath("abc/def/./../test.txt")).isEqualTo(false);
+        assertThat(ArchiveUtil.isSafePath("..\\test.xt")).isEqualTo(false);
 
         // allowed path patterns
         assertThat(ArchiveUtil.isSafePath(".test.txt")).isEqualTo(true);

--- a/server/src/test/java/org/eclipse/openvsx/util/ArchiveUtilTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/util/ArchiveUtilTest.java
@@ -10,7 +10,6 @@
 package org.eclipse.openvsx.util;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.api.InstanceOfAssertFactories.PATH;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -21,7 +20,7 @@ import org.junit.jupiter.api.Test;
 class ArchiveUtilTest {
 
     @Test
-    void testTodoTree() throws Exception {
+    public void testTodoTree() throws Exception {
         var packageUrl = getClass().getResource("todo-tree.zip");
 
         assertThat(packageUrl).isNotNull();
@@ -40,7 +39,7 @@ class ArchiveUtilTest {
     }
 
     @Test
-    void testExceedMaxEntrySize() throws IOException {
+    public void testExceedMaxEntrySize() throws IOException {
         // an artificially crafted zip file with a file whose size is set lower as its actual content
         var packageUrl = getClass().getResource("wrong-size.zip");
 
@@ -56,5 +55,22 @@ class ArchiveUtilTest {
                     .isExactlyInstanceOf(ErrorResultException.class)
                     .hasMessageContaining("Failed to read extension/package.json: File size exceeds limit of 0 bytes.");
         }
+    }
+
+    @Test
+    public void testSafePath() {
+        // restricted path patterns
+        assertThat(ArchiveUtil.isSafePath("\0")).isEqualTo(false);
+        assertThat(ArchiveUtil.isSafePath("abc\0")).isEqualTo(false);
+        assertThat(ArchiveUtil.isSafePath("/test.txt")).isEqualTo(false);
+        assertThat(ArchiveUtil.isSafePath("c:\\test.txt")).isEqualTo(false);
+        assertThat(ArchiveUtil.isSafePath("..")).isEqualTo(false);
+        assertThat(ArchiveUtil.isSafePath("../test.xt")).isEqualTo(false);
+        assertThat(ArchiveUtil.isSafePath("abc/../test.txt")).isEqualTo(false);
+        assertThat(ArchiveUtil.isSafePath("abc/def/./../test.txt")).isEqualTo(false);
+
+        // allowed path patterns
+        assertThat(ArchiveUtil.isSafePath(".test.txt")).isEqualTo(true);
+        assertThat(ArchiveUtil.isSafePath("..test.txt")).isEqualTo(true);
     }
 }


### PR DESCRIPTION
This PR adds an additional check to the `MaliciousZipCheckService` for potentially unsafe entry names.

Any extension containing entries with such names are rejected immediately.
As a consequence, the `ArchiveUtil.isSafePath` is not called anymore from the `SecretCheckService` and `BlocklistCheckService` as they will only operate on extensions that are considered to be safe.

The `ArchiveUtil.isSafePath` method has also been further extended for additional unsafe patterns, accompanied by unit tests/