### PR TITLE
Fix: normalize multiple slashes when detecting malicious zip files

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/scanning/MaliciousZipCheckService.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/MaliciousZipCheckService.java
@@ -77,7 +77,7 @@ public class MaliciousZipCheckService implements PublishCheck {
             // yauzl which is used by VS Code to extract vsix archives, silently normalizes
             // backslash characters to forward slashes, so we reject any extension that contains
             // duplicate filenames after normalization to avoid any potential issue.
-            var normalizedName = Path.of(name).normalize().toString().replaceAll("\\\\+", "/");
+            var normalizedName = Path.of(name).normalize().toString().replaceAll("\\\\+", "/").replaceAll("/+", "/");
             if (!seen.add(normalizedName)) {
                 return PublishCheck.Result.fail(DUPLICATE_ENTRIES_RULE, DUPLICATE_ENTRIES_MESSAGE);
             }

--- a/server/src/test/java/org/eclipse/openvsx/scanning/MaliciousZipCheckServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/scanning/MaliciousZipCheckServiceTest.java
@@ -130,6 +130,30 @@ class MaliciousZipCheckServiceTest {
         assertEquals("UNSAFE_PATH_DETECTED", result.failures().getLast().ruleName());
     }
 
+    @Test
+    void check_failsWhenEntriesCollideAfterDotDotSegmentNormalizationMultipleSlashes() throws Exception {
+        TempFile extensionFile = createZipWithEntries("dotdot-segment.vsix",
+            "extension\\/package.json", "extension/package.json");
+
+        var result = service.check(createContext(extensionFile));
+
+        assertFalse(result.passed());
+        assertEquals(1, result.failures().size());
+        assertEquals("DUPLICATE_NORMALIZED_ENTRIES", result.failures().getFirst().ruleName());
+    }
+
+    @Test
+    void check_failsWhenEntriesCollideAfterDotDotSegmentNormalizationMultipleSlashes2() throws Exception {
+        TempFile extensionFile = createZipWithEntries("dotdot-segment.vsix",
+            "extension/\\package.json", "extension/package.json");
+
+        var result = service.check(createContext(extensionFile));
+
+        assertFalse(result.passed());
+        assertEquals(1, result.failures().size());
+        assertEquals("DUPLICATE_NORMALIZED_ENTRIES", result.failures().getFirst().ruleName());
+    }
+
     // --- Unsafe paths checks ---
 
     @Test


### PR DESCRIPTION
When detecting potentially malicious zip files we do not yet consider the case of multiple slashes.

This PR normalizes consecutive slashes to a single one to reliably detect duplicate filenames.
We can not be sure what library the consumers will use to read the extension archives so best use a defensive approach here. It does not make any sense to have such filenames in general, so best to reject them.