### PR TITLE
Fix: correctly set http headers when uploading a file to AWS S3

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
@@ -45,7 +45,6 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.HashMap;
 import java.util.List;
 
 import static org.eclipse.openvsx.cache.CacheService.CACHE_EXTENSION_FILES;
@@ -217,27 +216,24 @@ public class AwsStorageService implements IStorageService {
     protected void uploadFile(TempFile file, String fileName, String objectKey) {
         var headers = HttpHeadersUtil.createFileResponseHeaders(file.getPath(), fileName);
 
+        var builder = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectKey);
+
         // see https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html
-        var metadata = new HashMap<String, String>();
         if (headers.getContentType() != null) {
-            metadata.put("Content-Type", headers.getContentType().toString());
+            builder.contentType(headers.getContentType().toString());
         }
 
         if (StringUtils.isNotBlank(headers.getContentDisposition().toString())) {
-            metadata.put("Content-Disposition", headers.getContentDisposition().toString());
+            builder.contentDisposition(headers.getContentDisposition().toString());
         }
 
         if (headers.getCacheControl() != null) {
-            metadata.put("Cache-Control", headers.getCacheControl());
+            builder.cacheControl(headers.getCacheControl());
         }
 
-        var request = PutObjectRequest.builder()
-                .bucket(bucket)
-                .key(objectKey)
-                .metadata(metadata)
-                .build();
-
-        getS3Client().putObject(request, file.getPath());
+        getS3Client().putObject(builder.build(), file.getPath());
     }
 
     @Override


### PR DESCRIPTION
This PR correctly set the http headers when uploading a file to AWS S3.

Tested locally with `minio` and works as expected. However when deploying to staging.open-vsx.org that does not work anymore as we receive 404 from our CDN. It might be due to a VCL misconfiguration, needs to be tested and fixed.