### PR TITLE
chore: move off guava; low hanging fruits

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -90,6 +90,7 @@ dependencies {
     implementation libs.commons.lang3
     implementation libs.bouncycastle
     implementation libs.jedis
+    implementation libs.guava
 
     implementation libs.bucket4j.spring
     implementation libs.bucket4j.redis

--- a/server/gradle/libs.versions.toml
+++ b/server/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ commons-lang3   = "3.20.0"
 flyway          = "11.20.3"
 gatling         = "3.15.0"
 gcloud          = "2.62.1"
+guava           = "33.5.0-jre"
 ipaddress       = "5.5.1"
 java            = "25"
 jaxb-api        = "2.3.1"
@@ -47,6 +48,7 @@ flyway-database-postgresql   = { module = "org.flywaydb:flyway-database-postgres
 gatling-app                  = { module = "io.gatling:gatling-app", version.ref = "gatling" }
 gatling-core                 = { module = "io.gatling:gatling-core", version.ref = "gatling" }
 google-cloud-storage         = { module = "com.google.cloud:google-cloud-storage", version.ref = "gcloud" }
+guava                        = { module = "com.google.guava:guava", version.ref = "guava" }
 ipaddress                    = { module = "com.github.seancfoley:ipaddress", version.ref = "ipaddress" }
 jackson-dataformat-yaml      = { module = "tools.jackson.dataformat:jackson-dataformat-yaml" }
 jackson-dataformat-xml       = { module = "tools.jackson.dataformat:jackson-dataformat-xml" }

--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -9,7 +9,6 @@
  ********************************************************************************/
 package org.eclipse.openvsx;
 
-import com.google.common.collect.Maps;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
@@ -26,7 +25,15 @@ import org.eclipse.openvsx.search.SearchResult;
 import org.eclipse.openvsx.search.SearchUtilService;
 import org.eclipse.openvsx.search.SimilarityCheckService;
 import org.eclipse.openvsx.storage.StorageUtilService;
-import org.eclipse.openvsx.util.*;
+import org.eclipse.openvsx.util.ErrorResultException;
+import org.eclipse.openvsx.util.ExtensionId;
+import org.eclipse.openvsx.util.NamingUtil;
+import org.eclipse.openvsx.util.NotFoundException;
+import org.eclipse.openvsx.util.TargetPlatform;
+import org.eclipse.openvsx.util.TimeUtil;
+import org.eclipse.openvsx.util.UrlUtil;
+import org.eclipse.openvsx.util.VersionAlias;
+import org.eclipse.openvsx.util.VersionService;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -881,7 +888,7 @@ public class LocalRegistryService implements IExtensionRegistry {
         var versionBaseUrl = UrlUtil.createApiVersionBaseUrl(serverUrl, json.getNamespace(), json.getName(), targetPlatform);
         allVersions.addAll(repositories.findVersionStringsSorted(extension, targetPlatform, onlyActive));
         json.setAllVersionsUrl(UrlUtil.createAllVersionsUrl(json.getNamespace(), json.getName(), targetPlatform));
-        var allVersionsJson = Maps.<String, String>newLinkedHashMapWithExpectedSize(allVersions.size());
+        var allVersionsJson = new LinkedHashMap<String, String>(allVersions.size());
         for (var version : allVersions) {
             allVersionsJson.put(version, createApiUrl(versionBaseUrl, version));
         }
@@ -950,14 +957,14 @@ public class LocalRegistryService implements IExtensionRegistry {
         }
 
         json.setAllVersionsUrl(UrlUtil.createAllVersionsUrl(json.getNamespace(), json.getName(), targetPlatformParam));
-        var allVersionsJson = Maps.<String, String>newLinkedHashMapWithExpectedSize(allVersions.size());
+        var allVersionsJson = new LinkedHashMap<String, String>(allVersions.size());
         var versionBaseUrl = UrlUtil.createApiVersionBaseUrl(serverUrl, json.getNamespace(), json.getName(), targetPlatformParam);
         for(var version : allVersions) {
             allVersionsJson.put(version, createApiUrl(versionBaseUrl, version));
         }
 
         json.setAllVersions(allVersionsJson);
-        var files = Maps.<String, String>newLinkedHashMapWithExpectedSize(8);
+        var files = new LinkedHashMap<String, String>(8);
         var fileBaseUrl = UrlUtil.createApiFileBaseUrl(serverUrl, json.getNamespace(), json.getName(), json.getTargetPlatform(), json.getVersion());
         for (var resource : resources) {
             var fileUrl = UrlUtil.createApiFileUrl(fileBaseUrl, resource.getName());
@@ -1055,7 +1062,7 @@ public class LocalRegistryService implements IExtensionRegistry {
             return null;
         }
 
-        var allVersionsJson = Maps.<String, String>newLinkedHashMapWithExpectedSize(allVersions.size());
+        var allVersionsJson = new LinkedHashMap<String, String>(allVersions.size());
         for(var version : allVersions) {
             allVersionsJson.put(version, createApiUrl(versionBaseUrl, version));
         }
@@ -1064,7 +1071,7 @@ public class LocalRegistryService implements IExtensionRegistry {
     }
 
     private Map<String, String> toFilesJson(ExtensionVersion extVersion, List<FileResource> resources, String fileBaseUrl) {
-        var files = Maps.<String, String>newLinkedHashMapWithExpectedSize(8);
+        var files = new LinkedHashMap<String, String>(8);
         for (var resource : resources) {
             var fileUrl = UrlUtil.createApiFileUrl(fileBaseUrl, resource.getName());
             files.put(resource.getType(), fileUrl);

--- a/server/src/main/java/org/eclipse/openvsx/UserService.java
+++ b/server/src/main/java/org/eclipse/openvsx/UserService.java
@@ -9,7 +9,6 @@
  ********************************************************************************/
 package org.eclipse.openvsx;
 
-import com.google.common.base.Joiner;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.SerializationUtils;
@@ -167,7 +166,8 @@ public class UserService {
         if (!issues.isEmpty()) {
             var message = issues.size() == 1
                     ? issues.getFirst().toString()
-                    : "Multiple issues were found in the extension metadata:\n" + Joiner.on("\n").join(issues);
+                    : "Multiple issues were found in the extension metadata:\n"
+                      + issues.stream().map(Object::toString).collect(Collectors.joining("\n"));
 
             throw new ErrorResultException(message);
         }

--- a/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
@@ -9,7 +9,6 @@
  * ****************************************************************************** */
 package org.eclipse.openvsx.adapter;
 
-import com.google.common.collect.Lists;
 import io.micrometer.observation.annotation.Observed;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.openvsx.cache.CacheService;
@@ -22,7 +21,14 @@ import org.eclipse.openvsx.search.ExtensionSearch;
 import org.eclipse.openvsx.search.SearchUtilService;
 import org.eclipse.openvsx.search.SortBy;
 import org.eclipse.openvsx.storage.StorageUtilService;
-import org.eclipse.openvsx.util.*;
+import org.eclipse.openvsx.util.BuiltInExtensionUtil;
+import org.eclipse.openvsx.util.ErrorResultException;
+import org.eclipse.openvsx.util.NamingUtil;
+import org.eclipse.openvsx.util.NotFoundException;
+import org.eclipse.openvsx.util.TargetPlatform;
+import org.eclipse.openvsx.util.TimeUtil;
+import org.eclipse.openvsx.util.UrlUtil;
+import org.eclipse.openvsx.util.VersionService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -530,7 +536,7 @@ public class LocalVSCodeService implements IVSCodeService {
 
         List<ExtensionQueryResult.Property> properties = null;
         if (test(flags, FLAG_INCLUDE_VERSION_PROPERTIES)) {
-            properties = Lists.newArrayList();
+            properties = new ArrayList<>();
             addQueryExtensionVersionProperty(properties, PROP_BRANDING_COLOR, extVer.getGalleryColor());
             addQueryExtensionVersionProperty(properties, PROP_BRANDING_THEME, extVer.getGalleryTheme());
             addQueryExtensionVersionProperty(properties, PROP_REPOSITORY, extVer.getRepository());
@@ -557,7 +563,7 @@ public class LocalVSCodeService implements IVSCodeService {
 
             var fileBaseUrl = UrlUtil.createApiFileBaseUrl(serverUrl, namespaceName, extensionName, extVer.getTargetPlatform(), extVer.getVersion());
 
-            files = Lists.newArrayList();
+            files = new ArrayList<>();
             addQueryExtensionVersionFile(files, FILE_MANIFEST, createFileUrl(resourcesByType.get(MANIFEST), fileBaseUrl));
             addQueryExtensionVersionFile(files, FILE_DETAILS, createFileUrl(resourcesByType.get(README), fileBaseUrl));
             addQueryExtensionVersionFile(files, FILE_LICENSE, createFileUrl(resourcesByType.get(LICENSE), fileBaseUrl));

--- a/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
@@ -9,7 +9,6 @@
  ********************************************************************************/
 package org.eclipse.openvsx.eclipse;
 
-import com.google.common.collect.Lists;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
@@ -239,7 +238,7 @@ public class EclipseService {
             eclipseLogin.setProvider("eclipse");
             eclipseLogin.setLoginName(personId);
             if (json.getAdditionalLogins() == null)
-                json.setAdditionalLogins(Lists.newArrayList(eclipseLogin));
+                json.setAdditionalLogins(List.of(eclipseLogin));
             else
                 json.getAdditionalLogins().add(eclipseLogin);
         }

--- a/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
@@ -37,6 +37,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -238,7 +239,7 @@ public class EclipseService {
             eclipseLogin.setProvider("eclipse");
             eclipseLogin.setLoginName(personId);
             if (json.getAdditionalLogins() == null)
-                json.setAdditionalLogins(List.of(eclipseLogin));
+                json.setAdditionalLogins(new ArrayList<>(List.of(eclipseLogin)));
             else
                 json.getAdditionalLogins().add(eclipseLogin);
         }

--- a/server/src/main/java/org/eclipse/openvsx/entities/ExtensionVersion.java
+++ b/server/src/main/java/org/eclipse/openvsx/entities/ExtensionVersion.java
@@ -9,8 +9,17 @@
  ********************************************************************************/
 package org.eclipse.openvsx.entities;
 
-import com.google.common.collect.Maps;
-import jakarta.persistence.*;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.openvsx.json.ExtensionJson;
 import org.eclipse.openvsx.json.ExtensionReferenceJson;
@@ -226,7 +235,7 @@ public class ExtensionVersion implements Serializable {
         var map = Optional.ofNullable(this.getEngines()).orElse(Collections.emptyList()).stream()
                 .map(engine -> engine.split("@"))
                 .filter(split -> split.length == 2)
-                .collect(Collectors.toMap(split -> split[0], split -> split[1], (a, b) -> a, Maps::newLinkedHashMap));
+                .collect(Collectors.toMap(split -> split[0], split -> split[1], (a, b) -> a, LinkedHashMap::new));
 
         return !map.isEmpty() ? map : null;
     }

--- a/server/src/main/java/org/eclipse/openvsx/entities/ListOfStringConverter.java
+++ b/server/src/main/java/org/eclipse/openvsx/entities/ListOfStringConverter.java
@@ -29,7 +29,7 @@ public class ListOfStringConverter implements AttributeConverter<List<String>, S
     public List<String> convertToEntityAttribute(String raw) {
         return (raw == null)
                 ? new ArrayList<>()
-                : new ArrayList<>(Arrays.stream(raw.split(",")).map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toList()));
+                : new ArrayList<>(Arrays.stream(raw.split(",")).map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toCollection(ArrayList::new)));
     }
 
 }

--- a/server/src/main/java/org/eclipse/openvsx/entities/ListOfStringConverter.java
+++ b/server/src/main/java/org/eclipse/openvsx/entities/ListOfStringConverter.java
@@ -9,25 +9,27 @@
  ********************************************************************************/
 package org.eclipse.openvsx.entities;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
-import com.google.common.collect.Lists;
-
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Converter
 public class ListOfStringConverter implements AttributeConverter<List<String>, String> {
 
     @Override
     public String convertToDatabaseColumn(List<String> data) {
-        return (data == null || data.isEmpty()) ? null : Joiner.on(',').join(data);
+        return (data == null || data.isEmpty()) ? null : String.join(",", data);
     }
 
     @Override
     public List<String> convertToEntityAttribute(String raw) {
-        return (raw == null) ? Lists.newArrayList() : Lists.newArrayList(Splitter.on(',').trimResults().omitEmptyStrings().split(raw));
+        return (raw == null)
+                ? new ArrayList<>()
+                : new ArrayList<>(Arrays.stream(raw.split(",")).map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toList()));
     }
 
 }

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -44,8 +45,6 @@ import org.springframework.resilience.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerErrorException;
-
-import com.google.common.base.Joiner;
 
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
@@ -289,7 +288,7 @@ public class PublishExtensionVersionHandler {
                 throw new ErrorResultException(metadataIssues.getFirst().toString());
             }
             throw new ErrorResultException("Multiple issues were found in the extension metadata:\n"
-                    + Joiner.on("\n").join(metadataIssues));
+                    + metadataIssues.stream().map(Object::toString).collect(Collectors.joining("\n")));
         }
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
@@ -9,7 +9,10 @@
  ********************************************************************************/
 package org.eclipse.openvsx.storage;
 
-import com.google.cloud.storage.*;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.openvsx.cache.FilesCacheKeyGenerator;
 import org.eclipse.openvsx.entities.FileResource;

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
@@ -9,7 +9,6 @@
  ********************************************************************************/
 package org.eclipse.openvsx.storage;
 
-import com.google.common.collect.Maps;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
@@ -271,7 +270,7 @@ public class StorageUtilService implements IStorageService {
      */
     public Map<Long, Map<String, String>> getFileUrls(Collection<ExtensionVersion> extVersions, String serverUrl, String... types) {
         var type2Url = extVersions.stream()
-                .map(ev -> Map.<Long, Map<String, String>>entry(ev.getId(), Maps.newLinkedHashMapWithExpectedSize(types.length)))
+                .map(ev -> Map.<Long, Map<String, String>>entry(ev.getId(), new LinkedHashMap<>(types.length)))
                 .collect(Collectors.<Map.Entry<Long, Map<String, String>>, Long, Map<String, String>>toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         var resources = repositories.findFilesByType(extVersions, Arrays.asList(types));

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
@@ -9,8 +9,6 @@
  ********************************************************************************/
 package org.eclipse.openvsx.adapter;
 
-import com.google.common.collect.Lists;
-import com.google.common.io.CharStreams;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.persistence.EntityManager;
 import org.eclipse.openvsx.ExtensionValidator;
@@ -51,7 +49,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -872,9 +869,9 @@ class VSCodeAPITest {
         extVersion.setDisplayName("YAML");
         extVersion.setDescription("YAML Language Support");
         extVersion.setRepository("https://github.com/redhat-developer/vscode-yaml");
-        extVersion.setEngines(Lists.newArrayList("vscode@^1.31.0"));
-        extVersion.setDependencies(Lists.newArrayList());
-        extVersion.setBundledExtensions(Lists.newArrayList());
+        extVersion.setEngines(List.of("vscode@^1.31.0"));
+        extVersion.setDependencies(List.of());
+        extVersion.setBundledExtensions(List.of());
         Mockito.when(repositories.findExtension("vscode-yaml", "redhat"))
                 .thenReturn(extension);
         Mockito.when(repositories.findVersion("0.5.2", targetPlatform, "vscode-yaml", "redhat"))
@@ -962,7 +959,8 @@ class VSCodeAPITest {
 
     private String file(String name) throws IOException {
         try (var stream = getClass().getResourceAsStream(name)) {
-            return CharStreams.toString(new InputStreamReader(stream, StandardCharsets.UTF_8));
+            assert stream != null;
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
         }
     }
 

--- a/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
@@ -9,7 +9,6 @@
  ********************************************************************************/
 package org.eclipse.openvsx.eclipse;
 
-import com.google.common.io.CharStreams;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.persistence.EntityManager;
 import org.eclipse.openvsx.ExtensionService;
@@ -49,7 +48,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -358,35 +357,40 @@ class EclipseServiceTest {
 
     private ResponseEntity<String> mockProfileResponse() throws IOException {
         try (var stream = getClass().getResourceAsStream("profile-response.json")) {
-            var json = CharStreams.toString(new InputStreamReader(stream));
+            assert stream != null;
+            var json = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
             return new ResponseEntity<>(json, HttpStatus.OK);
         }
     }
 
     private ResponseEntity<String> mockOutdatedProfileResponse() throws IOException {
         try (var stream = getClass().getResourceAsStream("profile-outdated-response.json")) {
-            var json = CharStreams.toString(new InputStreamReader(stream));
+            assert stream != null;
+            var json = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
             return new ResponseEntity<>(json, HttpStatus.OK);
         }
     }
 
     private ResponseEntity<String> mockAllowedProfileResponse() throws IOException {
         try (var stream = getClass().getResourceAsStream("profile-allowed-response.json")) {
-            var json = CharStreams.toString(new InputStreamReader(stream));
+            assert stream != null;
+            var json = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
             return new ResponseEntity<>(json, HttpStatus.OK);
         }
     }
 
     private ResponseEntity<String> mockAgreementResponse() throws IOException {
         try (var stream = getClass().getResourceAsStream("publisher-agreement-response.json")) {
-            var json = CharStreams.toString(new InputStreamReader(stream));
+            assert stream != null;
+            var json = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
             return new ResponseEntity<>(json, HttpStatus.OK);
         }
     }
 
     private ResponseEntity<String> mockOutdatedAgreementResponse() throws IOException {
         try (var stream = getClass().getResourceAsStream("publisher-agreement-outdated-response.json")) {
-            var json = CharStreams.toString(new InputStreamReader(stream));
+            assert stream != null;
+            var json = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
             return new ResponseEntity<>(json, HttpStatus.OK);
         }
     }

--- a/server/src/test/java/org/eclipse/openvsx/util/CollectionUtilTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/util/CollectionUtilTest.java
@@ -11,16 +11,16 @@ package org.eclipse.openvsx.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.Lists;
-
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 class CollectionUtilTest {
 
     @Test
     void testLimit() {
-        var source = Lists.newArrayList(1, 2, 3, 4, 5);
+        var source = List.of(1, 2, 3, 4, 5);
         var result = CollectionUtil.limit(source, 3);
-        assertThat(result).isEqualTo(Lists.newArrayList(1, 2, 3));
+        assertThat(result).isEqualTo(List.of(1, 2, 3));
     }
 }


### PR DESCRIPTION
Many of Guava helpers were concieved before modern Java language features.

This PR moves to "pure Java" counterpart where possible.

Also, Guava is not among dependencies, is transitive dependency, so next is worth to consider it as direct dependency, as it is being used.