### PR TITLE
feat: reject namespace display names that collide with other namespaces

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -224,8 +224,11 @@ tasks.register('unitTests', Test) {
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
     useJUnitPlatform()
+    exclude 'org/eclipse/openvsx/ExtensionDeleteTest.class'
     exclude 'org/eclipse/openvsx/IntegrationTest.class'
     exclude 'org/eclipse/openvsx/cache/CacheServiceTest.class'
+    exclude 'org/eclipse/openvsx/ratelimit/RateLimitIntegrationTest.class'
+    exclude 'org/eclipse/openvsx/repositories/NamespaceRepositoryTest.class'
     exclude 'org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.class'
     exclude 'org/eclipse/openvsx/storage/AwsStorageServiceIntegrationTest.class'
 }

--- a/server/src/main/java/org/eclipse/openvsx/UserService.java
+++ b/server/src/main/java/org/eclipse/openvsx/UserService.java
@@ -174,14 +174,16 @@ public class UserService {
 
         if (!Objects.equals(details.getDisplayName(), namespace.getDisplayName())) {
             if (StringUtils.isNotEmpty(details.getDisplayName())) {
-                repositories.findNamespaceConflict(details.getDisplayName(), namespace.getName())
-                .ifPresent(conflict -> {
+                var conflictingNamespaces = repositories.findConflictingNamespaces(details.getDisplayName(), namespace);
+                if (!conflictingNamespaces.isEmpty()) {
+                    // pick the first conflicting namespace
+                    var conflictingNamespace = conflictingNamespaces.getFirst();
                     throw new ErrorResultException(
                             "Display name '" + details.getDisplayName()
-                                    + "' collides with the name of existing namespace '" + conflict.getName()
-                                    + " (" + conflict.getDisplayName() + ")"
+                                    + "' collides with the name of existing namespace '" + conflictingNamespace.getName()
+                                    + " (" + conflictingNamespace.getDisplayName() + ")"
                                     + "'. Please choose a different display name.");
-                });
+                }
             }
             namespace.setDisplayName(details.getDisplayName());
         }

--- a/server/src/main/java/org/eclipse/openvsx/UserService.java
+++ b/server/src/main/java/org/eclipse/openvsx/UserService.java
@@ -173,6 +173,16 @@ public class UserService {
         }
 
         if (!Objects.equals(details.getDisplayName(), namespace.getDisplayName())) {
+            if (StringUtils.isNotEmpty(details.getDisplayName())) {
+                repositories.findNamespaceConflict(details.getDisplayName(), namespace.getName())
+                .ifPresent(conflict -> {
+                    throw new ErrorResultException(
+                            "Display name '" + details.getDisplayName()
+                                    + "' collides with the name of existing namespace '" + conflict.getName()
+                                    + " (" + conflict.getDisplayName() + ")"
+                                    + "'. Please choose a different display name.");
+                });
+            }
             namespace.setDisplayName(details.getDisplayName());
         }
         if (!Objects.equals(details.getDescription(), namespace.getDescription())) {

--- a/server/src/main/java/org/eclipse/openvsx/repositories/NamespaceRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/NamespaceRepository.java
@@ -14,9 +14,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.util.Streamable;
 
+import java.util.Optional;
+
 public interface NamespaceRepository extends Repository<Namespace, Long> {
 
     Namespace findByNameIgnoreCase(String name);
+
+    @Query("from Namespace n where (upper(n.displayName) = upper(?1) or upper(n.name) = upper(?1)) and upper(n.name) <> upper(?2)")
+    Optional<Namespace> findConflictingNamespace(String displayName, String excludedName);
 
     Namespace findByPublicId(String publicId);
 

--- a/server/src/main/java/org/eclipse/openvsx/repositories/NamespaceRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/NamespaceRepository.java
@@ -12,16 +12,24 @@ package org.eclipse.openvsx.repositories;
 import org.eclipse.openvsx.entities.Namespace;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.util.Streamable;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface NamespaceRepository extends Repository<Namespace, Long> {
 
     Namespace findByNameIgnoreCase(String name);
 
-    @Query("from Namespace n where (upper(n.displayName) = upper(?1) or upper(n.name) = upper(?1)) and upper(n.name) <> upper(?2)")
-    Optional<Namespace> findConflictingNamespace(String displayName, String excludedName);
+    /**
+     * Returns a list of namespaces whose name or displayName matches the given displayName case-insensitive.
+     *
+     * @param displayName the displayName to check for existing conflicts
+     * @param excludeNamespace the namespace to exclude
+     * @return a list of namespaces or an empty list of there are no conflicts
+     */
+    @Query("from Namespace n where (lower(n.displayName) = lower(:displayName) or lower(n.name) = lower(:displayName)) and n <> :namespace")
+    List<Namespace> findConflictingNamespaces(String displayName, @Param("namespace") Namespace excludeNamespace);
 
     Namespace findByPublicId(String publicId);
 

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -186,6 +186,10 @@ public class RepositoryService {
         return namespaceRepo.findByNameIgnoreCase(name);
     }
 
+    public Optional<Namespace> findNamespaceConflict(String displayName, String excludedName) {
+        return namespaceRepo.findConflictingNamespace(displayName, excludedName);
+    }
+
     public String findNamespaceName(String name) {
         return namespaceJooqRepo.findNameByNameIgnoreCase(name);
     }

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -47,7 +47,6 @@ import org.eclipse.openvsx.entities.TierType;
 import org.eclipse.openvsx.entities.UsageStats;
 import org.eclipse.openvsx.entities.UserData;
 import org.eclipse.openvsx.json.QueryRequest;
-import org.eclipse.openvsx.json.TargetPlatformVersionJson;
 import org.eclipse.openvsx.json.VersionTargetPlatformsJson;
 import org.eclipse.openvsx.util.ExtensionId;
 import org.eclipse.openvsx.util.NamingUtil;
@@ -186,8 +185,8 @@ public class RepositoryService {
         return namespaceRepo.findByNameIgnoreCase(name);
     }
 
-    public Optional<Namespace> findNamespaceConflict(String displayName, String excludedName) {
-        return namespaceRepo.findConflictingNamespace(displayName, excludedName);
+    public List<Namespace> findConflictingNamespaces(String displayName, Namespace excludedNamespace) {
+        return namespaceRepo.findConflictingNamespaces(displayName, excludedNamespace);
     }
 
     public String findNamespaceName(String name) {

--- a/server/src/test/java/org/eclipse/openvsx/ExtensionDeleteTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/ExtensionDeleteTest.java
@@ -56,7 +56,7 @@ import static org.mockito.Mockito.doAnswer;
  * {@link ExtensionService#deleteUserExtension(UserData, String, String, TargetPlatformVersion...)}
  * is protected by a {@code SELECT … FOR UPDATE NOWAIT} lock and therefore passes.
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+@SpringBootTest(properties = {
     "ovsx.elasticsearch.enabled=false"
 })
 @ActiveProfiles("test_db")

--- a/server/src/test/java/org/eclipse/openvsx/UserServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/UserServiceTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.eclipse.openvsx.cache.CacheService;
 import org.eclipse.openvsx.entities.Namespace;
@@ -91,7 +90,7 @@ class UserServiceTest {
         existing.setDisplayName("GitHub");
 
         Mockito.when(repositories.findNamespace("my-ns")).thenReturn(namespace);
-        Mockito.when(repositories.findNamespaceConflict("github", "my-ns")).thenReturn(Optional.of(existing));
+        Mockito.when(repositories.findConflictingNamespaces("github", namespace)).thenReturn(List.of(existing));
         Mockito.when(repositories.isNamespaceOwner(user, namespace)).thenReturn(true);
         Mockito.when(validator.validateNamespaceDetails(any())).thenReturn(List.of());
 
@@ -114,7 +113,7 @@ class UserServiceTest {
         namespace.setDisplayName("Old Display");
 
         Mockito.when(repositories.findNamespace("my-ns")).thenReturn(namespace);
-        Mockito.when(repositories.findNamespaceConflict("Brand New", "my-ns")).thenReturn(Optional.empty());
+        Mockito.when(repositories.findConflictingNamespaces("Brand New", namespace)).thenReturn(List.of());
         Mockito.when(repositories.isNamespaceOwner(user, namespace)).thenReturn(true);
         Mockito.when(validator.validateNamespaceDetails(any())).thenReturn(List.of());
 
@@ -124,7 +123,7 @@ class UserServiceTest {
 
         users.updateNamespaceDetails(details, user);
 
-        verify(repositories).findNamespaceConflict("Brand New", "my-ns");
+        verify(repositories).findConflictingNamespaces("Brand New", namespace);
         assertEquals("Brand New", namespace.getDisplayName());
     }
 
@@ -145,7 +144,7 @@ class UserServiceTest {
 
         users.updateNamespaceDetails(details, user);
 
-        verify(repositories, never()).findNamespaceConflict(anyString(), anyString());
+        verify(repositories, never()).findConflictingNamespaces(anyString(), any(Namespace.class));
     }
 
     private UserData mockUser(String authId) {

--- a/server/src/test/java/org/eclipse/openvsx/UserServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/UserServiceTest.java
@@ -12,14 +12,24 @@
  *****************************************************************************/
 package org.eclipse.openvsx;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.openvsx.cache.CacheService;
+import org.eclipse.openvsx.entities.Namespace;
 import org.eclipse.openvsx.entities.UserData;
+import org.eclipse.openvsx.json.NamespaceDetailsJson;
 import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.security.OAuth2AttributesConfig;
 import org.eclipse.openvsx.storage.StorageUtilService;
+import org.eclipse.openvsx.util.ErrorResultException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -35,12 +45,15 @@ import jakarta.persistence.EntityManager;
 
 @ExtendWith(SpringExtension.class)
 @MockitoBean(types = {
-    EntityManager.class, StorageUtilService.class, CacheService.class, ExtensionValidator.class, OAuth2AttributesConfig.class
+    EntityManager.class, StorageUtilService.class, CacheService.class, OAuth2AttributesConfig.class
 })
 class UserServiceTest {
 
     @MockitoBean
     RepositoryService repositories;
+
+    @MockitoBean
+    ExtensionValidator validator;
 
     @Autowired
     UserService users;
@@ -64,6 +77,75 @@ class UserServiceTest {
                 "Should succeed as there were no changes to the entity");
         assertTrue(exception.getMessage().startsWith("Could not login due to an existing"),
                 "Exception should pertain to mismatch of GitHub ID");
+    }
+
+    @Test
+    void shouldRejectDisplayNameMatchingAnotherNamespaceName() {
+        var user = mockUser("auth");
+        var namespace = new Namespace();
+        namespace.setName("my-ns");
+        namespace.setDisplayName("Old Display");
+
+        var existing = new Namespace();
+        existing.setName("github");
+        existing.setDisplayName("GitHub");
+
+        Mockito.when(repositories.findNamespace("my-ns")).thenReturn(namespace);
+        Mockito.when(repositories.findNamespaceConflict("github", "my-ns")).thenReturn(Optional.of(existing));
+        Mockito.when(repositories.isNamespaceOwner(user, namespace)).thenReturn(true);
+        Mockito.when(validator.validateNamespaceDetails(any())).thenReturn(List.of());
+
+        var details = new NamespaceDetailsJson();
+        details.setName("my-ns");
+        details.setDisplayName("github");
+
+        assertThatThrownBy(() -> users.updateNamespaceDetails(details, user))
+                .isInstanceOf(ErrorResultException.class)
+                .hasMessageContaining("collides with the name of existing namespace 'github (GitHub)'");
+
+        assertEquals("Old Display", namespace.getDisplayName(), "Display name should remain unchanged on rejection");
+    }
+
+    @Test
+    void shouldAllowDisplayNameWhenNoCollisionExists() {
+        var user = mockUser("auth");
+        var namespace = new Namespace();
+        namespace.setName("my-ns");
+        namespace.setDisplayName("Old Display");
+
+        Mockito.when(repositories.findNamespace("my-ns")).thenReturn(namespace);
+        Mockito.when(repositories.findNamespaceConflict("Brand New", "my-ns")).thenReturn(Optional.empty());
+        Mockito.when(repositories.isNamespaceOwner(user, namespace)).thenReturn(true);
+        Mockito.when(validator.validateNamespaceDetails(any())).thenReturn(List.of());
+
+        var details = new NamespaceDetailsJson();
+        details.setName("my-ns");
+        details.setDisplayName("Brand New");
+
+        users.updateNamespaceDetails(details, user);
+
+        verify(repositories).findNamespaceConflict("Brand New", "my-ns");
+        assertEquals("Brand New", namespace.getDisplayName());
+    }
+
+    @Test
+    void shouldSkipCollisionCheckWhenDisplayNameUnchanged() {
+        var user = mockUser("auth");
+        var namespace = new Namespace();
+        namespace.setName("my-ns");
+        namespace.setDisplayName("Same");
+
+        Mockito.when(repositories.findNamespace("my-ns")).thenReturn(namespace);
+        Mockito.when(repositories.isNamespaceOwner(user, namespace)).thenReturn(true);
+        Mockito.when(validator.validateNamespaceDetails(any())).thenReturn(List.of());
+
+        var details = new NamespaceDetailsJson();
+        details.setName("my-ns");
+        details.setDisplayName("Same");
+
+        users.updateNamespaceDetails(details, user);
+
+        verify(repositories, never()).findNamespaceConflict(anyString(), anyString());
     }
 
     private UserData mockUser(String authId) {

--- a/server/src/test/java/org/eclipse/openvsx/repositories/NamespaceRepositoryTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/NamespaceRepositoryTest.java
@@ -37,56 +37,69 @@ class NamespaceRepositoryTest {
     @Autowired
     EntityManager em;
 
+    Namespace github;
+    Namespace other;
+
     @BeforeEach
     void persistNamespaces() {
-        persistNamespace("github", "The GitHub Org");
-        persistNamespace("other", "Other Org");
+        github = persistNamespace("github", "The GitHub Org");
+        other = persistNamespace("other", "Other Org");
+    }
+
+    @Test
+    void findMultipleConflictingNamespaceMatches() {
+        persistNamespace("github2", "github");
+        var conflicts = repo.findConflictingNamespaces("GITHUB", other);
+
+        assertThat(conflicts).isNotEmpty();
+        assertThat(conflicts.getFirst().getName()).isEqualTo("github");
     }
 
     @Test
     void findConflictingNamespaceMatchesNameIgnoringCase() {
-        var conflict = repo.findConflictingNamespace("GITHUB", "other");
+        var conflicts = repo.findConflictingNamespaces("GITHUB", other);
 
-        assertThat(conflict).isPresent();
-        assertThat(conflict.get().getName()).isEqualTo("github");
+        assertThat(conflicts).isNotEmpty();
+        assertThat(conflicts.getFirst().getName()).isEqualTo("github");
     }
 
     @Test
     void findConflictingNamespaceMatchesDisplayNameIgnoringCase() {
-        var conflict = repo.findConflictingNamespace("the github org", "other");
+        var conflicts = repo.findConflictingNamespaces("the github org", other);
 
-        assertThat(conflict).isPresent();
-        assertThat(conflict.get().getName()).isEqualTo("github");
+        assertThat(conflicts).isNotEmpty();
+        assertThat(conflicts.getFirst().getName()).isEqualTo("github");
     }
 
     @Test
     void findConflictingNamespaceExcludesOwnNamespaceIgnoringCase() {
-        var conflict = repo.findConflictingNamespace("The GitHub Org", "GitHub");
+        var conflicts = repo.findConflictingNamespaces("The GitHub Org", github);
 
-        assertThat(conflict).isEmpty();
+        assertThat(conflicts).isEmpty();
     }
 
     @Test
     void findConflictingNamespaceStillFindsOtherNamespaces() {
-        persistNamespace("dup", "The GitHub Org");
+        var dup = persistNamespace("dup", "The GitHub Org");
 
-        var conflict = repo.findConflictingNamespace("the github org", "github");
+        var conflicts = repo.findConflictingNamespaces("the github org", github);
 
-        assertThat(conflict).isPresent();
-        assertThat(conflict.get().getName()).isEqualTo("dup");
+        assertThat(conflicts).isNotEmpty();
+        assertThat(conflicts.getFirst().getName()).isEqualTo(dup.getName());
     }
 
     @Test
     void findConflictingNamespaceEmptyWhenNothingMatches() {
-        var conflict = repo.findConflictingNamespace("Brand New", "github");
+        var conflicts = repo.findConflictingNamespaces("Brand New", github);
 
-        assertThat(conflict).isEmpty();
+        assertThat(conflicts).isEmpty();
     }
 
-    private void persistNamespace(String name, String displayName) {
+    private Namespace persistNamespace(String name, String displayName) {
         var namespace = new Namespace();
         namespace.setName(name);
         namespace.setDisplayName(displayName);
         em.persist(namespace);
+        return namespace;
     }
 }

--- a/server/src/test/java/org/eclipse/openvsx/repositories/NamespaceRepositoryTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/NamespaceRepositoryTest.java
@@ -1,0 +1,92 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.repositories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.openvsx.entities.Namespace;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+
+@SpringBootTest(properties = {
+        "ovsx.elasticsearch.enabled=false"
+})
+@ActiveProfiles("test_db")
+@Transactional
+class NamespaceRepositoryTest {
+
+    @Autowired
+    NamespaceRepository repo;
+
+    @Autowired
+    EntityManager em;
+
+    @BeforeEach
+    void persistNamespaces() {
+        persistNamespace("github", "The GitHub Org");
+        persistNamespace("other", "Other Org");
+    }
+
+    @Test
+    void findConflictingNamespaceMatchesNameIgnoringCase() {
+        var conflict = repo.findConflictingNamespace("GITHUB", "other");
+
+        assertThat(conflict).isPresent();
+        assertThat(conflict.get().getName()).isEqualTo("github");
+    }
+
+    @Test
+    void findConflictingNamespaceMatchesDisplayNameIgnoringCase() {
+        var conflict = repo.findConflictingNamespace("the github org", "other");
+
+        assertThat(conflict).isPresent();
+        assertThat(conflict.get().getName()).isEqualTo("github");
+    }
+
+    @Test
+    void findConflictingNamespaceExcludesOwnNamespaceIgnoringCase() {
+        var conflict = repo.findConflictingNamespace("The GitHub Org", "GitHub");
+
+        assertThat(conflict).isEmpty();
+    }
+
+    @Test
+    void findConflictingNamespaceStillFindsOtherNamespaces() {
+        persistNamespace("dup", "The GitHub Org");
+
+        var conflict = repo.findConflictingNamespace("the github org", "github");
+
+        assertThat(conflict).isPresent();
+        assertThat(conflict.get().getName()).isEqualTo("dup");
+    }
+
+    @Test
+    void findConflictingNamespaceEmptyWhenNothingMatches() {
+        var conflict = repo.findConflictingNamespace("Brand New", "github");
+
+        assertThat(conflict).isEmpty();
+    }
+
+    private void persistNamespace(String name, String displayName) {
+        var namespace = new Namespace();
+        namespace.setName(name);
+        namespace.setDisplayName(displayName);
+        em.persist(namespace);
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
@@ -56,7 +56,7 @@ import jakarta.transaction.Transactional;
  * Run the DB queries and assert no DB error, just to ensure that the queries
  * are consistent with the schema.
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+@SpringBootTest(properties = {
         "ovsx.elasticsearch.enabled=false"
 })
 @ActiveProfiles("test_db")
@@ -208,6 +208,7 @@ class RepositoryServiceSmokeTest {
                 () -> repositories.findMemberships(namespace, "role"),
                 () -> repositories.deleteMemberships(userData),
                 () -> repositories.findNamespace("name"),
+                () -> repositories.findNamespaceConflict("displayName", "name"),
                 () -> repositories.findOrphanNamespaces(),
                 () -> repositories.findPersistedLogsAfter(NOW),
                 () -> repositories.findTargetPlatformVersions("version", "extensionName", "namespaceName"),

--- a/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
@@ -208,7 +208,7 @@ class RepositoryServiceSmokeTest {
                 () -> repositories.findMemberships(namespace, "role"),
                 () -> repositories.deleteMemberships(userData),
                 () -> repositories.findNamespace("name"),
-                () -> repositories.findNamespaceConflict("displayName", "name"),
+                () -> repositories.findConflictingNamespaces("displayName", namespace),
                 () -> repositories.findOrphanNamespaces(),
                 () -> repositories.findPersistedLogsAfter(NOW),
                 () -> repositories.findTargetPlatformVersions("version", "extensionName", "namespaceName"),


### PR DESCRIPTION
This change errors when a user tries to save a display name that collides with an existing one

---
Example: 

We have a **Knostic** namespace that has the display name **Knostic Display Name**
When an owner of another namespace tries to update their name we block either **Knostic Display Name** or **Knostic**

<img width="573" height="230" alt="image" src="https://github.com/user-attachments/assets/71779a40-45f7-4e2d-b103-92df479919a1" />
<img width="568" height="227" alt="image" src="https://github.com/user-attachments/assets/d5184ac1-a329-44f3-b6d5-d7d573485efd" />

---

I've also realised we have the `unitTests` task that is excluding @SpringBootTests, so I'm also adding other tests that I created before, and making them not use a random port so they can share the same spring boot instance.