### PR TITLE
Fix: add consistent and strict http headers when serving files inside extensions

### DIFF
--- a/server/gradle/libs.versions.toml
+++ b/server/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ rewrite-java    = "3.26.0"
 spring-boot     = "3.5.14"
 springdoc       = "2.8.13"
 testcontainers  = "1.21.4"
-tika            = "3.2.2"
+tika            = "3.3.1"
 woodstox        = "6.4.0"
 
 [plugins]

--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -233,7 +233,7 @@ public class LocalRegistryService implements IExtensionRegistry {
         return storageUtil.getFileResponse(resource);
     }
 
-    public boolean isType (String fileName){
+    public boolean isType(String fileName) {
         var expectedTypes = new ArrayList<>(List.of(MANIFEST, README, LICENSE, ICON, DOWNLOAD, DOWNLOAD_SHA256, CHANGELOG, VSIXMANIFEST));
         if(integrityService.isEnabled()) {
             expectedTypes.add(DOWNLOAD_SIG);

--- a/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
@@ -809,7 +809,7 @@ public class RegistryAPI {
         result.setExtensions(resultExtensions);
         return ResponseEntity.ok()
                 // do not cache to avoid stale data, elasticsearch in general is fast
-                .cacheControl(CacheControl.noCache().cachePublic().mustRevalidate())
+                .cacheControl(CacheControl.noCache().cachePublic())
                 .body(result);
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
@@ -61,7 +61,17 @@ public class LocalVSCodeService implements IVSCodeService {
     private final ExtensionVersionIntegrityService integrityService;
     private final WebResourceService webResources;
     private final CacheService cache;
-    private final Map<String, String> assets;
+
+    private final Map<String, String> assets = Map.of(
+            FILE_VSIX, DOWNLOAD,
+            FILE_MANIFEST, MANIFEST,
+            FILE_DETAILS, README,
+            FILE_CHANGELOG, CHANGELOG,
+            FILE_LICENSE, LICENSE,
+            FILE_ICON, ICON,
+            FILE_VSIXMANIFEST, VSIXMANIFEST,
+            FILE_SIGNATURE, DOWNLOAD_SIG
+    );
 
     @Value("${ovsx.webui.url:}")
     String webuiUrl;
@@ -82,17 +92,6 @@ public class LocalVSCodeService implements IVSCodeService {
         this.integrityService = integrityService;
         this.webResources = webResources;
         this.cache = cache;
-
-        this.assets = Map.of(
-                FILE_VSIX, DOWNLOAD,
-                FILE_MANIFEST, MANIFEST,
-                FILE_DETAILS, README,
-                FILE_CHANGELOG, CHANGELOG,
-                FILE_LICENSE, LICENSE,
-                FILE_ICON, ICON,
-                FILE_VSIXMANIFEST, VSIXMANIFEST,
-                FILE_SIGNATURE, DOWNLOAD_SIG
-        );
     }
 
     @Override

--- a/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
@@ -61,6 +61,7 @@ public class LocalVSCodeService implements IVSCodeService {
     private final ExtensionVersionIntegrityService integrityService;
     private final WebResourceService webResources;
     private final CacheService cache;
+    private final Map<String, String> assets;
 
     @Value("${ovsx.webui.url:}")
     String webuiUrl;
@@ -81,6 +82,17 @@ public class LocalVSCodeService implements IVSCodeService {
         this.integrityService = integrityService;
         this.webResources = webResources;
         this.cache = cache;
+
+        this.assets = Map.of(
+                FILE_VSIX, DOWNLOAD,
+                FILE_MANIFEST, MANIFEST,
+                FILE_DETAILS, README,
+                FILE_CHANGELOG, CHANGELOG,
+                FILE_LICENSE, LICENSE,
+                FILE_ICON, ICON,
+                FILE_VSIXMANIFEST, VSIXMANIFEST,
+                FILE_SIGNATURE, DOWNLOAD_SIG
+        );
     }
 
     @Override
@@ -349,17 +361,6 @@ public class LocalVSCodeService implements IVSCodeService {
                         .build();
             }
         }
-
-        var assets = Map.of(
-                FILE_VSIX, DOWNLOAD,
-                FILE_MANIFEST, MANIFEST,
-                FILE_DETAILS, README,
-                FILE_CHANGELOG, CHANGELOG,
-                FILE_LICENSE, LICENSE,
-                FILE_ICON, ICON,
-                FILE_VSIXMANIFEST, VSIXMANIFEST,
-                FILE_SIGNATURE, DOWNLOAD_SIG
-        );
 
         var type = assets.get(assetType);
         if (type != null) {

--- a/server/src/main/java/org/eclipse/openvsx/adapter/UpstreamVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/UpstreamVSCodeService.java
@@ -171,7 +171,7 @@ public class UpstreamVSCodeService implements IVSCodeService {
                     var mapper = new ObjectMapper();
                     var json = proxy.rewriteUrls(mapper.readTree(response.getBody()));
                     return ResponseEntity.status(statusCode)
-                            .headers(HttpHeadersUtil.getJsonFileResponseHeaders())
+                            .headers(HttpHeadersUtil.createJsonFileResponseHeaders())
                             .body(outputStream -> mapper.writeValue(outputStream, json));
                 } else {
                     return streamResponse(response, org.springframework.util.StringUtils.getFilename(path), "browse");
@@ -349,7 +349,7 @@ public class UpstreamVSCodeService implements IVSCodeService {
                 response.getBody().transferTo(out);
             }
 
-            var headers = HttpHeadersUtil.getFileResponseHeaders(tempFile.getPath(), fileName);
+            var headers = HttpHeadersUtil.createFileResponseHeaders(tempFile.getPath(), fileName);
 
             return ResponseEntity.status(response.getStatusCode())
                     .headers(headers)

--- a/server/src/main/java/org/eclipse/openvsx/adapter/UpstreamVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/UpstreamVSCodeService.java
@@ -10,6 +10,7 @@
 package org.eclipse.openvsx.adapter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nullable;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.openvsx.ExtensionValidator;
@@ -157,28 +158,23 @@ public class UpstreamVSCodeService implements IVSCodeService {
             @Override
             public ResponseEntity<StreamingResponseBody> extractData(ClientHttpResponse response) throws IOException {
                 var statusCode = response.getStatusCode();
-                if(statusCode.isError() && statusCode != HttpStatus.NOT_FOUND) {
+                if (statusCode.isError() && statusCode != HttpStatus.NOT_FOUND) {
                     handleResponseError(urlTemplate, uriVariables, response);
                 }
 
                 var failed = !statusCode.is2xxSuccessful() && !statusCode.is3xxRedirection();
-                if(failed) {
+                if (failed) {
                     throw new NotFoundException();
                 }
 
-                var headers = new HttpHeaders();
-                headers.addAll(response.getHeaders());
-                headers.remove(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN);
-                headers.remove(HttpHeaders.VARY);
-
-                if (proxy != null && MediaType.APPLICATION_JSON.equals(headers.getContentType())) {
+                if (proxy != null && MediaType.APPLICATION_JSON.equals(response.getHeaders().getContentType())) {
                     var mapper = new ObjectMapper();
                     var json = proxy.rewriteUrls(mapper.readTree(response.getBody()));
                     return ResponseEntity.status(statusCode)
-                            .headers(headers)
+                            .headers(HttpHeadersUtil.getJsonFileResponseHeaders())
                             .body(outputStream -> mapper.writeValue(outputStream, json));
                 } else {
-                    return streamResponse(response, headers, "browse");
+                    return streamResponse(response, org.springframework.util.StringUtils.getFilename(path), "browse");
                 }
             }
         };
@@ -306,12 +302,8 @@ public class UpstreamVSCodeService implements IVSCodeService {
                     throw new NotFoundException();
                 }
 
-                var headers = new HttpHeaders();
-                headers.addAll(response.getHeaders());
-                headers.remove(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN);
-                headers.remove(HttpHeaders.VARY);
-
-                return streamResponse(response, headers, "asset");
+                // we cant safely know the filename of the asset, so just pass null
+                return streamResponse(response, null, "asset");
             }
         };
 
@@ -348,7 +340,7 @@ public class UpstreamVSCodeService implements IVSCodeService {
 
     private ResponseEntity<StreamingResponseBody> streamResponse(
             ClientHttpResponse response,
-            HttpHeaders headers,
+            @Nullable String fileName,
             String prefix
     ) throws IOException {
         var tempFile = new TempFile(prefix, null);
@@ -356,6 +348,8 @@ public class UpstreamVSCodeService implements IVSCodeService {
             try (var out = Files.newOutputStream(tempFile.getPath())) {
                 response.getBody().transferTo(out);
             }
+
+            var headers = HttpHeadersUtil.getFileResponseHeaders(tempFile.getPath(), fileName);
 
             return ResponseEntity.status(response.getStatusCode())
                     .headers(headers)

--- a/server/src/main/java/org/eclipse/openvsx/security/SecurityConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/security/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
                 .csrf(configurer -> configurer.ignoringRequestMatchers(pathMatchers("/api/-/publish", "/api/-/namespace/create", "/api/-/query", "/vscode/**", "/admin/api/**")))
                 .exceptionHandling(configurer -> configurer.authenticationEntryPoint(new Http403ForbiddenEntryPoint()));
 
-        if(userServices.canLogin()) {
+        if (userServices.canLogin()) {
             var redirectUrl = StringUtils.isEmpty(webuiUrl) ? "/" : webuiUrl;
             filterChain.oauth2Login(configurer -> {
                 configurer.defaultSuccessUrl(redirectUrl);

--- a/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
@@ -214,7 +214,7 @@ public class AwsStorageService implements IStorageService {
     }
 
     protected void uploadFile(TempFile file, String fileName, String objectKey) {
-        var headers = HttpHeadersUtil.getFileResponseHeaders(file.getPath(), fileName);
+        var headers = HttpHeadersUtil.createFileResponseHeaders(file.getPath(), fileName);
 
         var requestBuilder = PutObjectRequest.builder()
                 .bucket(bucket)

--- a/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
@@ -16,6 +16,7 @@ import org.eclipse.openvsx.cache.FilesCacheKeyGenerator;
 import org.eclipse.openvsx.entities.FileResource;
 import org.eclipse.openvsx.entities.Namespace;
 import org.eclipse.openvsx.util.FileUtil;
+import org.eclipse.openvsx.util.HttpHeadersUtil;
 import org.eclipse.openvsx.util.TempFile;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
@@ -44,7 +45,6 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.HashMap;
 import java.util.List;
 
 import static org.eclipse.openvsx.cache.CacheService.CACHE_EXTENSION_FILES;
@@ -214,21 +214,23 @@ public class AwsStorageService implements IStorageService {
     }
 
     protected void uploadFile(TempFile file, String fileName, String objectKey) {
-        var metadata = new HashMap<String, String>();
-        metadata.put("Content-Type", StorageUtil.getFileType(fileName).toString());
-        if (fileName.endsWith(".vsix")) {
-            metadata.put("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
-        } else {
-            metadata.put("Cache-Control", StorageUtil.getCacheControl(fileName).getHeaderValue());
+        var headers = HttpHeadersUtil.getFileResponseHeaders(file.getPath(), fileName);
+
+        var requestBuilder = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectKey);
+
+        if (headers.getContentType() != null) {
+            requestBuilder.contentType(headers.getContentType().toString());
         }
 
-        var request = PutObjectRequest.builder()
-                .bucket(bucket)
-                .key(objectKey)
-                .metadata(metadata)
-                .build();
+        requestBuilder.contentDisposition(headers.getContentDisposition().toString());
 
-        getS3Client().putObject(request, file.getPath());
+        if (headers.getCacheControl() != null) {
+            requestBuilder.cacheControl(headers.getCacheControl());
+        }
+
+        getS3Client().putObject(requestBuilder.build(), file.getPath());
     }
 
     @Override

--- a/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
@@ -45,6 +45,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.eclipse.openvsx.cache.CacheService.CACHE_EXTENSION_FILES;
@@ -216,21 +217,27 @@ public class AwsStorageService implements IStorageService {
     protected void uploadFile(TempFile file, String fileName, String objectKey) {
         var headers = HttpHeadersUtil.createFileResponseHeaders(file.getPath(), fileName);
 
-        var requestBuilder = PutObjectRequest.builder()
-                .bucket(bucket)
-                .key(objectKey);
-
+        // see https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html
+        var metadata = new HashMap<String, String>();
         if (headers.getContentType() != null) {
-            requestBuilder.contentType(headers.getContentType().toString());
+            metadata.put("Content-Type", headers.getContentType().toString());
         }
 
-        requestBuilder.contentDisposition(headers.getContentDisposition().toString());
+        if (StringUtils.isNotBlank(headers.getContentDisposition().toString())) {
+            metadata.put("Content-Disposition", headers.getContentDisposition().toString());
+        }
 
         if (headers.getCacheControl() != null) {
-            requestBuilder.cacheControl(headers.getCacheControl());
+            metadata.put("Cache-Control", headers.getCacheControl());
         }
 
-        getS3Client().putObject(requestBuilder.build(), file.getPath());
+        var request = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectKey)
+                .metadata(metadata)
+                .build();
+
+        getS3Client().putObject(request, file.getPath());
     }
 
     @Override

--- a/server/src/main/java/org/eclipse/openvsx/storage/AzureBlobStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AzureBlobStorageService.java
@@ -107,7 +107,7 @@ public class AzureBlobStorageService implements IStorageService {
             throw new IllegalStateException(missingEndpointMessage("Cannot upload file", blobName));
         }
 
-        var headers = HttpHeadersUtil.getFileResponseHeaders(file.getPath(), fileName);
+        var headers = HttpHeadersUtil.createFileResponseHeaders(file.getPath(), fileName);
 
         var blobClient = getContainerClient().getBlobClient(blobName);
         var blobHeaders = new BlobHttpHeaders();

--- a/server/src/main/java/org/eclipse/openvsx/storage/AzureBlobStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AzureBlobStorageService.java
@@ -116,7 +116,9 @@ public class AzureBlobStorageService implements IStorageService {
             blobHeaders.setContentType(headers.getContentType().toString());
         }
 
-        blobHeaders.setContentDisposition(headers.getContentDisposition().toString());
+        if (StringUtils.isNotBlank(headers.getContentDisposition().toString())) {
+            blobHeaders.setContentDisposition(headers.getContentDisposition().toString());
+        }
 
         if (headers.getCacheControl() != null) {
             blobHeaders.setCacheControl(headers.getCacheControl());

--- a/server/src/main/java/org/eclipse/openvsx/storage/AzureBlobStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AzureBlobStorageService.java
@@ -22,6 +22,7 @@ import org.eclipse.openvsx.cache.FilesCacheKeyGenerator;
 import org.eclipse.openvsx.entities.FileResource;
 import org.eclipse.openvsx.entities.Namespace;
 import org.eclipse.openvsx.util.FileUtil;
+import org.eclipse.openvsx.util.HttpHeadersUtil;
 import org.eclipse.openvsx.util.TempFile;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
@@ -106,18 +107,23 @@ public class AzureBlobStorageService implements IStorageService {
             throw new IllegalStateException(missingEndpointMessage("Cannot upload file", blobName));
         }
 
+        var headers = HttpHeadersUtil.getFileResponseHeaders(file.getPath(), fileName);
+
         var blobClient = getContainerClient().getBlobClient(blobName);
-        var headers = new BlobHttpHeaders();
-        headers.setContentType(StorageUtil.getFileType(fileName).toString());
-        if (fileName.endsWith(".vsix") || fileName.endsWith(".sigzip")) {
-            headers.setContentDisposition("attachment; filename=\"" + fileName + "\"");
-        } else {
-            var cacheControl = StorageUtil.getCacheControl(fileName);
-            headers.setCacheControl(cacheControl.getHeaderValue());
+        var blobHeaders = new BlobHttpHeaders();
+
+        if (headers.getContentType() != null) {
+            blobHeaders.setContentType(headers.getContentType().toString());
+        }
+
+        blobHeaders.setContentDisposition(headers.getContentDisposition().toString());
+
+        if (headers.getCacheControl() != null) {
+            blobHeaders.setCacheControl(headers.getCacheControl());
         }
 
         blobClient.uploadFromFile(file.getPath().toAbsolutePath().toString(), true);
-        blobClient.setHttpHeaders(headers);
+        blobClient.setHttpHeaders(blobHeaders);
     }
 
 	@Override

--- a/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
@@ -102,7 +102,9 @@ public class GoogleCloudStorageService implements IStorageService {
             blobInfoBuilder.setContentType(headers.getContentType().toString());
         }
 
-        blobInfoBuilder.setContentDisposition(headers.getContentDisposition().toString());
+        if (StringUtils.isNotBlank(headers.getContentDisposition().toString())) {
+            blobInfoBuilder.setContentDisposition(headers.getContentDisposition().toString());
+        }
 
         if (headers.getCacheControl() != null) {
             blobInfoBuilder.setCacheControl(headers.getCacheControl());

--- a/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
@@ -15,6 +15,7 @@ import org.eclipse.openvsx.cache.FilesCacheKeyGenerator;
 import org.eclipse.openvsx.entities.FileResource;
 import org.eclipse.openvsx.entities.Namespace;
 import org.eclipse.openvsx.util.FileUtil;
+import org.eclipse.openvsx.util.HttpHeadersUtil;
 import org.eclipse.openvsx.util.TempFile;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
@@ -94,14 +95,19 @@ public class GoogleCloudStorageService implements IStorageService {
     }
 
     protected void uploadFile(TempFile file, String fileName, String objectId) {
-        var blobInfoBuilder = BlobInfo.newBuilder(BlobId.of(bucketId, objectId))
-                .setContentType(StorageUtil.getFileType(fileName).toString());
-        if (fileName.endsWith(".vsix") || fileName.endsWith(".sigzip")) {
-            blobInfoBuilder.setContentDisposition("attachment; filename=\"" + fileName + "\"");
-        } else {
-            var cacheControl = StorageUtil.getCacheControl(fileName);
-            blobInfoBuilder.setCacheControl(cacheControl.getHeaderValue());
+        var headers = HttpHeadersUtil.getFileResponseHeaders(file.getPath(), fileName);
+        var blobInfoBuilder = BlobInfo.newBuilder(BlobId.of(bucketId, objectId));
+
+        if (headers.getContentType() != null) {
+            blobInfoBuilder.setContentType(headers.getContentType().toString());
         }
+
+        blobInfoBuilder.setContentDisposition(headers.getContentDisposition().toString());
+
+        if (headers.getCacheControl() != null) {
+            blobInfoBuilder.setCacheControl(headers.getCacheControl());
+        }
+
         try (
                 var in = Files.newByteChannel(file.getPath());
                 var out = getStorage().writer(blobInfoBuilder.build())

--- a/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
@@ -95,7 +95,7 @@ public class GoogleCloudStorageService implements IStorageService {
     }
 
     protected void uploadFile(TempFile file, String fileName, String objectId) {
-        var headers = HttpHeadersUtil.getFileResponseHeaders(file.getPath(), fileName);
+        var headers = HttpHeadersUtil.createFileResponseHeaders(file.getPath(), fileName);
         var blobInfoBuilder = BlobInfo.newBuilder(BlobId.of(bucketId, objectId));
 
         if (headers.getContentType() != null) {

--- a/server/src/main/java/org/eclipse/openvsx/storage/LocalStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/LocalStorageService.java
@@ -22,11 +22,11 @@ import jakarta.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.openvsx.entities.FileResource;
 import org.eclipse.openvsx.entities.Namespace;
+import org.eclipse.openvsx.util.HttpHeadersUtil;
 import org.eclipse.openvsx.util.TempFile;
 import org.eclipse.openvsx.util.UrlUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.util.Pair;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerErrorException;
@@ -87,11 +87,10 @@ public class LocalStorageService implements IStorageService {
     }
 
     public ResponseEntity<StreamingResponseBody> getFile(FileResource resource) {
-        var headers = getFileResponseHeaders(resource.getName());
+        var path = getPath(resource);
         return ResponseEntity.ok()
-                .headers(headers)
+                .headers(HttpHeadersUtil.getFileResponseHeaders(path))
                 .body(outputStream -> {
-                    var path = getPath(resource);
                     try (var in = Files.newInputStream(path)) {
                         in.transferTo(outputStream);
                     }
@@ -104,14 +103,15 @@ public class LocalStorageService implements IStorageService {
     }
 
     public ResponseEntity<StreamingResponseBody> getNamespaceLogo(Namespace namespace) {
-        if(!isEnabled()) {
+        if (!isEnabled()) {
             throw new IllegalStateException("Cannot determine location of logo. Configure the 'ovsx.storage.local.directory' property.");
         }
 
+        var path = getLogoPath(namespace);
+
         return ResponseEntity.ok()
-                .headers(getFileResponseHeaders(namespace.getLogoName()))
+                .headers(HttpHeadersUtil.getFileResponseHeaders(path))
                 .body(outputStream -> {
-                    var path = getLogoPath(namespace);
                     try (var in = Files.newInputStream(path)) {
                         in.transferTo(outputStream);
                     }
@@ -119,17 +119,6 @@ public class LocalStorageService implements IStorageService {
     }
     public URI getNamespaceLogoLocation(Namespace namespace) {
         return URI.create(UrlUtil.createApiUrl(UrlUtil.getBaseUrl(), "api", namespace.getName(), "logo", namespace.getLogoName()));
-    }
-
-    private HttpHeaders getFileResponseHeaders(String fileName) {
-        var headers = new HttpHeaders();
-        headers.setContentType(StorageUtil.getFileType(fileName));
-        if (fileName.endsWith(".vsix")) {
-            headers.add("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
-        } else {
-            headers.setCacheControl(StorageUtil.getCacheControl(fileName));
-        }
-        return headers;
     }
 
     @Override
@@ -182,7 +171,7 @@ public class LocalStorageService implements IStorageService {
     }
 
     private Path getPath(FileResource resource) {
-        if(!isEnabled()) {
+        if (!isEnabled()) {
             throw new IllegalStateException("Cannot determine location of file. Configure the 'ovsx.storage.local.directory' property.");
         }
 
@@ -190,7 +179,7 @@ public class LocalStorageService implements IStorageService {
         var extension = extVersion.getExtension();
         var namespace = extension.getNamespace();
         var segments = new ArrayList<>(List.of(storageDirectory, namespace.getName(), extension.getName()));
-        if(!extVersion.isUniversalTargetPlatform()) {
+        if (!extVersion.isUniversalTargetPlatform()) {
             segments.add(extVersion.getTargetPlatform());
         }
 
@@ -201,7 +190,7 @@ public class LocalStorageService implements IStorageService {
     }
 
     private Path getLogoPath(Namespace namespace) {
-        if(!isEnabled()) {
+        if (!isEnabled()) {
             throw new IllegalStateException("Cannot determine location of logo. Configure the 'ovsx.storage.local.directory' property.");
         }
 

--- a/server/src/main/java/org/eclipse/openvsx/storage/LocalStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/LocalStorageService.java
@@ -89,7 +89,7 @@ public class LocalStorageService implements IStorageService {
     public ResponseEntity<StreamingResponseBody> getFile(FileResource resource) {
         var path = getPath(resource);
         return ResponseEntity.ok()
-                .headers(HttpHeadersUtil.getFileResponseHeaders(path))
+                .headers(HttpHeadersUtil.createFileResponseHeaders(path))
                 .body(outputStream -> {
                     try (var in = Files.newInputStream(path)) {
                         in.transferTo(outputStream);
@@ -110,7 +110,7 @@ public class LocalStorageService implements IStorageService {
         var path = getLogoPath(namespace);
 
         return ResponseEntity.ok()
-                .headers(HttpHeadersUtil.getFileResponseHeaders(path))
+                .headers(HttpHeadersUtil.createFileResponseHeaders(path))
                 .body(outputStream -> {
                     try (var in = Files.newInputStream(path)) {
                         in.transferTo(outputStream);

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageUtil.java
@@ -7,34 +7,22 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  * ****************************************************************************** */
-
 package org.eclipse.openvsx.storage;
 
-import org.springframework.http.CacheControl;
-import org.springframework.http.MediaType;
+import org.springframework.http.*;
 
-import java.net.URLConnection;
 import java.util.concurrent.TimeUnit;
 
-class StorageUtil {
+public class StorageUtil {
 
-    private StorageUtil(){}
+    private StorageUtil() {}
 
-    static MediaType getFileType(String fileName) {
-        if (fileName.endsWith(".vsix"))
-            return MediaType.APPLICATION_OCTET_STREAM;
-        if (fileName.endsWith(".json"))
-            return MediaType.APPLICATION_JSON;
-        if (fileName.endsWith(".sigzip"))
-            return MediaType.valueOf("application/zip");
-        var contentType = URLConnection.guessContentTypeFromName(fileName);
-        if (contentType != null)
-            return MediaType.parseMediaType(contentType);
-        return MediaType.TEXT_PLAIN;
-    }
-
-    static CacheControl getCacheControl(String fileName) {
-        // Files are requested with a version string in the URL, so their content cannot change
-        return CacheControl.maxAge(30, TimeUnit.DAYS).cachePublic();
+    public static CacheControl getCacheControl(String fileName) {
+        // Files are requested with a version string in the URL, so their content does not change.
+        // As extension versions might get deleted, cache for max 1 day and force client to revalidate
+        // TODO: this is subject to change, it used to be 30 days, reduced to 1 day to prevent stale cache
+        //       entries if a CDN is configured in case extensions are deleted.
+        //       we need a mechanism to invalidate CDN caches
+        return CacheControl.maxAge(1, TimeUnit.DAYS).cachePublic().mustRevalidate();
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
@@ -23,6 +23,7 @@ import org.eclipse.openvsx.metrics.ExtensionDownloadMetrics;
 import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.search.SearchUtilService;
 import org.eclipse.openvsx.storage.log.DownloadCountService;
+import org.eclipse.openvsx.util.HttpHeadersUtil;
 import org.eclipse.openvsx.util.TempFile;
 import org.eclipse.openvsx.util.UrlUtil;
 import org.springframework.beans.factory.annotation.Value;
@@ -312,10 +313,7 @@ public class StorageUtilService implements IStorageService {
     }
 
     public ResponseEntity<StreamingResponseBody> getFileResponse(Path path) {
-        var fileName = path.getFileName().toString();
-        var headers = new HttpHeaders();
-        headers.setContentType(StorageUtil.getFileType(fileName));
-        headers.setCacheControl(StorageUtil.getCacheControl(fileName));
+        var headers = HttpHeadersUtil.getFileResponseHeaders(path);
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(outputStream -> {
@@ -327,14 +325,13 @@ public class StorageUtilService implements IStorageService {
 
     public ResponseEntity<StreamingResponseBody> getFileResponse(ArrayNode node) {
         var baseUrl = UrlUtil.getBaseUrl();
-        var headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
+        var headers = HttpHeadersUtil.getJsonFileResponseHeaders();
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(outputStream -> {
                     var mapper = new ObjectMapper();
                     var value = mapper.createArrayNode();
-                    for(var item : node) {
+                    for (var item : node) {
                         value.add(baseUrl + item.asText());
                     }
                     mapper.writeValue(outputStream, value);

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
@@ -313,7 +313,7 @@ public class StorageUtilService implements IStorageService {
     }
 
     public ResponseEntity<StreamingResponseBody> getFileResponse(Path path) {
-        var headers = HttpHeadersUtil.getFileResponseHeaders(path);
+        var headers = HttpHeadersUtil.createFileResponseHeaders(path);
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(outputStream -> {
@@ -325,7 +325,7 @@ public class StorageUtilService implements IStorageService {
 
     public ResponseEntity<StreamingResponseBody> getFileResponse(ArrayNode node) {
         var baseUrl = UrlUtil.getBaseUrl();
-        var headers = HttpHeadersUtil.getJsonFileResponseHeaders();
+        var headers = HttpHeadersUtil.createJsonFileResponseHeaders();
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(outputStream -> {

--- a/server/src/main/java/org/eclipse/openvsx/util/HttpHeadersUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/HttpHeadersUtil.java
@@ -1,15 +1,63 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
 package org.eclipse.openvsx.util;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.apache.tika.Tika;
+import org.eclipse.openvsx.storage.StorageUtil;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 
 public class HttpHeadersUtil {
-    private HttpHeadersUtil() {
-    }
+    private static final MediaType APPLICATION_ZIP = MediaType.valueOf("application/zip");
+    private static final MediaType TEXT_PLAIN_UTF8 = new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8);
+
+    private static final Tika tika = new Tika();
+
+    private static final int MAX_FILENAME_LENGTH = 255;
+
+    // Characters explicitly dangerous in Content-Disposition or HTTP headers
+    private static final Set<Character> FORBIDDEN_CHARS = Set.of(
+            '/', '\\', ':', '*', '?', '"', '<', '>', '|', // filesystem/shell
+            '\r', '\n', '\0',                              // header injection
+            ';', ',', '='                                  // header parameter delimiters
+    );
+
+    private static final Set<String> TEXT_VIEWABLE_MEDIA_TYPES = Set.of(
+            "text/plain", "text/html", "text/markdown", "text/css", "text/javascript"
+    );
+
+    private static final Set<String> PASSTHROUGH_MEDIA_TYPES = Set.of(
+            "application/json", "application/xml"
+    );
+
+    public static final String CSP_PREVENT_ALL =
+            "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; sandbox";
+
+    private HttpHeadersUtil() {}
 
     public static HttpHeaders getForwardedHeaders() {
         var headers = new HttpHeaders();
@@ -32,5 +80,139 @@ public class HttpHeadersUtil {
         var headers = new HttpHeaders();
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         return headers;
+    }
+
+    public static HttpHeaders getFileResponseHeaders(@Nonnull Path file) {
+        var fileName = file.getFileName().toString();
+        return getFileResponseHeaders(file, fileName);
+    }
+
+    public static HttpHeaders getFileResponseHeaders(@Nonnull Path file, @Nullable String fileName) {
+        try (var inputStream = Files.newInputStream(file)) {
+            return getFileResponseHeaders(inputStream, fileName);
+        } catch (IOException ex) {
+            return getFileResponseHeaders((InputStream) null, fileName);
+        }
+    }
+
+    public static HttpHeaders getJsonFileResponseHeaders() {
+        return getFileResponseHeaders((InputStream) null, "data.json");
+    }
+
+    public static HttpHeaders getFileResponseHeaders(@Nullable InputStream inputStream, @Nullable String fileName) {
+        HttpHeaders headers = new HttpHeaders();
+
+        // by default, we treat all files as octet stream
+        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+
+        headers.set("X-Content-Type-Options", "nosniff"); // prevents MIME sniffing
+        headers.set("X-Frame-Options", "DENY");           // prevents framing
+
+        boolean viewableAsText = false;
+        boolean forceDownload = true;
+
+        // treat vsix and sigzip files special:
+        //   - set content-disposition: attachment
+        //   - no explicit cache control
+
+        if (fileName != null && fileName.endsWith(".vsix")) {
+            headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        } else if (fileName != null && fileName.endsWith(".sigzip")) {
+            headers.setContentType(APPLICATION_ZIP);
+        } else {
+            try {
+                var mediaTypeString = tika.detect(inputStream, fileName);
+                if (TEXT_VIEWABLE_MEDIA_TYPES.contains(mediaTypeString)) {
+                    viewableAsText = true;
+                } else if (PASSTHROUGH_MEDIA_TYPES.contains(mediaTypeString)) {
+                    // allow some media types to passthrough as is
+                    forceDownload = false;
+                    headers.setContentType(MediaType.valueOf(mediaTypeString));
+                }
+            } catch (IOException _) {
+                // if we can not determine the media type, do not treat it as text
+            }
+
+            // add a default cache control for all other served files
+            headers.setCacheControl(StorageUtil.getCacheControl(fileName));
+        }
+
+        if (viewableAsText) {
+            // if we determined that the file can be safely viewed in its source form
+            // set a text/plain content type to prevent any rendering in the browser
+            headers.setContentType(TEXT_PLAIN_UTF8);
+        } else if (forceDownload) {
+            // files not viewable as text need to be downloaded and not displayed inline
+            String sanitizedFileName = sanitize(fileName);
+            ContentDisposition disposition = ContentDisposition.attachment()
+                    .filename(sanitizedFileName, StandardCharsets.UTF_8)
+                    .build();
+            headers.setContentDisposition(disposition);
+        }
+
+        // as a safety net, set the strictest possible CSP as we are serving user-controlled input
+        headers.set("Content-Security-Policy", CSP_PREVENT_ALL);
+
+        return headers;
+    }
+
+    private static String sanitize(String filename) {
+        if (filename == null || filename.isBlank()) {
+            return "download";
+        }
+
+        // Strip any directory components an attacker may have included
+        // (handles both Unix and Windows path separators)
+        String sanitized = getSanitized(filename);
+
+        // Collapse to just the extension if the name part is empty
+        if (sanitized.isBlank()) {
+            return "download";
+        }
+
+        // Prevent hidden files / relative path tricks
+        while (sanitized.startsWith(".")) {
+            sanitized = sanitized.substring(1);
+        }
+        if (sanitized.isBlank()) {
+            return "download";
+        }
+
+        // Truncate, but preserve the extension
+        if (sanitized.length() > MAX_FILENAME_LENGTH) {
+            int dot = sanitized.lastIndexOf('.');
+            if (dot > 0 && dot > sanitized.length() - 16) {
+                // Has a short extension — preserve it
+                String ext = sanitized.substring(dot);           // e.g. ".tar.gz" won't work but ".gz" will
+                String name = sanitized.substring(0, dot);
+                name = name.substring(0, MAX_FILENAME_LENGTH - ext.length());
+                sanitized = name + ext;
+            } else {
+                sanitized = sanitized.substring(0, MAX_FILENAME_LENGTH);
+            }
+        }
+
+        return sanitized;
+    }
+
+    private static @NonNull String getSanitized(String filename) {
+        String stripped = filename;
+        int lastSep = Math.max(
+                filename.lastIndexOf('/'),
+                filename.lastIndexOf('\\')
+        );
+        if (lastSep >= 0) {
+            stripped = filename.substring(lastSep + 1);
+        }
+
+        // Remove forbidden characters
+        StringBuilder sb = new StringBuilder();
+        for (char c : stripped.toCharArray()) {
+            if (!FORBIDDEN_CHARS.contains(c) && c >= 0x20) { // drop control chars
+                sb.append(c);
+            }
+        }
+
+        return sb.toString().trim();
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/util/HttpHeadersUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/HttpHeadersUtil.java
@@ -145,7 +145,7 @@ public class HttpHeadersUtil {
             // files not viewable as text need to be downloaded and not displayed inline
             String sanitizedFileName = sanitize(fileName);
             ContentDisposition disposition = ContentDisposition.attachment()
-                    .filename(sanitizedFileName, StandardCharsets.UTF_8)
+                    .filename(sanitizedFileName)
                     .build();
             headers.setContentDisposition(disposition);
         }

--- a/server/src/main/java/org/eclipse/openvsx/util/HttpHeadersUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/HttpHeadersUtil.java
@@ -82,24 +82,24 @@ public class HttpHeadersUtil {
         return headers;
     }
 
-    public static HttpHeaders getFileResponseHeaders(@Nonnull Path file) {
+    public static HttpHeaders createFileResponseHeaders(@Nonnull Path file) {
         var fileName = file.getFileName().toString();
-        return getFileResponseHeaders(file, fileName);
+        return createFileResponseHeaders(file, fileName);
     }
 
-    public static HttpHeaders getFileResponseHeaders(@Nonnull Path file, @Nullable String fileName) {
+    public static HttpHeaders createFileResponseHeaders(@Nonnull Path file, @Nullable String fileName) {
         try (var inputStream = Files.newInputStream(file)) {
-            return getFileResponseHeaders(inputStream, fileName);
+            return createFileResponseHeaders(inputStream, fileName);
         } catch (IOException ex) {
-            return getFileResponseHeaders((InputStream) null, fileName);
+            return createFileResponseHeaders((InputStream) null, fileName);
         }
     }
 
-    public static HttpHeaders getJsonFileResponseHeaders() {
-        return getFileResponseHeaders((InputStream) null, "data.json");
+    public static HttpHeaders createJsonFileResponseHeaders() {
+        return createFileResponseHeaders((InputStream) null, "data.json");
     }
 
-    public static HttpHeaders getFileResponseHeaders(@Nullable InputStream inputStream, @Nullable String fileName) {
+    public static HttpHeaders createFileResponseHeaders(@Nullable InputStream inputStream, @Nullable String fileName) {
         HttpHeaders headers = new HttpHeaders();
 
         // by default, we treat all files as octet stream

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -81,6 +81,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import static org.eclipse.openvsx.entities.FileResource.*;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -483,7 +484,29 @@ class RegistryAPITest {
                 .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().string("Please read me"))
-                .andDo(result -> Files.delete(filePath));
+                .andExpect(header().string("X-Content-Type-Options", "nosniff"))
+                .andExpect(header().string("X-Frame-Options", "DENY"))
+                .andExpect(header().string("Content-Type", containsString("text/plain;charset=UTF-8")))
+                .andExpect(header().string("Content-Security-Policy",
+                        containsString("default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; sandbox")))
+                .andDo(_ -> Files.delete(filePath));
+    }
+
+    @Test
+    void testHtmlResourceIsServedAsPlainText() throws Exception {
+        // A resource whose filename resolves to a renderable type (e.g. text/html)
+        // must come back with the hardened response headers.
+        var filePath = mockReadme(TargetPlatform.NAME_UNIVERSAL, "readme.html", "<script>alert(1)</script>");
+        mockMvc.perform(get("/api/{namespace}/{extension}/{version}/file/{fileName}", "foo", "bar", "1.0.0", "readme.html"))
+                .andExpect(request().asyncStarted())
+                .andDo(MvcResult::getAsyncResult)
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Content-Type-Options", "nosniff"))
+                .andExpect(header().string("X-Frame-Options", "DENY"))
+                .andExpect(header().string("Content-Type", containsString("text/plain;charset=UTF-8")))
+                .andExpect(header().string("Content-Security-Policy",
+                        containsString("default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; sandbox")))
+                .andDo(_ -> Files.delete(filePath));
     }
 
     @Test
@@ -494,7 +517,7 @@ class RegistryAPITest {
                 .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().string("Please read me"))
-                .andDo(result -> Files.delete(filePath));
+                .andDo(_ -> Files.delete(filePath));
     }
 
     @Test
@@ -502,7 +525,7 @@ class RegistryAPITest {
         var filePath = mockReadme();
         mockMvc.perform(get("/api/{namespace}/{extension}/{target}/{version}/file/{fileName}", "foo", "bar", "darwin-x64", "1.0.0", "README"))
                 .andExpect(status().isNotFound())
-                .andDo(result -> Files.delete(filePath));
+                .andDo(_ -> Files.delete(filePath));
     }
 
     @Test
@@ -513,7 +536,7 @@ class RegistryAPITest {
                 .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().string("All notable changes is documented here"))
-                .andDo(result -> Files.delete(filePath));
+                .andDo(_ -> Files.delete(filePath));
     }
 
     @Test
@@ -524,7 +547,7 @@ class RegistryAPITest {
                 .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().string("I never broke the Law! I am the law!"))
-                .andDo(result -> Files.delete(filePath));
+                .andDo(_ -> Files.delete(filePath));
     }
 
     @Test
@@ -551,7 +574,7 @@ class RegistryAPITest {
                 .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().string("latest download"))
-                .andDo(result -> Files.delete(filePath));
+                .andDo(_ -> Files.delete(filePath));
     }
 
     @Test
@@ -2265,14 +2288,20 @@ class RegistryAPITest {
     }
 
     private Path mockReadme(String targetPlatform) throws IOException {
+        return mockReadme(targetPlatform, "README", "Please read me");
+    }
+
+    private Path mockReadme(String targetPlatform, String fileName, String content) throws IOException {
         var extVersion = mockExtension(targetPlatform);
         var resource = new FileResource();
         resource.setExtension(extVersion);
-        resource.setName("README");
+        resource.setName(fileName);
         resource.setType(FileResource.README);
         resource.setStorageType(STORAGE_LOCAL);
         Mockito.when(entityManager.find(FileResource.class, resource.getId())).thenReturn(resource);
         Mockito.when(repositories.findFileByType("foo", "bar", targetPlatform, "1.0.0", README)).thenReturn(resource);
+        // Filenames that aren't well-known type aliases are looked up by name.
+        Mockito.when(repositories.findFileByName("foo", "bar", targetPlatform, "1.0.0", fileName)).thenReturn(resource);
 
         var segments = new String[]{ "foo", "bar" };
         if(!targetPlatform.equals(TargetPlatform.NAME_UNIVERSAL)) {
@@ -2280,10 +2309,10 @@ class RegistryAPITest {
         }
 
         segments = ArrayUtils.add(segments, "1.0.0");
-        segments = ArrayUtils.add(segments, "README");
+        segments = ArrayUtils.add(segments, fileName);
         var path = Path.of("/tmp", segments);
         Files.createDirectories(path.getParent());
-        Files.writeString(path, "Please read me");
+        Files.writeString(path, content);
         return path;
     }
 

--- a/server/src/test/java/org/eclipse/openvsx/adapter/UpstreamVSCodeServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/UpstreamVSCodeServiceTest.java
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.adapter;
+
+import org.eclipse.openvsx.ExtensionValidator;
+import org.eclipse.openvsx.UrlConfigService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Verifies that proxied responses use our own response headers rather than
+ * trusting the upstream registry's headers verbatim.
+ */
+public class UpstreamVSCodeServiceTest {
+
+    @Test
+    void browseDoesNotTrustUpstreamContentType() {
+        var nonRedirecting = new RestTemplate();
+        var server = MockRestServiceServer.bindTo(nonRedirecting).build();
+        server.expect(requestTo("http://upstream.example/vscode/unpkg/foo/bar/1.0.0/extension/readme.md"))
+                .andRespond(withSuccess("### blablabla", MediaType.TEXT_MARKDOWN));
+
+        server.expect(requestTo("http://upstream.example/vscode/unpkg/foo/bar/1.0.0/extension/readme.html"))
+                .andRespond(withSuccess("<script>alert(1)</script>", MediaType.TEXT_HTML));
+
+        var urlConfig = Mockito.mock(UrlConfigService.class);
+        Mockito.when(urlConfig.getUpstreamUrl()).thenReturn("http://upstream.example");
+
+        var service = new UpstreamVSCodeService(
+                new RestTemplate(), Optional.empty(), nonRedirecting, urlConfig, Mockito.mock(ExtensionValidator.class)
+        );
+
+        var response = service.browse("foo", "bar", "1.0.0", "extension/readme.md");
+
+        assertEquals("text/plain;charset=UTF-8", Objects.requireNonNull(response.getHeaders().getContentType()).toString());
+        assertNotNull(response.getHeaders().getFirst("Content-Security-Policy"),
+                "proxied files must carry a Content-Security-Policy");
+
+        response = service.browse("foo", "bar", "1.0.0", "extension/readme.html");
+
+        assertEquals("text/plain;charset=UTF-8", Objects.requireNonNull(response.getHeaders().getContentType()).toString());
+        assertNotNull(response.getHeaders().getFirst("Content-Security-Policy"),
+                "proxied files must carry a Content-Security-Policy");
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/util/HttpHeadersUtilTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/util/HttpHeadersUtilTest.java
@@ -1,0 +1,78 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HttpHeadersUtilTest {
+
+    @Test
+    void testCreateJsonFileResponseHeaders() {
+        var headers = HttpHeadersUtil.createJsonFileResponseHeaders();
+
+        var contentType = headers.getContentType();
+        assertThat(contentType).isNotNull();
+        assertThat(contentType.toString()).isEqualTo("application/json");
+
+        var contentTypeOptions = headers.get("X-Content-Type-Options");
+        assertThat(contentTypeOptions).isEqualTo(List.of("nosniff"));
+
+        var contentSecurityPolicy = headers.get("Content-Security-Policy");
+        assertThat(contentSecurityPolicy).isEqualTo(
+                List.of("default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; sandbox")
+        );
+    }
+
+    @Test
+    void testCreateFileResponseHeadersForHtml() {
+        var headers = HttpHeadersUtil.createFileResponseHeaders((InputStream) null, "file.html");
+
+        var contentType = headers.getContentType();
+        assertThat(contentType).isNotNull();
+        assertThat(contentType.toString()).isEqualTo("text/plain;charset=UTF-8");
+
+        var contentTypeOptions = headers.get("X-Content-Type-Options");
+        assertThat(contentTypeOptions).isEqualTo(List.of("nosniff"));
+
+        var contentSecurityPolicy = headers.get("Content-Security-Policy");
+        assertThat(contentSecurityPolicy).isEqualTo(
+                List.of("default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; sandbox")
+        );
+    }
+
+    @Test
+    void testCreateFileResponseHeadersForVsix() {
+        var headers = HttpHeadersUtil.createFileResponseHeaders((InputStream) null, "file.vsix");
+
+        var contentType = headers.getContentType();
+        assertThat(contentType).isNotNull();
+        assertThat(contentType.toString()).isEqualTo("application/octet-stream");
+
+        var contentTypeOptions = headers.get("X-Content-Type-Options");
+        assertThat(contentTypeOptions).isEqualTo(List.of("nosniff"));
+
+        var contentSecurityPolicy = headers.get("Content-Security-Policy");
+        assertThat(contentSecurityPolicy).isEqualTo(
+                List.of("default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; sandbox")
+        );
+
+        var contentDisposition = headers.getContentDisposition();
+        assertThat(contentDisposition.isAttachment()).isTrue();
+        assertThat(contentDisposition.getFilename()).isEqualTo("file.vsix");
+    }
+}


### PR DESCRIPTION
Previously, when files within extensions were served from various endpoints, the content type was deduced from the file type without any explicit security measure.

This could lead to XSS attacks.

This PR does the following:

 - add strict http headers whenever a user controlled input is served directly
 - correctly set content type / disposition / cache control when uploading the the configured cloud storage provider

The following protections are added:

 - `X-Content-Type-Options: nosniff` to prevent browsers from guessing the content type
 - strictest possible `Content-Security-Policy` when serving user controlled input
 - `Content-Type: text/plain` for certain files whose source can be viewed (preventing rendering)
 - `Content-Type: application/octet-stream` for remaining files
 - `Content-Disposition: attachment` for files that can not be viewed to prevent inline rendering

`application/json` and `application/xml` are kept as is, to allow rendering them in the browser in a convenient way