### PR TITLE
feat(cli): replace keytar with cross-keychain for token storage

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This change log covers only the command line interface (CLI) of Open VSX.
 
+### [next] (unreleased)
+
+#### Additions
+
+- Add an encrypted filestore as fallback to the system keychain if it cant be accessed ([#1950](https://github.com/eclipse/openvsx/pull/1950))
+
+#### Changes
+
+- Replace `keytar` with `cross-keychain` to store credentials in the system keychain ([#1950](https://github.com/eclipse/openvsx/pull/1950))
+
 ### [v1.0.2] (23/06/2026)
 
 #### Dependencies

--- a/cli/README.md
+++ b/cli/README.md
@@ -59,4 +59,4 @@ The `logout` command lets you remove a stored access token.
  * `ovsx logout <name>`
    the name must correspond to the `publisher` of your extension.
 
-By default `ovsx` will try to use a `keytar` store with a plaintext file store as fallback. You can specify the environment variable `OVSX_STORE=file` to use the file store.
+By default `ovsx` stores access tokens in the operating system's credential manager (via [`cross-keychain`](https://www.npmjs.com/package/cross-keychain)). Setting the environment variable `OVSX_STORE=file` switches to storing them as plaintext in the `~/.ovsx` file; this is strongly discouraged, as it leaves your tokens readable by anyone with access to your home directory.

--- a/cli/README.md
+++ b/cli/README.md
@@ -59,4 +59,4 @@ The `logout` command lets you remove a stored access token.
  * `ovsx logout <name>`
    the name must correspond to the `publisher` of your extension.
 
-By default `ovsx` stores access tokens in the operating system's credential manager (via [`cross-keychain`](https://www.npmjs.com/package/cross-keychain)). Setting the environment variable `OVSX_STORE=file` switches to storing them as plaintext in the `~/.ovsx` file; this is strongly discouraged, as it leaves your tokens readable by anyone with access to your home directory.
+By default `ovsx` stores access tokens in the operating system's credential manager (via [`cross-keychain`](https://www.npmjs.com/package/cross-keychain)), falling back to storing them as plaintext in the `~/.ovsx` file if the credential manager can't be used. You can also set the environment variable `OVSX_STORE=file` to force plaintext storage; this is strongly discouraged, as it leaves your tokens readable by anyone with access to your home directory.

--- a/cli/package.json
+++ b/cli/package.json
@@ -36,6 +36,7 @@
     "dependencies": {
         "@vscode/vsce": "^3.7.1",
         "commander": "^6.2.1",
+        "cross-keychain": "^1.1.0",
         "follow-redirects": "^1.16.0",
         "is-ci": "^2.0.0",
         "leven": "^3.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ovsx",
-    "version": "1.0.2",
+    "version": "1.1.0-dev.0",
     "description": "Command line interface for Eclipse Open VSX",
     "keywords": [
         "cli",

--- a/cli/src/login.ts
+++ b/cli/src/login.ts
@@ -7,7 +7,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
-import {  } from '@vscode/vsce';
 import { addEnvOptions, getUserInput } from './util';
 import { openDefaultStore } from './store';
 import { LoginOptions } from './login-options';
@@ -20,7 +19,7 @@ export default async function login(options: LoginOptions) {
     }
 
 	const store = await openDefaultStore();
-	let pat = store.get(options.namespace);
+	let pat = await store.get(options.namespace);
 	if (pat) {
 		console.log(`Namespace '${options.namespace}' is already known.`);
 		const answer = await getUserInput('Do you want to overwrite its PAT? [y/N] ');

--- a/cli/src/logout.ts
+++ b/cli/src/logout.ts
@@ -15,7 +15,7 @@ export default async function logout(namespaceName: string) {
     }
 
 	const store = await openDefaultStore();
-	if (!store.get(namespaceName)) {
+	if (!await store.get(namespaceName)) {
 		throw new Error(`Unknown namespace '${namespaceName}'.`);
 	}
 

--- a/cli/src/pat.ts
+++ b/cli/src/pat.ts
@@ -40,7 +40,7 @@ export async function getPAT(namespace: string, options: CreateNamespaceOptions 
     }
 
     const store = await openDefaultStore();
-    let pat = store.get(namespace);
+    let pat = await store.get(namespace);
     if (pat) {
         return pat;
     }

--- a/cli/src/store.ts
+++ b/cli/src/store.ts
@@ -107,7 +107,7 @@ export class KeychainStore implements Store {
 
 export async function openDefaultStore(): Promise<Store> {
 	if (/^file$/i.test(process.env['OVSX_STORE'] ?? '')) {
-		console.warn(`!!  Storing secrets clear-text in '${FileStore.DefaultPath}'. Unset OVSX_STORE to use the system credential store.`);
+		console.warn(`!!  Storing secrets clear-text in '${FileStore.DefaultPath}' (not recommended). Unset OVSX_STORE to use the system credential store instead.`);
 		return await FileStore.open();
 	}
 
@@ -115,7 +115,9 @@ export async function openDefaultStore(): Promise<Store> {
 	try {
 		keychainStore = await KeychainStore.open();
 	} catch (err) {
-		throw new Error(`Failed to open the system credential store: ${err.message}\nAs a last resort, set the environment variable OVSX_STORE=file to store secrets clear-text in '${FileStore.DefaultPath}' (not recommended).`);
+		console.warn(`Failed to open the system credential store: ${err.message}`);
+		console.warn(`!!  Falling back to storing secrets clear-text in '${FileStore.DefaultPath}' (not recommended).`);
+		return await FileStore.open();
 	}
 
 	const fileStore = await FileStore.open();

--- a/cli/src/store.ts
+++ b/cli/src/store.ts
@@ -78,18 +78,21 @@ export class FileStore implements Store {
 	}
 }
 
-export class KeychainStore implements Store {
-	static async open(serviceName = 'ovsx'): Promise<KeychainStore> {
-		const keychain = await import('cross-keychain');
-		// probe the credential store so we can fall back to the file store when it's unusable
+async function verifyBackend(keychain: typeof import('cross-keychain'), serviceName: string, description: string): Promise<void> {
+	// Probe the active backend so we fail fast when it's present but unusable (e.g.
+	// `security`/`secret-tool` exists but the keychain is locked or the daemon is down).
+	try {
 		await keychain.getPassword(serviceName, serviceName);
-
-		return new KeychainStore(keychain, serviceName);
+	} catch (err) {
+		throw new Error(`${description} is unavailable: ${err.message}`);
 	}
+}
 
-	private constructor(
-		private readonly keychain: typeof import('cross-keychain'),
-		private readonly serviceName: string
+/** Shared behaviour for stores backed by the cross-keychain library. */
+abstract class CrossKeychainStore implements Store {
+	protected constructor(
+		protected readonly keychain: typeof import('cross-keychain'),
+		protected readonly serviceName: string
 	) { }
 
 	async get(name: string): Promise<string | undefined> {
@@ -105,32 +108,81 @@ export class KeychainStore implements Store {
 	}
 }
 
+export class KeychainStore extends CrossKeychainStore {
+	static async open(serviceName = 'ovsx'): Promise<KeychainStore> {
+		const keychain = await import('cross-keychain');
+
+		// cross-keychain auto-detects the highest-priority backend for this platform.
+		const { id, name } = await keychain.diagnose();
+		if (id === 'file' || id === 'null') {
+			throw new Error('No OS credential store detected on this platform.');
+		}
+
+		await verifyBackend(keychain, serviceName, `System credential store '${name}'`);
+		return new KeychainStore(keychain, serviceName);
+	}
+}
+
+export class EncryptedFileStore extends CrossKeychainStore {
+	static async open(serviceName = 'ovsx'): Promise<EncryptedFileStore> {
+		const keychain = await import('cross-keychain');
+
+		await keychain.useBackend('file');
+		await verifyBackend(keychain, serviceName, 'Encrypted file store');
+		return new EncryptedFileStore(keychain, serviceName);
+	}
+}
+
 export async function openDefaultStore(): Promise<Store> {
-	if (/^file$/i.test(process.env['OVSX_STORE'] ?? '')) {
-		console.warn(`!!  Storing secrets clear-text in '${FileStore.DefaultPath}' (not recommended). Unset OVSX_STORE to use the system credential store instead.`);
-		return await FileStore.open();
+	// OVSX_STORE=file forces the encrypted file store and skips the OS credential store.
+	const forceFile = /^file$/i.test(process.env['OVSX_STORE'] ?? '');
+
+	let store: KeychainStore | EncryptedFileStore | undefined;
+
+	// Prefer the operating system's credential store.
+	if (!forceFile) {
+		try {
+			store = await KeychainStore.open();
+		} catch (err) {
+			console.warn(err.message);
+		}
 	}
 
-	let keychainStore: Store;
-	try {
-		keychainStore = await KeychainStore.open();
-	} catch (err) {
-		console.warn(`Failed to open the system credential store: ${err.message}`);
+	// Otherwise fall back to cross-keychain's encrypted file store.
+	if (!store) {
+		try {
+			store = await EncryptedFileStore.open();
+			if (!forceFile) {
+				console.warn(`Storing secrets in cross-keychain's encrypted file store instead.`);
+			}
+		} catch (err) {
+			console.warn(err.message);
+		}
+	}
+
+	// Last resort: if no cross-keychain store works, keep publishing usable by storing secrets clear-text.
+	if (!store) {
 		console.warn(`!!  Falling back to storing secrets clear-text in '${FileStore.DefaultPath}' (not recommended).`);
 		return await FileStore.open();
 	}
 
+	await migrateLegacyStore(store);
+
+	return store;
+}
+
+// Migrate secrets from the legacy clear-text file store into the given store, then delete it.
+async function migrateLegacyStore(target: Store): Promise<void> {
 	const fileStore = await FileStore.open();
-
-	// migrate from file store
-	if (fileStore.size) {
-		for (const { name, value } of fileStore) {
-			await keychainStore.add(name, value);
-		}
-
-		await fileStore.deleteStore();
-		console.info(`Migrated ${fileStore.size} publishers to system credential manager. Deleted local store '${fileStore.path}'.`);
+	if (!fileStore.size) {
+		return;
 	}
 
-	return keychainStore;
+	const migrated = fileStore.size;
+	for (const { name, value } of fileStore) {
+		await target.add(name, value);
+	}
+
+	await fileStore.deleteStore();
+	console.info(`Migrated ${migrated} publishers to the credential store. Deleted local store '${fileStore.path}'.`);
 }

--- a/cli/src/store.ts
+++ b/cli/src/store.ts
@@ -16,15 +16,14 @@ interface StoreEntry {
     value: string
 }
 
-export interface Store extends Iterable<StoreEntry> {
-	readonly size: number;
-	get(name: string): string | undefined;
+export interface Store {
+	get(name: string): Promise<string | undefined>;
 	add(name: string, value: string): Promise<void>;
 	delete(name: string): Promise<void>;
 }
 
 export class FileStore implements Store {
-	private static readonly DefaultPath = path.join(homedir(), '.ovsx');
+	static readonly DefaultPath = path.join(homedir(), '.ovsx');
 
 	static async open(path: string = FileStore.DefaultPath): Promise<FileStore> {
 		try {
@@ -59,7 +58,7 @@ export class FileStore implements Store {
 		}
 	}
 
-	get(name: string): string | undefined {
+	async get(name: string): Promise<string | undefined> {
         return this.entries.find(p => p.name === name)?.value;
 	}
 
@@ -79,60 +78,44 @@ export class FileStore implements Store {
 	}
 }
 
-export class KeytarStore implements Store {
-	static async open(serviceName = 'ovsx'): Promise<KeytarStore> {
-		const keytar = await import('keytar');
-		const creds = await keytar.findCredentials(serviceName);
+export class KeychainStore implements Store {
+	static async open(serviceName = 'ovsx'): Promise<KeychainStore> {
+		const keychain = await import('cross-keychain');
+		// probe the credential store so we can fall back to the file store when it's unusable
+		await keychain.getPassword(serviceName, serviceName);
 
-		return new KeytarStore(
-			keytar,
-			serviceName,
-			creds.map(({ account, password }) => ({ name: account, value: password }))
-		);
-	}
-
-	get size(): number {
-		return this.entries.length;
+		return new KeychainStore(keychain, serviceName);
 	}
 
 	private constructor(
-		private readonly keytar: typeof import('keytar'),
-		private readonly serviceName: string,
-		private entries: StoreEntry[]
+		private readonly keychain: typeof import('cross-keychain'),
+		private readonly serviceName: string
 	) { }
 
-	get(name: string): string | undefined {
-        return this.entries.find(p => p.name === name)?.value;
+	async get(name: string): Promise<string | undefined> {
+		return await this.keychain.getPassword(this.serviceName, name) ?? undefined;
 	}
 
 	async add(name: string, value: string): Promise<void> {
-        const newEntry: StoreEntry = { name, value };
-		this.entries = [...this.entries.filter(p => p.name !== name), newEntry];
-		await this.keytar.setPassword(this.serviceName, name, value);
+		await this.keychain.setPassword(this.serviceName, name, value);
 	}
 
 	async delete(name: string): Promise<void> {
-		this.entries = this.entries.filter(p => p.name !== name);
-		await this.keytar.deletePassword(this.serviceName, name);
-	}
-
-	[Symbol.iterator](): Iterator<StoreEntry, any, undefined> {
-		return this.entries[Symbol.iterator]();
+		await this.keychain.deletePassword(this.serviceName, name);
 	}
 }
 
 export async function openDefaultStore(): Promise<Store> {
 	if (/^file$/i.test(process.env['OVSX_STORE'] ?? '')) {
+		console.warn(`!!  Storing secrets clear-text in '${FileStore.DefaultPath}'. Unset OVSX_STORE to use the system credential store.`);
 		return await FileStore.open();
 	}
 
-	let keytarStore: Store;
+	let keychainStore: Store;
 	try {
-		keytarStore = await KeytarStore.open();
+		keychainStore = await KeychainStore.open();
 	} catch (err) {
-		const store = await FileStore.open();
-		console.warn(`Failed to open credential store. Falling back to storing secrets clear-text in: ${store.path}.`);
-		return store;
+		throw new Error(`Failed to open the system credential store: ${err.message}\nAs a last resort, set the environment variable OVSX_STORE=file to store secrets clear-text in '${FileStore.DefaultPath}' (not recommended).`);
 	}
 
 	const fileStore = await FileStore.open();
@@ -140,12 +123,12 @@ export async function openDefaultStore(): Promise<Store> {
 	// migrate from file store
 	if (fileStore.size) {
 		for (const { name, value } of fileStore) {
-			await keytarStore.add(name, value);
+			await keychainStore.add(name, value);
 		}
 
 		await fileStore.deleteStore();
 		console.info(`Migrated ${fileStore.size} publishers to system credential manager. Deleted local store '${fileStore.path}'.`);
 	}
 
-	return keytarStore;
+	return keychainStore;
 }

--- a/cli/src/store.ts
+++ b/cli/src/store.ts
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
+
 import * as fs from 'fs';
 import * as path from 'path';
 import { homedir } from 'os';
@@ -88,7 +89,7 @@ async function verifyBackend(keychain: typeof import('cross-keychain'), serviceN
 	}
 }
 
-/** Shared behaviour for stores backed by the cross-keychain library. */
+/** Shared behavior for stores backed by the cross-keychain library. */
 abstract class CrossKeychainStore implements Store {
 	protected constructor(
 		protected readonly keychain: typeof import('cross-keychain'),
@@ -124,7 +125,7 @@ export class KeychainStore extends CrossKeychainStore {
 }
 
 export class EncryptedFileStore extends CrossKeychainStore {
-	static async open(serviceName = 'ovsx'): Promise<EncryptedFileStore> {
+    static async open(serviceName = 'ovsx'): Promise<EncryptedFileStore> {
 		const keychain = await import('cross-keychain');
 
 		await keychain.useBackend('file');
@@ -144,7 +145,7 @@ export async function openDefaultStore(): Promise<Store> {
 		try {
 			store = await KeychainStore.open();
 		} catch (err) {
-			console.warn(err.message);
+			console.warn(`WARN: ${err.message}`);
 		}
 	}
 
@@ -153,20 +154,25 @@ export async function openDefaultStore(): Promise<Store> {
 		try {
 			store = await EncryptedFileStore.open();
 			if (!forceFile) {
-				console.warn(`Storing secrets in cross-keychain's encrypted file store instead.`);
+				console.warn(`WARN: Storing secrets in cross-keychain's encrypted file store as system keychain is not available..`);
 			}
 		} catch (err) {
-			console.warn(err.message);
+            console.warn(`WARN: ${err.message}`);
 		}
 	}
 
 	// Last resort: if no cross-keychain store works, keep publishing usable by storing secrets clear-text.
 	if (!store) {
-		console.warn(`!!  Falling back to storing secrets clear-text in '${FileStore.DefaultPath}' (not recommended).`);
+		console.warn(`WARN: Falling back to storing secrets clear-text at '${FileStore.DefaultPath}' (not recommended).`);
 		return await FileStore.open();
 	}
 
-	await migrateLegacyStore(store);
+    try {
+        await migrateLegacyStore(store);
+    } catch (err) {
+        console.warn(`WARN: Failed to read legacy file store at '${FileStore.DefaultPath}': ${err.message}`);
+        console.warn(`WARN: Skipping migration of Legacy file store.`);
+    }
 
 	return store;
 }
@@ -184,5 +190,5 @@ async function migrateLegacyStore(target: Store): Promise<void> {
 	}
 
 	await fileStore.deleteStore();
-	console.info(`Migrated ${migrated} publishers to the credential store. Deleted local store '${fileStore.path}'.`);
+	console.info(`INFO: Migrated ${migrated} publishers to the credential store. Deleted local store '${fileStore.path}'.`);
 }

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -10,7 +10,8 @@
         "noImplicitReturns": true,
         "noUnusedLocals": true,
         "strictNullChecks": true,
-        "outDir": "lib"
+        "outDir": "lib",
+        "typeRoots": ["./node_modules/@types"]
     },
     "include": [
         "src"

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -345,6 +345,253 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/ansi@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@inquirer/ansi@npm:1.0.2"
+  checksum: 10/d1496e573a63ee6752bcf3fc93375cdabc55b0d60f0588fe7902282c710b223252ad318ff600ee904e48555634663b53fda517f5b29ce9fbda90bfae18592fbc
+  languageName: node
+  linkType: hard
+
+"@inquirer/checkbox@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "@inquirer/checkbox@npm:4.3.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/4ac5dd2679981e23f066c51c605cb1c63ccda9ea6e1ad895e675eb26702aaf6cf961bf5ca3acd832efba5edcf9883b6742002c801673d2b35c123a7fa7db7b23
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^5.1.21":
+  version: 5.1.21
+  resolution: "@inquirer/confirm@npm:5.1.21"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/a107aa0073965ea510affb9e5b55baf40333503d600970c458c07770cd4e0eee01efc4caba66f0409b0fadc9550d127329622efb543cffcabff3ad0e7f865372
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^10.3.2":
+  version: 10.3.2
+  resolution: "@inquirer/core@npm:10.3.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    cli-width: "npm:^4.1.0"
+    mute-stream: "npm:^2.0.0"
+    signal-exit: "npm:^4.1.0"
+    wrap-ansi: "npm:^6.2.0"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/eb434bdf0ae7d904367003c772bcd80cbf679f79c087c99a4949fd7288e9a2f713ec3ea63381b9a001f52389ab56a77fcd88d64d81a03b1195193410ce8971c2
+  languageName: node
+  linkType: hard
+
+"@inquirer/editor@npm:^4.2.23":
+  version: 4.2.23
+  resolution: "@inquirer/editor@npm:4.2.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/external-editor": "npm:^1.0.3"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/f91b9aadba6ea28a0f4ea5f075af421e076262aebbd737e1b9779f086fa9d559d064e9942a581544645d1dcf56d6b685e8063fe46677880fbca73f6de4e4e7c5
+  languageName: node
+  linkType: hard
+
+"@inquirer/expand@npm:^4.0.23":
+  version: 4.0.23
+  resolution: "@inquirer/expand@npm:4.0.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/73ad1d6376e5efe2a452c33494d6d16ee2670c638ae470a795fdff4acb59a8e032e38e141f87b603b6e96320977519b375dac6471d86d5e3087a9c1db40e3111
+  languageName: node
+  linkType: hard
+
+"@inquirer/external-editor@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@inquirer/external-editor@npm:1.0.3"
+  dependencies:
+    chardet: "npm:^2.1.1"
+    iconv-lite: "npm:^0.7.0"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/c95d7237a885b32031715089f92820525731d4d3c2bd7afdb826307dc296cc2b39e7a644b0bb265441963348cca42e7785feb29c3aaf18fd2b63131769bf6587
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^1.0.15":
+  version: 1.0.15
+  resolution: "@inquirer/figures@npm:1.0.15"
+  checksum: 10/3f858807f361ca29f41ec1076bbece4098cc140d86a06159d42c6e3f6e4d9bec9e10871ccfcbbaa367d6a8462b01dff89f2b1b157d9de6e8726bec85533f525c
+  languageName: node
+  linkType: hard
+
+"@inquirer/input@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@inquirer/input@npm:4.3.1"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/713aaa4c94263299fbd7adfd65378f788cac1b5047f2b7e1ea349ca669db6c7c91b69ab6e2f6660cdbc28c7f7888c5c77ab4433bd149931597e43976d1ba5f34
+  languageName: node
+  linkType: hard
+
+"@inquirer/number@npm:^3.0.23":
+  version: 3.0.23
+  resolution: "@inquirer/number@npm:3.0.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/50694807b71746e15ed69d100aae3c8014d83c90aa660e8a179fe0db1046f26d727947542f64e24cc8b969a61659cb89fe36208cc2b59c1816382b598e686dd2
+  languageName: node
+  linkType: hard
+
+"@inquirer/password@npm:^4.0.23":
+  version: 4.0.23
+  resolution: "@inquirer/password@npm:4.0.23"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/97364970b01c85946a4a50ad876c53ef0c1857a9144e24fad65e5dfa4b4e5dd42564fbcdfa2b49bb049a25d127efbe0882cb18afcdd47b166ebd01c6c4b5e825
+  languageName: node
+  linkType: hard
+
+"@inquirer/prompts@npm:^7.8.6":
+  version: 7.10.1
+  resolution: "@inquirer/prompts@npm:7.10.1"
+  dependencies:
+    "@inquirer/checkbox": "npm:^4.3.2"
+    "@inquirer/confirm": "npm:^5.1.21"
+    "@inquirer/editor": "npm:^4.2.23"
+    "@inquirer/expand": "npm:^4.0.23"
+    "@inquirer/input": "npm:^4.3.1"
+    "@inquirer/number": "npm:^3.0.23"
+    "@inquirer/password": "npm:^4.0.23"
+    "@inquirer/rawlist": "npm:^4.1.11"
+    "@inquirer/search": "npm:^3.2.2"
+    "@inquirer/select": "npm:^4.4.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/b3e3386edd255e4e91c7908050674f8a2e69b043883c00feec2f87d697be37bc6e8cd4a360e7e3233a9825ae7ea044a2ac63d5700926d27f9959013d8566f890
+  languageName: node
+  linkType: hard
+
+"@inquirer/rawlist@npm:^4.1.11":
+  version: 4.1.11
+  resolution: "@inquirer/rawlist@npm:4.1.11"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/0d8f6484cfc20749190e95eecfb2d034bafb3644ec4907b84b1673646f5dd71730e38e35565ea98dfd240d8851e3cff653edafcc4e0af617054b127b407e3229
+  languageName: node
+  linkType: hard
+
+"@inquirer/search@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@inquirer/search@npm:3.2.2"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/abaed2df7763633ff4414b58d1c87233b69ed3cd2ac77629f0d54b72b8b585dc4806c7a2a8261daba58af5b0a2147e586d079fdc82060b6bcf56b75d3d03f3a7
+  languageName: node
+  linkType: hard
+
+"@inquirer/select@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "@inquirer/select@npm:4.4.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/795ec0ac77d575f20bd6a12fb1c040093e62217ac0c80194829a8d3c3d1e09f70ad738e9a9dd6095cc8358fff4e13882209c09bdf8eb0864a86dcabef5b0a6a6
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@inquirer/type@npm:3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/57d113a9db7abc73326491e29bedc88ef362e53779f9f58a1b61225e0be068ce0c54e33cd65f4a13ca46131676fb72c3ef488463c4c9af0aa89680684c55d74c
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -365,6 +612,135 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.4"
   checksum: 10/4412e9e6713c89c1e66d80bb0bb5a2a93192f10477623a27d08f228ba0316bb880affabc5bfe7f838f58a34d26c2c190da726e576cdfc18c49a72e89adabdcf5
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-darwin-arm64@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-darwin-arm64@npm:1.3.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-darwin-x64@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-darwin-x64@npm:1.3.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-freebsd-x64@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-freebsd-x64@npm:1.3.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-arm-gnueabihf@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-linux-arm-gnueabihf@npm:1.3.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-arm64-gnu@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-linux-arm64-gnu@npm:1.3.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-arm64-musl@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-linux-arm64-musl@npm:1.3.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-riscv64-gnu@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-linux-riscv64-gnu@npm:1.3.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-x64-gnu@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-linux-x64-gnu@npm:1.3.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-x64-musl@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-linux-x64-musl@npm:1.3.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-win32-arm64-msvc@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-win32-arm64-msvc@npm:1.3.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-win32-ia32-msvc@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-win32-ia32-msvc@npm:1.3.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-win32-x64-msvc@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-win32-x64-msvc@npm:1.3.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring@npm:^1.2.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring@npm:1.3.0"
+  dependencies:
+    "@napi-rs/keyring-darwin-arm64": "npm:1.3.0"
+    "@napi-rs/keyring-darwin-x64": "npm:1.3.0"
+    "@napi-rs/keyring-freebsd-x64": "npm:1.3.0"
+    "@napi-rs/keyring-linux-arm-gnueabihf": "npm:1.3.0"
+    "@napi-rs/keyring-linux-arm64-gnu": "npm:1.3.0"
+    "@napi-rs/keyring-linux-arm64-musl": "npm:1.3.0"
+    "@napi-rs/keyring-linux-riscv64-gnu": "npm:1.3.0"
+    "@napi-rs/keyring-linux-x64-gnu": "npm:1.3.0"
+    "@napi-rs/keyring-linux-x64-musl": "npm:1.3.0"
+    "@napi-rs/keyring-win32-arm64-msvc": "npm:1.3.0"
+    "@napi-rs/keyring-win32-ia32-msvc": "npm:1.3.0"
+    "@napi-rs/keyring-win32-x64-msvc": "npm:1.3.0"
+  dependenciesMeta:
+    "@napi-rs/keyring-darwin-arm64":
+      optional: true
+    "@napi-rs/keyring-darwin-x64":
+      optional: true
+    "@napi-rs/keyring-freebsd-x64":
+      optional: true
+    "@napi-rs/keyring-linux-arm-gnueabihf":
+      optional: true
+    "@napi-rs/keyring-linux-arm64-gnu":
+      optional: true
+    "@napi-rs/keyring-linux-arm64-musl":
+      optional: true
+    "@napi-rs/keyring-linux-riscv64-gnu":
+      optional: true
+    "@napi-rs/keyring-linux-x64-gnu":
+      optional: true
+    "@napi-rs/keyring-linux-x64-musl":
+      optional: true
+    "@napi-rs/keyring-win32-arm64-msvc":
+      optional: true
+    "@napi-rs/keyring-win32-ia32-msvc":
+      optional: true
+    "@napi-rs/keyring-win32-x64-msvc":
+      optional: true
+  checksum: 10/bfef7fe1dfcfc29a5cf0988ce3dad06a19850351598b6a8f2b8ccd6a8f64540a80f66ae3eb018112bdabb366dbb421c026c418756ffe93d2ea19518aa87c0440
   languageName: node
   linkType: hard
 
@@ -1473,6 +1849,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chardet@npm:^2.1.1":
+  version: 2.2.0
+  resolution: "chardet@npm:2.2.0"
+  checksum: 10/78d1e5ba7bdc7db23511a194eedca805918df90a511f9c57f9cc7c1fc03702ed4ad053e485a766ace930362869269c4a731feaf460ae24bd3ed7d190cde8087d
+  languageName: node
+  linkType: hard
+
 "cheerio-select@npm:^2.1.0":
   version: 2.1.0
   resolution: "cheerio-select@npm:2.1.0"
@@ -1520,6 +1903,13 @@ __metadata:
   version: 2.0.0
   resolution: "ci-info@npm:2.0.0"
   checksum: 10/3b374666a85ea3ca43fa49aa3a048d21c9b475c96eb13c133505d2324e7ae5efd6a454f41efe46a152269e9b6a00c9edbe63ec7fa1921957165aae16625acd67
+  languageName: node
+  linkType: hard
+
+"cli-width@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cli-width@npm:4.1.0"
+  checksum: 10/b58876fbf0310a8a35c79b72ecfcf579b354e18ad04e6b20588724ea2b522799a758507a37dfe132fafaf93a9922cafd9514d9e1598e6b2cd46694853aed099f
   languageName: node
   linkType: hard
 
@@ -1573,6 +1963,22 @@ __metadata:
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
   checksum: 10/9680699c8e2b3af0ae22592cb764acaf973f292a7b71b8a06720233011853a58e256c89216a10cbe889727532fd77f8bcd49a760cedfde271b8e006c20e079f2
+  languageName: node
+  linkType: hard
+
+"cross-keychain@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "cross-keychain@npm:1.1.0"
+  dependencies:
+    "@inquirer/prompts": "npm:^7.8.6"
+    "@napi-rs/keyring": "npm:^1.2.0"
+    meow: "npm:^14.0.0"
+  dependenciesMeta:
+    "@napi-rs/keyring":
+      optional: true
+  bin:
+    cross-keychain: dist/cli.js
+  checksum: 10/8292e835373e29606e79eede335fbf90d3f9152d02ba2a3c91537cf6f3a8d9160b79ca6e8ddae0899a0b017aecffc1428f356a0b59f748e96afab2a1b1773c27
   languageName: node
   linkType: hard
 
@@ -2537,6 +2943,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iconv-lite@npm:^0.7.0":
+  version: 0.7.3
+  resolution: "iconv-lite@npm:0.7.3"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10/b88a3f4527795c96854743bcdcdd03e0083ff5f1c072cb13d3e27c67cd276efd9a2a364922cb836538e976456f82323d645f7ea91d5bc8da1f000dc16742a0aa
+  languageName: node
+  linkType: hard
+
 "ieee754@npm:^1.1.13":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
@@ -3068,6 +3483,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"meow@npm:^14.0.0":
+  version: 14.1.0
+  resolution: "meow@npm:14.1.0"
+  checksum: 10/c6a22b3912a6bc849dee0d6475cd8bb63b9307e26919ca3ace28dc1aaf3d30257071de32bba496f7b5eec3e62b03a6b7731e3d04d18efb3c3103b829aad52ca5
+  languageName: node
+  linkType: hard
+
 "merge2@npm:^1.3.0":
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
@@ -3255,6 +3677,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mute-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mute-stream@npm:2.0.0"
+  checksum: 10/d2e4fd2f5aa342b89b98134a8d899d8ef9b0a6d69274c4af9df46faa2d97aeb1f2ce83d867880d6de63643c52386579b99139801e24e7526c3b9b0a6d1e18d6c
+  languageName: node
+  linkType: hard
+
 "mute-stream@npm:~0.0.4":
   version: 0.0.8
   resolution: "mute-stream@npm:0.0.8"
@@ -3427,6 +3856,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.15.0"
     "@vscode/vsce": "npm:^3.7.1"
     commander: "npm:^6.2.1"
+    cross-keychain: "npm:^1.1.0"
     eslint: "npm:^9.15.0"
     follow-redirects: "npm:^1.16.0"
     is-ci: "npm:^2.0.0"
@@ -3934,7 +4364,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1":
+"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10/c9fa63bbbd7431066174a48ba2dd9986dfd930c3a8b59de9c29d7b6854ec1c12a80d15310869ea5166d413b99f041bfa3dd80a7947bcd44ea8e6eb3ffeabfa1f
@@ -4500,6 +4930,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wrap-ansi@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "wrap-ansi@npm:6.2.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10/0d64f2d438e0b555e693b95aee7b2689a12c3be5ac458192a1ce28f542a6e9e59ddfecc37520910c2c88eb1f82a5411260566dba5064e8f9895e76e169e76187
+  languageName: node
+  linkType: hard
+
 "wrap-ansi@npm:^8.1.0":
   version: 8.1.0
   resolution: "wrap-ansi@npm:8.1.0"
@@ -4583,5 +5024,12 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10/f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"yoctocolors-cjs@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "yoctocolors-cjs@npm:2.1.3"
+  checksum: 10/b2144b38807673a4254dae06fe1a212729550609e606289c305e45c585b36fab1dbba44fe6cde90db9b28be465ec63f4c2a50867aeec6672f6bc36b6c9a361a0
   languageName: node
   linkType: hard


### PR DESCRIPTION
keytar is archived and unmaintained, for now the approach was to fallback to plaintext if for whatever reason the system store fails to bind. That was a likely situation given the unmaintained/archived status of such dependency.

This patch changes the store library to use a cross-keychain, a library that's in active development and should work better cross-platfom-wise.

The old implmentation was already failing to me in macos (in dev environment) and falling back to plain text, I'm not sure about other systems, the tool already migrates plaintext secrets to system keychain as soon as it's available.

A good test would be to run  since this command only interacts with the store and not with the registry, if it replies with unknown namespace it's likely not finding the old token.

In macOS is working fine:

<img width="1055" height="724" alt="image" src="https://github.com/user-attachments/assets/53b66b75-3ee3-48d8-a5d1-1242eb47f33d" />
