### PR TITLE
Chore: some minor cleanups in jooq repositories

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionJooqRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionJooqRepository.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.eclipse.openvsx.jooq.Tables.EXTENSION;
 import static org.eclipse.openvsx.jooq.Tables.EXTENSION_VERSION;
@@ -188,7 +187,7 @@ public class ExtensionJooqRepository {
         var extension = EXTENSION.as("e");
         var rows = publicIds.entrySet().stream()
                 .map(e -> DSL.row(e.getKey(), e.getValue()))
-                .collect(Collectors.toList());
+                .toList();
 
         var updates = DSL.values(rows.toArray(Row2[]::new)).as("u", "id", "public_id");
         dsl.update(extension)

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepository.java
@@ -357,7 +357,7 @@ public class ExtensionVersionJooqRepository {
             return extVersion;
         });
         var total = totalQuery.fetchOne(totalCol, Integer.class);
-        return new PageImpl<>(content, PageRequest.of(request.offset() / request.size(), request.size()), total);
+        return new PageImpl<>(content, PageRequest.of(request.offset() / request.size(), request.size()), total != null ? total : 0);
     }
 
     public List<ExtensionVersion> findAllActiveByExtensionName(String targetPlatform, String extensionName) {

--- a/server/src/main/java/org/eclipse/openvsx/repositories/NamespaceJooqRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/NamespaceJooqRepository.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.eclipse.openvsx.jooq.Tables.NAMESPACE;
 import static org.eclipse.openvsx.jooq.Tables.NAMESPACE_MEMBERSHIP;
@@ -39,13 +38,13 @@ public class NamespaceJooqRepository {
         var namespace = NAMESPACE.as("n");
         var rows = publicIds.entrySet().stream()
                 .map(e -> DSL.row(e.getKey(), e.getValue()))
-                .collect(Collectors.toList());
+                .toList();
 
         var updates = DSL.values(rows.toArray(Row2[]::new)).as("u", "id", "public_id");
         dsl.update(namespace)
                 .set(namespace.PUBLIC_ID, updates.field("public_id", String.class))
                 .from(updates)
-                .where(updates.field("id", Long.class).eq(namespace.ID))
+                .where(namespace.ID.eq(updates.field("id", Long.class)))
                 .execute();
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/repositories/UserDataJooqRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/UserDataJooqRepository.java
@@ -9,10 +9,6 @@
  ********************************************************************************/
 package org.eclipse.openvsx.repositories;
 
-import static org.eclipse.openvsx.jooq.Tables.CUSTOMER;
-import static org.eclipse.openvsx.jooq.Tables.CUSTOMER_MEMBERSHIP;
-import static org.eclipse.openvsx.jooq.Tables.NAMESPACE;
-import static org.eclipse.openvsx.jooq.Tables.NAMESPACE_MEMBERSHIP;
 import static org.eclipse.openvsx.jooq.Tables.USER_DATA;
 
 import java.util.ArrayList;
@@ -55,7 +51,7 @@ public class UserDataJooqRepository {
         query.addLimit(pageable.getPageSize());
         var content = query.fetch(this::toUserData);
 
-        return new PageImpl<>(content, pageable, total);
+        return new PageImpl<>(content, pageable, total != null ? total : 0);
     }
 
     private SelectQuery<Record> baseQuery() {


### PR DESCRIPTION
Some minor cleanups:

- remove unused imports
- make comparison null safe
- coerce total count in some queries to 0 if no row was fetched