### PR TITLE
chore: remove unused dep jsonpath

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -120,7 +120,6 @@ dependencies {
 
     implementation libs.tika.core
     implementation libs.re2j
-    implementation libs.json.path
     implementation libs.loki.logback.appender
 
     runtimeOnly "io.micrometer:micrometer-registry-prometheus"

--- a/server/gradle/libs.versions.toml
+++ b/server/gradle/libs.versions.toml
@@ -15,8 +15,6 @@ jaxb-api        = "2.3.1"
 jaxb-impl       = "2.3.8"
 jedis           = "7.4.1"
 jobrunr         = "8.6.1"
-jooq            = "3.19.34"
-jsonpath        = "2.9.0"
 loki4j          = "1.4.2"
 re2j            = "1.7"
 rewrite-java    = "3.38.0"
@@ -29,7 +27,7 @@ woodstox        = "6.4.0"
 download                     = { id = "de.undercouch.download", version = "5.7.0" }
 gatling                      = { id = "io.gatling.gradle", version.ref = "gatling" }
 hibernate-orm                = { id = "org.hibernate.orm" }
-jooq-codegen                 = { id = "org.jooq.jooq-codegen-gradle", version.ref = "jooq" }
+jooq-codegen                 = { id = "org.jooq.jooq-codegen-gradle" }
 spring-boot                  = { id = "org.springframework.boot", version.ref = "spring-boot"}
 spring-dependency-management = { id = "io.spring.dependency-management", version = "1.1.7" }
 test-logger                  = { id = "com.adarshr.test-logger", version = "4.0.0" }
@@ -57,7 +55,6 @@ jaxb-api                     = { module = "javax.xml.bind:jaxb-api", version.ref
 jaxb-impl                    = { module = "com.sun.xml.bind:jaxb-impl", version.ref = "jaxb-impl" }
 jedis                        = { module = "redis.clients:jedis", version.ref = "jedis" }
 jobrunr-spring               = { module = "org.jobrunr:jobrunr-spring-boot-4-starter", version.ref = "jobrunr" }
-json-path                    = { module = "com.jayway.jsonpath:json-path", version.ref = "jsonpath" }
 loki-logback-appender        = { module = "com.github.loki4j:loki-logback-appender", version.ref = "loki4j" }
 re2j                         = { module = "com.google.re2j:re2j", version.ref = "re2j" }
 rewrite-java                 = { module = "org.openrewrite.recipe:rewrite-migrate-java", version.ref = "rewrite-java"}

--- a/server/gradle/libs.versions.toml
+++ b/server/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ jaxb-api        = "2.3.1"
 jaxb-impl       = "2.3.8"
 jedis           = "7.4.1"
 jobrunr         = "8.6.1"
+jooq            = "3.19.34"
 loki4j          = "1.4.2"
 re2j            = "1.7"
 rewrite-java    = "3.38.0"
@@ -27,7 +28,7 @@ woodstox        = "6.4.0"
 download                     = { id = "de.undercouch.download", version = "5.7.0" }
 gatling                      = { id = "io.gatling.gradle", version.ref = "gatling" }
 hibernate-orm                = { id = "org.hibernate.orm" }
-jooq-codegen                 = { id = "org.jooq.jooq-codegen-gradle" }
+jooq-codegen                 = { id = "org.jooq.jooq-codegen-gradle", version.ref = "jooq" }
 spring-boot                  = { id = "org.springframework.boot", version.ref = "spring-boot"}
 spring-dependency-management = { id = "io.spring.dependency-management", version = "1.1.7" }
 test-logger                  = { id = "com.adarshr.test-logger", version = "4.0.0" }

--- a/server/settings.gradle
+++ b/server/settings.gradle
@@ -12,6 +12,11 @@ pluginManagement {
             if (requested.id.id == 'org.hibernate.orm') {
                 useVersion(gradle.ext.hibernateOrmVersion)
             }
+            // Supply the jOOQ codegen plugin version from Spring Boot's BOM so it is
+            // always kept in sync with the managed jOOQ dependency.
+            if (requested.id.id == 'org.jooq.jooq-codegen-gradle') {
+                useVersion(gradle.ext.jooqVersion)
+            }
         }
     }
 }
@@ -36,3 +41,4 @@ def bomPomFile = buildscript.configurations.detachedConfiguration(
 ).singleFile
 def bomPom = new XmlSlurper().parse(bomPomFile)
 gradle.ext.hibernateOrmVersion = bomPom.properties['hibernate.version'].text()
+gradle.ext.jooqVersion = bomPom.properties['jooq.version'].text()

--- a/server/settings.gradle
+++ b/server/settings.gradle
@@ -12,11 +12,6 @@ pluginManagement {
             if (requested.id.id == 'org.hibernate.orm') {
                 useVersion(gradle.ext.hibernateOrmVersion)
             }
-            // Supply the jOOQ codegen plugin version from Spring Boot's BOM so it is
-            // always kept in sync with the managed jOOQ dependency.
-            if (requested.id.id == 'org.jooq.jooq-codegen-gradle') {
-                useVersion(gradle.ext.jooqVersion)
-            }
         }
     }
 }
@@ -41,4 +36,3 @@ def bomPomFile = buildscript.configurations.detachedConfiguration(
 ).singleFile
 def bomPom = new XmlSlurper().parse(bomPomFile)
 gradle.ext.hibernateOrmVersion = bomPom.properties['hibernate.version'].text()
-gradle.ext.jooqVersion = bomPom.properties['jooq.version'].text()


### PR DESCRIPTION
jsonpath is not actually used, its an artifact from a PR, spring boot includes it also by default
jooq plugin should use the same version as used by spring boot