### PR TITLE
Change: disable transitive delete of extensions in extension control by default

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
@@ -27,6 +27,7 @@ import org.eclipse.openvsx.scanning.ExtensionScanService;
 import org.eclipse.openvsx.search.SearchUtilService;
 import org.eclipse.openvsx.util.*;
 import org.jobrunr.scheduling.JobRequestScheduler;
+import org.jspecify.annotations.NonNull;
 import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -250,7 +251,7 @@ public class ExtensionService {
             String extensionName,
             TargetPlatformVersion... targetVersions
     ) throws ErrorResultException {
-        var extension = lockExtension(namespaceName, extensionName);
+        var extension = lockExtensionNoWait(namespaceName, extensionName);
         if (repositories.isDeleteAllVersions(restrictedToUser ? user : null, namespaceName, extensionName, targetVersions)) {
             return deleteExtension(user, extension, true);
         }
@@ -286,11 +287,25 @@ public class ExtensionService {
     }
 
     /**
+     * Locks and return the {@code Extension} identified by {@code namespaceName} and {@code extensionName}.
+     *
+     * @throws ErrorResultException if no extension exists with the given namespace and extension name
+     */
+    public @NonNull Extension lockExtension(String namespaceName, String extensionName) throws ErrorResultException {
+        var extension = repositories.findExtensionForUpdate(extensionName, namespaceName);
+        if (extension == null) {
+            var extensionId = NamingUtil.toExtensionId(namespaceName, extensionName);
+            throw new ErrorResultException("Extension not found: " + extensionId, HttpStatus.NOT_FOUND);
+        }
+        return extension;
+    }
+
+    /**
      * Locks the extension row ({@code SELECT … FOR UPDATE NOWAIT}) without waiting.
      * <p>
      * If the lock can not be acquired, throw an {@code ErrorResultException} with status code {@code 409}.
      */
-    private Extension lockExtension(String namespaceName, String extensionName) throws ErrorResultException {
+    private Extension lockExtensionNoWait(String namespaceName, String extensionName) throws ErrorResultException {
         Extension extension;
         try {
             extension = repositories.findExtensionForUpdateNoWait(extensionName, namespaceName);

--- a/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
@@ -217,6 +217,9 @@ public class ExtensionService {
     /**
      * Delete an extension version published by the given user.
      * <p>
+     * The extension will be locked for the operation. If the lock can not be acquired, i.e. the extension
+     * is updated at the same time, the operation will fail.
+     * <p>
      * If the resolved extension version has not been published by the given user,
      * a {@code ErrorResultException} will be thrown.
      */
@@ -233,6 +236,9 @@ public class ExtensionService {
     /**
      * Deletes the given extension.
      * <p>
+     * The extension will be locked for the operation. If the lock can not be acquired, i.e. the extension
+     * is updated at the same time, the operation will fail.
+     * <p>
      * If {@code restrictedToUser} is {@code true}, the deletion operation is only successful if the user
      * has published the respective extension version.
      */
@@ -246,7 +252,7 @@ public class ExtensionService {
     ) throws ErrorResultException {
         var extension = lockExtension(namespaceName, extensionName);
         if (repositories.isDeleteAllVersions(restrictedToUser ? user : null, namespaceName, extensionName, targetVersions)) {
-            return deleteExtension(user, extension);
+            return deleteExtension(user, extension, true);
         }
 
         return deleteExtensionVersions(user, Arrays.stream(targetVersions)
@@ -280,8 +286,9 @@ public class ExtensionService {
     }
 
     /**
-     * Locks the extension row ({@code SELECT … FOR UPDATE NOWAIT}).
-     * this fails fast with {@code 409}
+     * Locks the extension row ({@code SELECT … FOR UPDATE NOWAIT}) without waiting.
+     * <p>
+     * If the lock can not be acquired, throw an {@code ErrorResultException} with status code {@code 409}.
      */
     private Extension lockExtension(String namespaceName, String extensionName) throws ErrorResultException {
         Extension extension;
@@ -312,22 +319,34 @@ public class ExtensionService {
         return result;
     }
 
+    /**
+     * Delete the given extension and evict caches.
+     * <p>
+     * If {@code checkDependencies} is {@code true} and this extension is referenced by a bundle or used
+     * as a dependency, the delete operation will fail.
+     *
+     * @param user the user that will be used for logging the operation
+     * @param extension the extension to delete
+     * @param checkDependencies whether to check if this extension is still references by bundles or as a dependency
+     */
     @Transactional(rollbackOn = ErrorResultException.class)
-    public ResultJson deleteExtension(UserData user, Extension extension) throws ErrorResultException {
-        var bundledRefs = repositories.findBundledExtensionsReference(extension);
-        if (!bundledRefs.isEmpty()) {
-            throw new ErrorResultException("Extension " + NamingUtil.toExtensionId(extension)
-                    + " is bundled by the following extension packs: "
-                    + bundledRefs.stream()
-                    .map(NamingUtil::toFileFormat)
-                    .collect(Collectors.joining(", ")));
-        }
-        var dependRefs = repositories.findDependenciesReference(extension);
-        if (!dependRefs.isEmpty()) {
-            throw new ErrorResultException("The following extensions have a dependency on " + NamingUtil.toExtensionId(extension) + ": "
-                    + dependRefs.stream()
-                    .map(NamingUtil::toFileFormat)
-                    .collect(Collectors.joining(", ")));
+    public ResultJson deleteExtension(UserData user, Extension extension, boolean checkDependencies) throws ErrorResultException {
+        if (checkDependencies) {
+            var bundledRefs = repositories.findBundledExtensionsReference(extension);
+            if (!bundledRefs.isEmpty()) {
+                throw new ErrorResultException("Extension " + NamingUtil.toExtensionId(extension)
+                        + " is bundled by the following extension packs: "
+                        + bundledRefs.stream()
+                        .map(NamingUtil::toFileFormat)
+                        .collect(Collectors.joining(", ")));
+            }
+            var dependRefs = repositories.findDependenciesReference(extension);
+            if (!dependRefs.isEmpty()) {
+                throw new ErrorResultException("The following extensions have a dependency on " + NamingUtil.toExtensionId(extension) + ": "
+                        + dependRefs.stream()
+                        .map(NamingUtil::toFileFormat)
+                        .collect(Collectors.joining(", ")));
+            }
         }
 
         for (var extVersion : repositories.findVersions(extension)) {

--- a/server/src/main/java/org/eclipse/openvsx/admin/AdminAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/admin/AdminAPI.java
@@ -419,7 +419,7 @@ public class AdminAPI {
         try {
             var adminUser = admins.checkAdminUser(tokenValue);
             var targets = CollectionUtil.toArray(targetVersions, TargetPlatformVersionJson::toTargetPlatformVersion, TargetPlatformVersion[]::new);
-            var result = admins.deleteExtension(adminUser, namespaceName, extensionName, targets);
+            var result = admins.deleteExtensionNoWait(adminUser, namespaceName, extensionName, targets);
             return ResponseEntity.ok(result);
         } catch (ErrorResultException exc) {
             return exc.toResponseEntity();
@@ -455,7 +455,7 @@ public class AdminAPI {
         try {
             var adminUser = admins.checkAdminUser();
             var targets = CollectionUtil.toArray(targetVersions, TargetPlatformVersionJson::toTargetPlatformVersion, TargetPlatformVersion[]::new);
-            var result = admins.deleteExtension(adminUser, namespaceName, extensionName, targets);
+            var result = admins.deleteExtensionNoWait(adminUser, namespaceName, extensionName, targets);
             return ResponseEntity.ok(result);
         } catch (ErrorResultException exc) {
             return exc.toResponseEntity();

--- a/server/src/main/java/org/eclipse/openvsx/admin/AdminService.java
+++ b/server/src/main/java/org/eclipse/openvsx/admin/AdminService.java
@@ -122,12 +122,7 @@ public class AdminService {
      */
     @Transactional(rollbackOn = ErrorResultException.class)
     public void lockAndDeleteExtensionAndDependencies(UserData admin, String namespaceName, String extensionName) throws ErrorResultException {
-        var extension = repositories.findExtensionForUpdate(extensionName, namespaceName);
-        if (extension == null) {
-            var extensionId = NamingUtil.toExtensionId(namespaceName, extensionName);
-            throw new ErrorResultException("Extension not found: " + extensionId, HttpStatus.NOT_FOUND);
-        }
-
+        var extension = extensions.lockExtension(namespaceName, extensionName);
         deleteExtensionAndDependencies(admin, extension, 0);
     }
 
@@ -175,12 +170,7 @@ public class AdminService {
      */
     @Transactional(rollbackOn = ErrorResultException.class)
     public void lockAndDeleteExtension(UserData admin, String namespaceName, String extensionName) throws ErrorResultException {
-        var extension = repositories.findExtensionForUpdate(extensionName, namespaceName);
-        if (extension == null) {
-            var extensionId = NamingUtil.toExtensionId(namespaceName, extensionName);
-            throw new ErrorResultException("Extension not found: " + extensionId, HttpStatus.NOT_FOUND);
-        }
-
+        var extension = extensions.lockExtension(namespaceName, extensionName);
         extensions.deleteExtension(admin, extension, false);
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/admin/AdminService.java
+++ b/server/src/main/java/org/eclipse/openvsx/admin/AdminService.java
@@ -116,12 +116,12 @@ public class AdminService {
     }
 
     /**
-     * Locks and deletes the given extension together with all bundled or dependent extensions.
+     * Deletes the given extension together with all bundled or dependent extensions.
      * <p>
      * No further checks are made if the extension is referenced by bundles or as a dependency.
      */
     @Transactional(rollbackOn = ErrorResultException.class)
-    public void lockAndDeleteExtensionAndDependencies(UserData admin, String namespaceName, String extensionName) throws ErrorResultException {
+    public void deleteExtensionAndDependencies(UserData admin, String namespaceName, String extensionName) throws ErrorResultException {
         var extension = extensions.lockExtension(namespaceName, extensionName);
         deleteExtensionAndDependencies(admin, extension, 0);
     }
@@ -163,13 +163,13 @@ public class AdminService {
     }
 
     /**
-     * Locks and deletes the given extension unconditionally. No further checks are made if the extension
+     * Deletes the given extension unconditionally. No further checks are made if the extension
      * is referenced by bundles or as a dependency.
      * <p>
      * This method is intended for non-user interaction as it will wait till the lock can be acquired.
      */
     @Transactional(rollbackOn = ErrorResultException.class)
-    public void lockAndDeleteExtension(UserData admin, String namespaceName, String extensionName) throws ErrorResultException {
+    public void deleteExtension(UserData admin, String namespaceName, String extensionName) throws ErrorResultException {
         var extension = extensions.lockExtension(namespaceName, extensionName);
         extensions.deleteExtension(admin, extension, false);
     }
@@ -183,7 +183,7 @@ public class AdminService {
      * This method is intended to be used for user interaction as it can fail when the extension is concurrently updated.
      */
     @Transactional(rollbackOn = ErrorResultException.class)
-    public ResultJson deleteExtension(
+    public ResultJson deleteExtensionNoWait(
         UserData user,
         String namespaceName,
         String extensionName,

--- a/server/src/main/java/org/eclipse/openvsx/admin/AdminService.java
+++ b/server/src/main/java/org/eclipse/openvsx/admin/AdminService.java
@@ -115,9 +115,14 @@ public class AdminService {
         scheduler.scheduleRecurrently("MonthlyAdminStatistics", Cron.monthly(1, 0, 3), ZoneId.of("UTC"), jobRequest);
     }
 
+    /**
+     * Locks and deletes the given extension together with all bundled or dependent extensions.
+     * <p>
+     * No further checks are made if the extension is referenced by bundles or as a dependency.
+     */
     @Transactional(rollbackOn = ErrorResultException.class)
-    public void deleteExtensionAndDependencies(UserData admin, String namespaceName, String extensionName) throws ErrorResultException {
-        var extension = repositories.findExtension(extensionName, namespaceName);
+    public void lockAndDeleteExtensionAndDependencies(UserData admin, String namespaceName, String extensionName) throws ErrorResultException {
+        var extension = repositories.findExtensionForUpdate(extensionName, namespaceName);
         if (extension == null) {
             var extensionId = NamingUtil.toExtensionId(namespaceName, extensionName);
             throw new ErrorResultException("Extension not found: " + extensionId, HttpStatus.NOT_FOUND);
@@ -128,7 +133,10 @@ public class AdminService {
 
     private void deleteExtensionAndDependencies(UserData admin, Extension extension, int depth) throws ErrorResultException {
         if (depth > 5) {
-            throw new ErrorResultException("Failed to delete extension and its dependencies. Exceeded maximum recursion depth.", HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new ErrorResultException(
+                    "Failed to delete extension and its dependencies. Exceeded maximum recursion depth.",
+                    HttpStatus.INTERNAL_SERVER_ERROR
+            );
         }
 
         var bundledRefs = repositories.findBundledExtensionsReference(extension);
@@ -141,29 +149,9 @@ public class AdminService {
             deleteExtensionAndDependencies(admin, dependRef, depth);
         }
 
-        for (var extVersion : repositories.findVersions(extension)) {
-            extensions.removeExtensionVersion(extVersion);
-        }
-
-        for (var review : repositories.findAllReviews(extension)) {
-            entityManager.remove(review);
-        }
-
-        var deprecatedExtensions = repositories.findDeprecatedExtensions(extension);
-        for (var deprecatedExtension : deprecatedExtensions) {
-            deprecatedExtension.setReplacement(null);
-            cache.evictExtensionJsons(deprecatedExtension);
-        }
-
-        entityManager.remove(extension);
-
-        // evict the cache entries only after the changes have been commited
-        cache.evictExtensionJsons(extension);
-        cache.evictNamespaceDetails(extension);
-        cache.evictLatestExtensionVersion(extension);
-
-        search.removeSearchEntry(extension);
-        logs.logAction(admin, ResultJson.success("Deleted " + NamingUtil.toExtensionId(extension)));
+        // We unconditionally delete the extension,
+        // not checking if there are dependencies on this extension.
+        extensions.deleteExtension(admin, extension, false);
     }
 
     private void deleteExtensionAndDependencies(UserData admin, ExtensionVersion extVersion, int depth) {
@@ -180,10 +168,29 @@ public class AdminService {
     }
 
     /**
-     * Delete the provided versions of an extension.
+     * Locks and deletes the given extension unconditionally. No further checks are made if the extension
+     * is referenced by bundles or as a dependency.
      * <p>
-     * The extension version is deleted unconditionally if it exists, no further authorization checks
-     * are performed, i.e. if the given user does own the extension or is an admin user.
+     * This method is intended for non-user interaction as it will wait till the lock can be acquired.
+     */
+    @Transactional(rollbackOn = ErrorResultException.class)
+    public void lockAndDeleteExtension(UserData admin, String namespaceName, String extensionName) throws ErrorResultException {
+        var extension = repositories.findExtensionForUpdate(extensionName, namespaceName);
+        if (extension == null) {
+            var extensionId = NamingUtil.toExtensionId(namespaceName, extensionName);
+            throw new ErrorResultException("Extension not found: " + extensionId, HttpStatus.NOT_FOUND);
+        }
+
+        extensions.deleteExtension(admin, extension, false);
+    }
+
+    /**
+     * Delete the provided versions of an extension. If all versions of the extension shall be deleted, the
+     * extension as a whole will be removed unless it is referenced by bundles or used as a dependency.
+     * <p>
+     * The method will try to lock the extension and fail with an {@code ErrorResultException} if it can't acquire it.
+     * <p>
+     * This method is intended to be used for user interaction as it can fail when the extension is concurrently updated.
      */
     @Transactional(rollbackOn = ErrorResultException.class)
     public ResultJson deleteExtension(

--- a/server/src/main/java/org/eclipse/openvsx/extension_control/ExtensionControlJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/extension_control/ExtensionControlJobRequestHandler.java
@@ -75,7 +75,11 @@ public class ExtensionControlJobRequestHandler implements JobRequestHandler<Hand
             var extensionId = NamingUtil.fromExtensionId(item.asString());
             if (extensionId != null && repositories.hasExtension(extensionId.namespace(), extensionId.extension())) {
                 logger.info("delete malicious extension");
-                admin.deleteExtensionAndDependencies(extensionControlUser, extensionId.namespace(), extensionId.extension());
+                if (service.deleteTransitively) {
+                    admin.lockAndDeleteExtensionAndDependencies(extensionControlUser, extensionId.namespace(), extensionId.extension());
+                } else {
+                    admin.lockAndDeleteExtension(extensionControlUser, extensionId.namespace(), extensionId.extension());
+                }
             }
         }
     }

--- a/server/src/main/java/org/eclipse/openvsx/extension_control/ExtensionControlJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/extension_control/ExtensionControlJobRequestHandler.java
@@ -76,9 +76,9 @@ public class ExtensionControlJobRequestHandler implements JobRequestHandler<Hand
             if (extensionId != null && repositories.hasExtension(extensionId.namespace(), extensionId.extension())) {
                 logger.info("delete malicious extension");
                 if (service.deleteTransitively) {
-                    admin.lockAndDeleteExtensionAndDependencies(extensionControlUser, extensionId.namespace(), extensionId.extension());
+                    admin.deleteExtensionAndDependencies(extensionControlUser, extensionId.namespace(), extensionId.extension());
                 } else {
-                    admin.lockAndDeleteExtension(extensionControlUser, extensionId.namespace(), extensionId.extension());
+                    admin.deleteExtension(extensionControlUser, extensionId.namespace(), extensionId.extension());
                 }
             }
         }

--- a/server/src/main/java/org/eclipse/openvsx/extension_control/ExtensionControlService.java
+++ b/server/src/main/java/org/eclipse/openvsx/extension_control/ExtensionControlService.java
@@ -56,6 +56,9 @@ public class ExtensionControlService {
     @Value("${ovsx.extension-control.enabled:true}")
     boolean enabled;
 
+    @Value("${ovsx.extension-control.delete-transitively:false}")
+    boolean deleteTransitively;
+
     @Value("${ovsx.extension-control.update-on-start:false}")
     boolean updateOnStart;
 
@@ -92,7 +95,7 @@ public class ExtensionControlService {
     public UserData createExtensionControlUser() {
         var userName = "ExtensionControlUser";
         var user = repositories.findUserByLoginName("system", userName);
-        if(user == null) {
+        if (user == null) {
             user = new UserData();
             user.setProvider("system");
             user.setLoginName(userName);
@@ -132,13 +135,13 @@ public class ExtensionControlService {
 
     @Cacheable(CACHE_MALICIOUS_EXTENSIONS)
     public List<String> getMaliciousExtensionIds() throws IOException {
-        if(!enabled) {
+        if (!enabled) {
             return Collections.emptyList();
         }
 
         var json = getExtensionControlJson();
         var malicious = json.get("malicious");
-        if(!malicious.isArray()) {
+        if (!malicious.isArray()) {
             logger.error("field 'malicious' is not an array");
             return Collections.emptyList();
         }

--- a/server/src/main/java/org/eclipse/openvsx/migration/FixTargetPlatformsJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/FixTargetPlatformsJobRequestHandler.java
@@ -11,10 +11,7 @@ package org.eclipse.openvsx.migration;
 
 import org.eclipse.openvsx.ExtensionProcessor;
 import org.eclipse.openvsx.ExtensionService;
-import org.eclipse.openvsx.admin.AdminService;
-import org.eclipse.openvsx.entities.ExtensionVersion;
 import org.eclipse.openvsx.util.NamingUtil;
-import org.eclipse.openvsx.util.TargetPlatformVersion;
 import org.jobrunr.jobs.annotations.Job;
 import org.jobrunr.jobs.context.JobRunrDashboardLogger;
 import org.jobrunr.jobs.lambdas.JobRequestHandler;
@@ -32,18 +29,15 @@ public class FixTargetPlatformsJobRequestHandler implements JobRequestHandler<Mi
     protected final Logger logger = new JobRunrDashboardLogger(LoggerFactory.getLogger(FixTargetPlatformsJobRequestHandler.class));
 
     private final ExtensionService extensions;
-    private final AdminService admins;
     private final MigrationService migrations;
     private final FixTargetPlatformsService service;
 
     public FixTargetPlatformsJobRequestHandler(
             ExtensionService extensions,
-            AdminService admins,
             MigrationService migrations,
             FixTargetPlatformsService service
     ) {
         this.extensions = extensions;
-        this.admins = admins;
         this.migrations = migrations;
         this.service = service;
     }
@@ -69,21 +63,11 @@ public class FixTargetPlatformsJobRequestHandler implements JobRequestHandler<Mi
                         .addArgument(() -> NamingUtil.toLogFormat(extVersion))
                         .log();
 
-                deleteExtension(extVersion);
+                extensions.deleteExtensionVersion(service.getUser(), extVersion);
                 try (var input = Files.newInputStream(extensionFile.getPath())) {
                     extensions.publishVersion(input, extVersion.getPublishedWith());
                 }
             }
         }
-    }
-
-    private void deleteExtension(ExtensionVersion extVersion) {
-        var extension = extVersion.getExtension();
-        admins.deleteExtension(
-                service.getUser(),
-                extension.getNamespace().getName(),
-                extension.getName(),
-                TargetPlatformVersion.of(extVersion.getTargetPlatform(), extVersion.getVersion())
-        );
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/mirror/DataMirrorJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/mirror/DataMirrorJobRequestHandler.java
@@ -138,7 +138,7 @@ public class DataMirrorJobRequestHandler implements JobRequestHandler<DataMirror
             ThreadLocalJobContext.getJobContext().logger().info("deleting " + extensionId);
             try {
                 var namespace = extension.getNamespace();
-                admin.deleteExtension(mirrorUser, namespace.getName(), extension.getName());
+                admin.deleteExtensionNoWait(mirrorUser, namespace.getName(), extension.getName());
             } catch (ErrorResultException e) {
                 if (e.getStatus() != HttpStatus.NOT_FOUND) {
                     logger.warn("mirror: failed to delete extension {}", extensionId, e);

--- a/server/src/main/java/org/eclipse/openvsx/mirror/DataMirrorService.java
+++ b/server/src/main/java/org/eclipse/openvsx/mirror/DataMirrorService.java
@@ -239,7 +239,7 @@ public class DataMirrorService {
 
     public void deleteExtensionVersion(ExtensionVersion extVersion, UserData user) {
         var extension = extVersion.getExtension();
-        admin.deleteExtension(
+        admin.deleteExtensionNoWait(
                 user,
                 extension.getNamespace().getName(),
                 extension.getName(),

--- a/server/src/test/java/org/eclipse/openvsx/cache/CacheServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/cache/CacheServiceTest.java
@@ -238,7 +238,7 @@ class CacheServiceTest {
 
             registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
 
-            admins.deleteExtension(admin, namespace.getName(), extension.getName());
+            admins.deleteExtensionNoWait(admin, namespace.getName(), extension.getName());
             assertNull(getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
         }
     }
@@ -263,7 +263,12 @@ class CacheServiceTest {
                 assertTrue(json.getAllVersions().containsKey(newVersion));
                 assertTrue(json.getAllVersions().containsKey(oldVersion));
 
-                admins.deleteExtension(admin, namespace.getName(), extension.getName(), TargetPlatformVersion.of(extVersion.getTargetPlatform(), newVersion));
+                admins.deleteExtensionNoWait(
+                        admin,
+                        namespace.getName(),
+                        extension.getName(),
+                        TargetPlatformVersion.of(extVersion.getTargetPlatform(), newVersion)
+                );
                 assertNull(getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
 
                 entityManager.flush();

--- a/server/src/test/java/org/eclipse/openvsx/cache/CacheServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/cache/CacheServiceTest.java
@@ -18,7 +18,6 @@ import org.eclipse.openvsx.admin.AdminService;
 import org.eclipse.openvsx.entities.*;
 import org.eclipse.openvsx.json.ExtensionJson;
 import org.eclipse.openvsx.json.ReviewJson;
-import org.eclipse.openvsx.json.TargetPlatformVersionJson;
 import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.security.IdPrincipal;
 import org.eclipse.openvsx.util.TargetPlatformVersion;
@@ -28,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authentication.TestingAuthenticationToken;
@@ -43,6 +43,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
+import static org.eclipse.openvsx.cache.CacheService.CACHE_AVERAGE_REVIEW_RATING;
 import static org.eclipse.openvsx.cache.CacheService.CACHE_EXTENSION_JSON;
 import static org.eclipse.openvsx.entities.FileResource.DOWNLOAD;
 import static org.eclipse.openvsx.entities.FileResource.STORAGE_LOCAL;
@@ -78,8 +79,14 @@ class CacheServiceTest {
     @BeforeEach
     public void clearCaches() {
         for (var name : cache.getCacheNames()) {
-            cache.getCache(name).clear();
+            getCache(name).clear();
         }
+    }
+
+    private Cache getCache(String name) {
+        var c = cache.getCache(name);
+        assert c != null;
+        return c;
     }
 
     @Test
@@ -94,7 +101,7 @@ class CacheServiceTest {
                     extVersion.getTargetPlatform(), extVersion.getVersion());
 
             var json = registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
-            var cachedJson = cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
+            var cachedJson = getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
             assertEquals(json, cachedJson);
         }
     }
@@ -121,7 +128,7 @@ class CacheServiceTest {
             updatedUser.setAvatarUrl("https://github.com/user2/avatar");
 
             users.upsertUser(updatedUser);
-            assertNull(cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
+            assertNull(getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
 
             var json = registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
             assertEquals("user", json.getPublishedBy().getLoginName());
@@ -130,7 +137,7 @@ class CacheServiceTest {
             assertEquals("github", json.getPublishedBy().getProvider());
             assertEquals("https://github.com/user2/avatar", json.getPublishedBy().getAvatarUrl());
 
-            var cachedJson = cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
+            var cachedJson = getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
             assertEquals(json, cachedJson);
         }
     }
@@ -161,7 +168,7 @@ class CacheServiceTest {
             review.setTimestamp("2000-01-01T10:00Z");
 
             registry.postReview(review, namespace.getName(), extension.getName());
-            assertNull(cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
+            assertNull(getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
 
             entityManager.flush();
 
@@ -169,7 +176,7 @@ class CacheServiceTest {
             assertEquals(Long.valueOf(1), json.getReviewCount());
             assertEquals(Double.valueOf(3), json.getAverageRating());
 
-            var cachedJson = cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
+            var cachedJson = getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
             assertEquals(json, cachedJson);
         }
     }
@@ -204,7 +211,7 @@ class CacheServiceTest {
             assertEquals(Double.valueOf(3), json.getAverageRating());
 
             registry.deleteReview(namespace.getName(), extension.getName());
-            assertNull(cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
+            assertNull(getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
 
             entityManager.flush();
 
@@ -212,7 +219,7 @@ class CacheServiceTest {
             assertEquals(Long.valueOf(0), json.getReviewCount());
             assertNull(json.getAverageRating());
 
-            var cachedJson = cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
+            var cachedJson = getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
             assertEquals(json, cachedJson);
         }
     }
@@ -232,7 +239,7 @@ class CacheServiceTest {
             registry.getExtension(namespace.getName(), extension.getName(), extVersion.getTargetPlatform(), extVersion.getVersion());
 
             admins.deleteExtension(admin, namespace.getName(), extension.getName());
-            assertNull(cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
+            assertNull(getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
         }
     }
 
@@ -257,7 +264,7 @@ class CacheServiceTest {
                 assertTrue(json.getAllVersions().containsKey(oldVersion));
 
                 admins.deleteExtension(admin, namespace.getName(), extension.getName(), TargetPlatformVersion.of(extVersion.getTargetPlatform(), newVersion));
-                assertNull(cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
+                assertNull(getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
 
                 entityManager.flush();
 
@@ -265,7 +272,7 @@ class CacheServiceTest {
                 assertFalse(json.getAllVersions().containsKey(newVersion));
                 assertTrue(json.getAllVersions().containsKey(oldVersion));
 
-                var cachedJson = cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
+                var cachedJson = getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
                 assertEquals(json, cachedJson);
             }
         }
@@ -289,7 +296,7 @@ class CacheServiceTest {
             try (var newTempFile = insertNewVersion(extension, extVersion.getPublishedWith(), newVersion)) {
                 newTempFile.getResource().getExtension().setPreRelease(true);
                 extensions.updateExtension(extension);
-                assertNull(cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
+                assertNull(getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class));
 
                 entityManager.flush();
 
@@ -299,7 +306,7 @@ class CacheServiceTest {
                 assertTrue(json.getAllVersions().containsKey("latest"));
                 assertTrue(json.getAllVersions().containsKey("pre-release"));
 
-                var cachedJson = cache.getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
+                var cachedJson = getCache(CACHE_EXTENSION_JSON).get(cacheKey, ExtensionJson.class);
                 assertEquals(json, cachedJson);
             }
         }
@@ -325,7 +332,7 @@ class CacheServiceTest {
             // returns cached value
             assertEquals(0L, repositories.getAverageReviewRating());
 
-            cache.getCache(CacheService.CACHE_AVERAGE_REVIEW_RATING).clear();
+            getCache(CACHE_AVERAGE_REVIEW_RATING).clear();
 
             // returns new value from database
             assertEquals(3L, repositories.getAverageReviewRating());


### PR DESCRIPTION
This PR adds a new configuration parameter `ovsx.extension-control.delete-transitively` which is set to `false` by default.

It controls whether the recurring extension control job deletes transitive dependencies of malicious extensions.

Additional changes in this PR:

 - further reduce code duplication
 - make method names more descriptive
 - add javadoc outlining the contract for the various deleteExtension method
