### PR TITLE
fix: Add lower casing to namespace + extension name in cache keys

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/cache/ExtensionJsonCacheKeyGenerator.java
+++ b/server/src/main/java/org/eclipse/openvsx/cache/ExtensionJsonCacheKeyGenerator.java
@@ -9,6 +9,7 @@
  * ****************************************************************************** */
 package org.eclipse.openvsx.cache;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.util.NamingUtil;
 import org.eclipse.openvsx.util.VersionAlias;
@@ -27,12 +28,12 @@ public class ExtensionJsonCacheKeyGenerator implements KeyGenerator {
     }
 
     public String generate(String namespaceName, String extensionName, String targetPlatform, String version) {
-        return NamingUtil.toFileFormat(namespaceName, extensionName, targetPlatform, version);
+        return NamingUtil.toFileFormat(StringUtils.lowerCase(namespaceName), StringUtils.lowerCase(extensionName), targetPlatform, version);
     }
 
     public String generateWildcard(Extension extension) {
-        var extensionName = extension.getName();
-        var namespaceName = extension.getNamespace().getName();
+        var extensionName = StringUtils.lowerCase(extension.getName());
+        var namespaceName = StringUtils.lowerCase(extension.getNamespace().getName());
         return NamingUtil.toExtensionId(namespaceName, extensionName) + "*";
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/cache/LatestExtensionVersionCacheKeyGenerator.java
+++ b/server/src/main/java/org/eclipse/openvsx/cache/LatestExtensionVersionCacheKeyGenerator.java
@@ -9,6 +9,7 @@
  * ****************************************************************************** */
 package org.eclipse.openvsx.cache;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.ExtensionVersion;
 import org.eclipse.openvsx.util.NamingUtil;
@@ -51,15 +52,15 @@ public class LatestExtensionVersionCacheKeyGenerator implements KeyGenerator {
     }
 
     public String generate(Extension extension, String targetPlatform, boolean preRelease, boolean onlyActive, ExtensionVersion.Type type) {
-        var extensionName = extension.getName();
-        var namespaceName = extension.getNamespace().getName();
+        var extensionName = StringUtils.lowerCase(extension.getName());
+        var namespaceName = StringUtils.lowerCase(extension.getNamespace().getName());
         return NamingUtil.toFileFormat(namespaceName, extensionName, targetPlatform, VersionAlias.LATEST) +
                 ",pre-release=" + preRelease + ",only-active=" + onlyActive + ",type=" + type;
     }
 
     public String generateWildcard(Extension extension) {
-        var extensionName = extension.getName();
-        var namespaceName = extension.getNamespace().getName();
+        var extensionName = StringUtils.lowerCase(extension.getName());
+        var namespaceName = StringUtils.lowerCase(extension.getNamespace().getName());
         return NamingUtil.toExtensionId(namespaceName, extensionName) + "*";
     }
 }

--- a/server/src/test/java/org/eclipse/openvsx/cache/ExtensionJsonCacheKeyGeneratorTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/cache/ExtensionJsonCacheKeyGeneratorTest.java
@@ -1,0 +1,64 @@
+/** ******************************************************************************
+ * Copyright (c) 2026 Eclipse Foundation AISBL
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.cache;
+
+import org.eclipse.openvsx.entities.Extension;
+import org.eclipse.openvsx.entities.Namespace;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExtensionJsonCacheKeyGeneratorTest {
+
+	private final ExtensionJsonCacheKeyGenerator generator = new ExtensionJsonCacheKeyGenerator();
+
+	@Test
+	void shouldLowerCaseExtensionNameForCacheKey() {
+		var results = generator.generate("foobar", "BAZ", "linux", "1.0.0");
+
+		assertThat(results).startsWith("foobar.baz");
+	}
+
+	@Test
+	void shouldLowerCaseNamespaceNameForCacheKey() {
+		var results = generator.generate("FOoBAr", "baz", "linux", "1.0.0");
+
+		assertThat(results).startsWith("foobar.baz");
+	}
+
+	@Test
+	void shouldLowerCaseExtensionNameForWildcard() {
+		var extension = mockExtension();
+		extension.setName("BAZ");
+		var results = generator.generateWildcard(extension);
+
+		assertThat(results).startsWith("foobar.baz");
+	}
+
+	@Test
+	void shouldLowerCaseNamespaceNameForWildcard() {
+		var extension = mockExtension();
+		extension.getNamespace().setName("FOoBAr");
+		var results = generator.generateWildcard(extension);
+
+		assertThat(results).startsWith("foobar.baz");
+	}
+	
+	private Extension mockExtension() {
+		var namespace = new Namespace();
+		namespace.setName("foobar");
+		var extension = new Extension();
+		extension.setNamespace(namespace);
+		extension.setName("baz");
+		extension.setActive(true);
+
+		return extension;
+	}
+}

--- a/server/src/test/java/org/eclipse/openvsx/cache/LatestExtensionVersionCacheKeyGeneratorTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/cache/LatestExtensionVersionCacheKeyGeneratorTest.java
@@ -1,0 +1,69 @@
+/** ******************************************************************************
+ * Copyright (c) 2026 Eclipse Foundation AISBL
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.cache;
+
+import org.eclipse.openvsx.entities.Extension;
+import org.eclipse.openvsx.entities.ExtensionVersion.Type;
+import org.eclipse.openvsx.entities.Namespace;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LatestExtensionVersionCacheKeyGeneratorTest {
+
+	private final LatestExtensionVersionCacheKeyGenerator generator = new LatestExtensionVersionCacheKeyGenerator();
+
+	@Test
+	void shouldLowerCaseExtensionNameForCacheKey() {
+		var extension = mockExtension();
+		extension.setName("BAZ");
+		var results = generator.generate(extension, "linux", false, false, Type.REGULAR);
+
+		assertThat(results).startsWith("foobar.baz");
+	}
+
+	@Test
+	void shouldLowerCaseNamespaceNameForCacheKey() {
+		var extension = mockExtension();
+		extension.getNamespace().setName("FOoBAr");
+		var results = generator.generate(extension, "linux", false, false, Type.REGULAR);
+
+		assertThat(results).startsWith("foobar.baz");
+	}
+
+	@Test
+	void shouldLowerCaseExtensionNameForWildcard() {
+		var extension = mockExtension();
+		extension.setName("BAZ");
+		var results = generator.generate(extension, "linux", false, false, Type.REGULAR);
+
+		assertThat(results).startsWith("foobar.baz");
+	}
+
+	@Test
+	void shouldLowerCaseNamespaceNameForExtension() {
+		var extension = mockExtension();
+		extension.getNamespace().setName("FOoBAr");
+		var results = generator.generate(extension, "linux", false, false, Type.REGULAR);
+
+		assertThat(results).startsWith("foobar.baz");
+	}
+	
+	private Extension mockExtension() {
+		var namespace = new Namespace();
+		namespace.setName("foobar");
+		var extension = new Extension();
+		extension.setNamespace(namespace);
+		extension.setName("baz");
+		extension.setActive(true);
+
+		return extension;
+	}
+}


### PR DESCRIPTION
Authored by @autumnfound .

This PR changes the generated key for certain caches to the canonical form as already done in `FilesCacheKeyGenerator`.