### PR TITLE
fix: normalize section margins

### DIFF
--- a/webui/src/components/page-container.tsx
+++ b/webui/src/components/page-container.tsx
@@ -1,0 +1,50 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+import { forwardRef } from 'react';
+import { Container, ContainerProps } from '@mui/material';
+
+export interface PageContainerProps extends ContainerProps {
+    /** Full-bleed: drop the width cap and gutters so nested containers own their centering (e.g. the home). */
+    fluid?: boolean;
+    /** No top margin — content hugs the nav, or an inner element supplies its own. */
+    flushTop?: boolean;
+    /** No bottom margin — content meets the footer line, or an inner element supplies its own. */
+    flushBottom?: boolean;
+}
+
+/**
+ * A MUI `Container` plus the standard page margins (a top offset below the nav and
+ * a gap above the footer). For page-level content; non-pages or custom spacing
+ * should use `Container` directly.
+ */
+export const PageContainer = forwardRef<HTMLDivElement, PageContainerProps>(function PageContainer(
+    { fluid, flushTop, flushBottom, sx, ...props },
+    ref
+) {
+    return (
+        <Container
+            ref={ref}
+            maxWidth={fluid ? false : 'xl'}
+            disableGutters={fluid}
+            sx={[
+                {
+                    pt: flushTop ? 0 : { xs: '2.75rem', sm: '4.875rem' },
+                    pb: flushBottom ? 0 : { xs: '2.5rem', sm: '4rem' }
+                },
+                ...(Array.isArray(sx) ? sx : [sx])
+            ]}
+            {...props}
+        />
+    );
+});

--- a/webui/src/components/page-primitives.tsx
+++ b/webui/src/components/page-primitives.tsx
@@ -30,6 +30,26 @@ export const Section = styled(Box)(({ theme }) => ({
     }
 }));
 
+/**
+ * Vertical stack of page `Section`s that owns all vertical rhythm: a top offset
+ * below the nav plus a single, normalized gap between sections. Sections carry no
+ * spacing of their own, so a custom home can cherry-pick and reorder them — and
+ * whichever lands first always gets the top offset, never a leading gap. The owl
+ * selector skips the first (and any null) child.
+ */
+export const SectionStack = styled(Box)(({ theme }) => ({
+    paddingTop: '4.875rem',
+    [theme.breakpoints.down('sm')]: {
+        paddingTop: '2.75rem'
+    },
+    '& > * + *': {
+        marginTop: '4.5rem',
+        [theme.breakpoints.down('sm')]: {
+            marginTop: '3rem'
+        }
+    }
+}));
+
 /** Small uppercase label used to head sections, columns and sidebars. */
 export const Eyebrow = styled(Typography)(({ theme }) => ({
     fontSize: '0.75rem',

--- a/webui/src/components/page-primitives.tsx
+++ b/webui/src/components/page-primitives.tsx
@@ -17,9 +17,9 @@ import { alpha, styled, Theme } from '@mui/material/styles';
 /** Normalized gap between stacked sections; the owl selector skips the first (and any null) child. */
 export const SectionStack = styled(Box)(({ theme }) => ({
     '& > * + *': {
-        marginTop: '4.5rem',
+        marginTop: '2.5rem',
         [theme.breakpoints.down('sm')]: {
-            marginTop: '3rem'
+            marginTop: '1.5rem'
         }
     }
 }));

--- a/webui/src/components/page-primitives.tsx
+++ b/webui/src/components/page-primitives.tsx
@@ -14,34 +14,8 @@
 import { Box, Typography } from '@mui/material';
 import { alpha, styled, Theme } from '@mui/material/styles';
 
-/** Max width of the centered content column shared by every page section. */
-export const CONTENT_MAX_WIDTH = 1320;
-
-/**
- * Horizontally-centered content column with responsive gutters. The single
- * source of truth for page width so sections stay aligned across the app.
- */
-export const Section = styled(Box)(({ theme }) => ({
-    maxWidth: CONTENT_MAX_WIDTH,
-    marginInline: 'auto',
-    paddingInline: '1.75rem',
-    [theme.breakpoints.down('sm')]: {
-        paddingInline: '1rem'
-    }
-}));
-
-/**
- * Vertical stack of page `Section`s that owns all vertical rhythm: a top offset
- * below the nav plus a single, normalized gap between sections. Sections carry no
- * spacing of their own, so a custom home can cherry-pick and reorder them — and
- * whichever lands first always gets the top offset, never a leading gap. The owl
- * selector skips the first (and any null) child.
- */
+/** Normalized gap between stacked sections; the owl selector skips the first (and any null) child. */
 export const SectionStack = styled(Box)(({ theme }) => ({
-    paddingTop: '4.875rem',
-    [theme.breakpoints.down('sm')]: {
-        paddingTop: '2.75rem'
-    },
     '& > * + *': {
         marginTop: '4.5rem',
         [theme.breakpoints.down('sm')]: {

--- a/webui/src/default/theme.tsx
+++ b/webui/src/default/theme.tsx
@@ -197,7 +197,7 @@ export default function createDefaultTheme(themeType: 'light' | 'dark'): Theme {
             }
         },
         breakpoints: {
-            values: { xs: 0, sm: 550, md: 800, lg: 1040, xl: 1240 }
+            values: { xs: 0, sm: 550, md: 800, lg: 1040, xl: 1320 }
         },
         components: {
             MuiAccordion: {

--- a/webui/src/index.ts
+++ b/webui/src/index.ts
@@ -33,6 +33,7 @@ export {
 } from './pages/home/use-home-data';
 export { ExtensionCard, type ExtensionCardProps } from './components/extension-card';
 export * from './components/page-primitives';
+export * from './components/page-container';
 // Leaf hook modules keep their helpers private, so `export *` exposes only the
 // public hook plus its types (e.g. useSearch + SearchFilter).
 export * from './hooks/use-search';

--- a/webui/src/layout/app-footer.tsx
+++ b/webui/src/layout/app-footer.tsx
@@ -12,13 +12,13 @@
  ********************************************************************************/
 
 import { FunctionComponent, useContext, useState } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Container, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import type { Theme } from '@mui/material/styles';
 import { Link as RouteLink } from 'react-router-dom';
 import { KbdKey } from '../components/kbd-key';
 import { useShortcut } from '../hooks/use-shortcut';
-import { Section, Eyebrow, accentHover, focusOutline } from '../components/page-primitives';
+import { Eyebrow, accentHover, focusOutline } from '../components/page-primitives';
 import { MONO_FONT } from '../default/theme';
 import { CustomFooterSettings, StructuredFooterSettings } from '../page-settings';
 import { MainContext } from '../context';
@@ -131,7 +131,8 @@ const StructuredFooter: FunctionComponent<StructuredFooterProps> = ({ footer, ve
         component='footer'
         sx={{ mt: 'auto', borderTop: '1px solid', borderColor: 'divider', bgcolor: 'background.paper' }}>
         {footer && (footer.brand || footer.columns) && (
-            <Section
+            <Container
+                maxWidth='xl'
                 sx={{
                     pt: '3rem',
                     pb: '1.875rem',
@@ -191,9 +192,10 @@ const StructuredFooter: FunctionComponent<StructuredFooterProps> = ({ footer, ve
                         </Box>
                     </Box>
                 ))}
-            </Section>
+            </Container>
         )}
-        <Section
+        <Container
+            maxWidth='xl'
             sx={{
                 py: '1.25rem',
                 borderTop: footer?.brand || footer?.columns ? '1px solid' : 'none',
@@ -217,6 +219,6 @@ const StructuredFooter: FunctionComponent<StructuredFooterProps> = ({ footer, ve
                     </Typography>
                 )}
             </Box>
-        </Section>
+        </Container>
     </Box>
 );

--- a/webui/src/layout/app-layout.tsx
+++ b/webui/src/layout/app-layout.tsx
@@ -109,8 +109,8 @@ const AppLayoutContent: FunctionComponent<AppLayoutProps> = props => {
                 sx={{
                     flexGrow: 1,
                     minHeight: { xs: `calc(100vh - ${NAVBAR_HEIGHT})`, sm: 0 },
-                    // Legacy footer is fixed, so pad by its height; otherwise leave a gap above the footer divider.
-                    pb: legacyFooterHeight ? `${legacyFooterHeight + 24}px` : { xs: '2.5rem', sm: '4rem' }
+                    // Only the fixed legacy footer needs clearance; the in-flow footer's gap lives on <PageContainer>.
+                    pb: legacyFooterHeight ? `${legacyFooterHeight + 24}px` : 0
                 }}>
                 <Suspense fallback={null}>
                     <Routes>

--- a/webui/src/not-found.tsx
+++ b/webui/src/not-found.tsx
@@ -1,14 +1,15 @@
 import { FunctionComponent } from 'react';
-import { Box, Container, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import BrokenImageIcon from '@mui/icons-material/BrokenImage';
+import { PageContainer } from './components/page-container';
 
 export const NotFound: FunctionComponent = () => {
     return (
-        <Container>
+        <PageContainer flushTop>
             <Box height='30vh' display='flex' flexWrap='wrap' justifyContent='center' alignItems='center'>
                 <Typography variant='h3'>Oooups...this is a 404 page.</Typography>
                 <BrokenImageIcon sx={{ fontSize: '4rem', flexBasis: '100%' }} />
             </Box>
-        </Container>
+        </PageContainer>
     );
 };

--- a/webui/src/pages/extension-detail/extension-detail.tsx
+++ b/webui/src/pages/extension-detail/extension-detail.tsx
@@ -49,6 +49,7 @@ import { useShortcut } from '../../hooks/use-shortcut';
 import { NAVBAR_HEIGHT, NAVBAR_HEIGHT_PX } from '../../default/theme';
 import { useSetExtensionTint } from '../../context/extension-tint-context';
 import { accentHover, focusOutline } from '../../components/page-primitives';
+import { PageContainer } from '../../components/page-container';
 
 // Category-pill look for the sticky tabs, floating over the nav bar's blur fan;
 // the translucent fill matches the nav search field's treatment.
@@ -505,7 +506,7 @@ export const ExtensionDetail: FunctionComponent = () => {
             {extension && (
                 <>
                     <ExtensionHeader extension={extension} bandRef={bandRef} />
-                    <Container maxWidth='xl'>
+                    <PageContainer flushTop>
                         <Tabs
                             value={activeTab}
                             variant='scrollable'
@@ -567,10 +568,7 @@ export const ExtensionDetail: FunctionComponent = () => {
                                 state={{ preserveScroll: true }}
                             />
                         </Tabs>
-                        {/* Owns the space below the pinned pills for every tab, so the panels
-                            don't each set their own; min-height keeps the preserved scroll
-                            position valid while a panel loads. */}
-                        <Box sx={{ minHeight: '100vh', pt: 2 }}>
+                        <Box sx={{ pt: 2 }}>
                             <Routes>
                                 <Route
                                     path={ExtensionTab.REVIEWS}
@@ -591,7 +589,7 @@ export const ExtensionDetail: FunctionComponent = () => {
                                 />
                             </Routes>
                         </Box>
-                    </Container>
+                    </PageContainer>
                 </>
             )}
             {error && (

--- a/webui/src/pages/home/browse-categories.tsx
+++ b/webui/src/pages/home/browse-categories.tsx
@@ -38,7 +38,7 @@ export const BrowseCategories: FunctionComponent<BrowseCategoriesProps> = props 
         return null;
     }
     return (
-        <Section component='section' sx={{ mt: { xs: '1.375rem', sm: '2.25rem' } }}>
+        <Section component='section'>
             <Eyebrow sx={{ mb: { xs: '0.75rem', sm: '1.125rem' } }}>Browse by category</Eyebrow>
             <Box
                 sx={{

--- a/webui/src/pages/home/browse-categories.tsx
+++ b/webui/src/pages/home/browse-categories.tsx
@@ -12,12 +12,12 @@
  ********************************************************************************/
 
 import { FunctionComponent } from 'react';
-import { Box } from '@mui/material';
+import { Box, Container } from '@mui/material';
 import { ExtensionCategory } from '../../extension-registry-types';
 import { CATEGORY_ICONS, DefaultCategoryIcon } from '../../components/categories';
 import { CategoryPill } from '../../components/category-pill';
 import { CategoryCard } from '../../components/category-card';
-import { Section, Eyebrow } from '../../components/page-primitives';
+import { Eyebrow } from '../../components/page-primitives';
 import { useSearch } from '../../hooks/use-search';
 import { useHomeCategories } from './use-home-data';
 
@@ -38,7 +38,7 @@ export const BrowseCategories: FunctionComponent<BrowseCategoriesProps> = props 
         return null;
     }
     return (
-        <Section component='section'>
+        <Container maxWidth='xl' component='section'>
             <Eyebrow sx={{ mb: { xs: '0.75rem', sm: '1.125rem' } }}>Browse by category</Eyebrow>
             <Box
                 sx={{
@@ -77,6 +77,6 @@ export const BrowseCategories: FunctionComponent<BrowseCategoriesProps> = props 
                     />
                 ))}
             </Box>
-        </Section>
+        </Container>
     );
 };

--- a/webui/src/pages/home/curated-sections.tsx
+++ b/webui/src/pages/home/curated-sections.tsx
@@ -38,7 +38,7 @@ export const CuratedSections: FunctionComponent<CuratedSectionsProps> = props =>
                     return null;
                 }
                 return (
-                    <Section component='section' key={row.title} sx={{ mt: { xs: '2.25rem', sm: '3.375rem' } }}>
+                    <Section component='section' key={row.title}>
                         <Box
                             sx={{
                                 display: 'flex',

--- a/webui/src/pages/home/curated-sections.tsx
+++ b/webui/src/pages/home/curated-sections.tsx
@@ -12,9 +12,8 @@
  ********************************************************************************/
 
 import { FunctionComponent } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Container, Typography } from '@mui/material';
 import { ExtensionCard } from '../../components/extension-card';
-import { Section } from '../../components/page-primitives';
 import { HomeCuratedSection } from '../../page-settings';
 import { useSearch } from '../../hooks/use-search';
 import { CURATED_SIZE, DEFAULT_CURATED_SECTIONS, useCuratedRows } from './use-home-data';
@@ -38,7 +37,7 @@ export const CuratedSections: FunctionComponent<CuratedSectionsProps> = props =>
                     return null;
                 }
                 return (
-                    <Section component='section' key={row.title}>
+                    <Container maxWidth='xl' component='section' key={row.title}>
                         <Box
                             sx={{
                                 display: 'flex',
@@ -97,7 +96,7 @@ export const CuratedSections: FunctionComponent<CuratedSectionsProps> = props =>
                                 />
                             ))}
                         </Box>
-                    </Section>
+                    </Container>
                 );
             })}
         </>

--- a/webui/src/pages/home/get-involved.tsx
+++ b/webui/src/pages/home/get-involved.tsx
@@ -12,12 +12,12 @@
  ********************************************************************************/
 
 import { FunctionComponent, ReactNode } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Container, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import type { Theme } from '@mui/material/styles';
 import { Link as RouteLink } from 'react-router-dom';
 import { HomeInvolvementCard } from '../../page-settings';
-import { Section, Eyebrow, focusOutline } from '../../components/page-primitives';
+import { Eyebrow, focusOutline } from '../../components/page-primitives';
 
 const GetInvolvedCard = styled(Box)(({ theme }) => ({
     backgroundColor: theme.palette.background.paper,
@@ -74,7 +74,7 @@ export const GetInvolved: FunctionComponent<GetInvolvedProps> = ({ heading, card
         return null;
     }
     return (
-        <Section component='section'>
+        <Container maxWidth='xl' component='section'>
             <Eyebrow sx={{ letterSpacing: '0.1em', mb: { xs: '0.875rem', sm: '1.25rem' } }}>
                 {heading ?? 'Get Involved'}
             </Eyebrow>
@@ -120,6 +120,6 @@ export const GetInvolved: FunctionComponent<GetInvolvedProps> = ({ heading, card
                     );
                 })}
             </Box>
-        </Section>
+        </Container>
     );
 };

--- a/webui/src/pages/home/get-involved.tsx
+++ b/webui/src/pages/home/get-involved.tsx
@@ -74,7 +74,7 @@ export const GetInvolved: FunctionComponent<GetInvolvedProps> = ({ heading, card
         return null;
     }
     return (
-        <Section component='section' sx={{ mt: { xs: '3rem', sm: '4.5rem' } }}>
+        <Section component='section'>
             <Eyebrow sx={{ letterSpacing: '0.1em', mb: { xs: '0.875rem', sm: '1.25rem' } }}>
                 {heading ?? 'Get Involved'}
             </Eyebrow>

--- a/webui/src/pages/home/hero-search.tsx
+++ b/webui/src/pages/home/hero-search.tsx
@@ -21,11 +21,11 @@ import {
     useRef,
     useState
 } from 'react';
-import { Box, ButtonBase, Typography } from '@mui/material';
+import { Box, ButtonBase, Container, Typography } from '@mui/material';
 import { useLocation } from 'react-router-dom';
 import { flushSync } from 'react-dom';
 import { styled, alpha } from '@mui/material/styles';
-import { accentHover, focusOutline, focusRing, Section } from '../../components/page-primitives';
+import { accentHover, focusOutline, focusRing } from '../../components/page-primitives';
 import { useSearch, SEARCH_DEBOUNCE_MS } from '../../hooks/use-search';
 import { useSearchQuery } from '../../context/search/search-context';
 import { useSearchFocus } from '../../context/search/search-focus-context';
@@ -223,7 +223,7 @@ export const HeroSearch: FunctionComponent<HeroSearchProps> = ({
     };
 
     return (
-        <Section component='section' sx={{ textAlign: 'center' }}>
+        <Container maxWidth='xl' component='section' sx={{ textAlign: 'center' }}>
             {SearchHeader && <SearchHeader />}
             <Box component='form' onSubmit={handleSubmit} sx={{ maxWidth: '41.25rem', mx: 'auto' }}>
                 {/* The nav field claims 'vt-search' while the hero is unregistered — duplicate names abort transitions. */}
@@ -290,6 +290,6 @@ export const HeroSearch: FunctionComponent<HeroSearchProps> = ({
                     ))}
                 </Box>
             )}
-        </Section>
+        </Container>
     );
 };

--- a/webui/src/pages/home/hero-search.tsx
+++ b/webui/src/pages/home/hero-search.tsx
@@ -223,13 +223,7 @@ export const HeroSearch: FunctionComponent<HeroSearchProps> = ({
     };
 
     return (
-        <Section
-            component='section'
-            sx={{
-                pt: { xs: '2.75rem', sm: '4.875rem' },
-                pb: { xs: '1.125rem', sm: '1.875rem' },
-                textAlign: 'center'
-            }}>
+        <Section component='section' sx={{ textAlign: 'center' }}>
             {SearchHeader && <SearchHeader />}
             <Box component='form' onSubmit={handleSubmit} sx={{ maxWidth: '41.25rem', mx: 'auto' }}>
                 {/* The nav field claims 'vt-search' while the hero is unregistered — duplicate names abort transitions. */}

--- a/webui/src/pages/home/home-page.tsx
+++ b/webui/src/pages/home/home-page.tsx
@@ -12,8 +12,8 @@
  ********************************************************************************/
 
 import { FunctionComponent, useContext } from 'react';
-import { Box } from '@mui/material';
 import { Navigate, useSearchParams } from 'react-router-dom';
+import { SectionStack } from '../../components/page-primitives';
 import { MainContext } from '../../context';
 import { HomeSettings } from '../../page-settings';
 import { ExtensionListRoutes } from '../extension-list/extension-list-routes';
@@ -48,11 +48,11 @@ export const HomePage: FunctionComponent = () => {
 const HomeContent: FunctionComponent<{ home?: HomeSettings }> = ({ home }) => {
     const { pageSettings } = useContext(MainContext);
     return (
-        <Box component='main' sx={{ animation: 'fadeIn .25s ease' }}>
+        <SectionStack component='main' sx={{ animation: 'fadeIn .25s ease' }}>
             <HeroSearch searchHeader={pageSettings.elements.searchHeader} popularSearches={home?.popularSearches} />
-            <BrowseCategories />
             <CuratedSections sections={home?.curatedSections} />
+            <BrowseCategories />
             <GetInvolved heading={home?.involvement?.heading} cards={home?.involvement?.cards} />
-        </Box>
+        </SectionStack>
     );
 };

--- a/webui/src/pages/home/home-page.tsx
+++ b/webui/src/pages/home/home-page.tsx
@@ -13,6 +13,7 @@
 
 import { FunctionComponent, useContext } from 'react';
 import { Navigate, useSearchParams } from 'react-router-dom';
+import { PageContainer } from '../../components/page-container';
 import { SectionStack } from '../../components/page-primitives';
 import { MainContext } from '../../context';
 import { HomeSettings } from '../../page-settings';
@@ -48,11 +49,13 @@ export const HomePage: FunctionComponent = () => {
 const HomeContent: FunctionComponent<{ home?: HomeSettings }> = ({ home }) => {
     const { pageSettings } = useContext(MainContext);
     return (
-        <SectionStack component='main' sx={{ animation: 'fadeIn .25s ease' }}>
-            <HeroSearch searchHeader={pageSettings.elements.searchHeader} popularSearches={home?.popularSearches} />
-            <CuratedSections sections={home?.curatedSections} />
-            <BrowseCategories />
-            <GetInvolved heading={home?.involvement?.heading} cards={home?.involvement?.cards} />
-        </SectionStack>
+        <PageContainer fluid component='main' sx={{ animation: 'fadeIn .25s ease' }}>
+            <SectionStack>
+                <HeroSearch searchHeader={pageSettings.elements.searchHeader} popularSearches={home?.popularSearches} />
+                <BrowseCategories />
+                <CuratedSections sections={home?.curatedSections} />
+                <GetInvolved heading={home?.involvement?.heading} cards={home?.involvement?.cards} />
+            </SectionStack>
+        </PageContainer>
     );
 };

--- a/webui/src/pages/namespace-detail/namespace-detail.tsx
+++ b/webui/src/pages/namespace-detail/namespace-detail.tsx
@@ -9,7 +9,7 @@
  ********************************************************************************/
 
 import { FunctionComponent, ReactNode, useContext, useEffect, useState, useRef } from 'react';
-import { Typography, Box, Link, Divider } from '@mui/material';
+import { Typography, Box, Container, Link, Divider } from '@mui/material';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import TwitterIcon from '@mui/icons-material/Twitter';
@@ -17,7 +17,6 @@ import { useParams } from 'react-router-dom';
 import { ExtensionCard } from '../../components/extension-card';
 import { MainContext } from '../../context';
 import { DelayedLoadIndicator } from '../../components/delayed-load-indicator';
-import { Section } from '../../components/page-primitives';
 import { NamespaceDetails, isError, UrlString } from '../../extension-registry-types';
 
 export const NamespaceDetail: FunctionComponent = () => {
@@ -111,7 +110,7 @@ export const NamespaceDetail: FunctionComponent = () => {
         return (
             <>
                 <Box sx={{ borderBottom: '1px solid', borderColor: 'divider' }}>
-                    <Section sx={{ py: { xs: '2rem', sm: '3rem' } }}>
+                    <Container maxWidth='xl' sx={{ py: { xs: '2rem', sm: '3rem' } }}>
                         <Box
                             sx={{
                                 display: 'flex',
@@ -205,10 +204,10 @@ export const NamespaceDetail: FunctionComponent = () => {
                                 ) : null}
                             </Box>
                         </Box>
-                    </Section>
+                    </Container>
                 </Box>
                 {namespaceDetails.extensions ? (
-                    <Section sx={{ py: { xs: '2rem', sm: '3rem' } }}>
+                    <Container maxWidth='xl' sx={{ py: { xs: '2rem', sm: '3rem' } }}>
                         <Box
                             sx={{
                                 display: 'grid',
@@ -226,7 +225,7 @@ export const NamespaceDetail: FunctionComponent = () => {
                                 />
                             ))}
                         </Box>
-                    </Section>
+                    </Container>
                 ) : null}
             </>
         );

--- a/webui/src/pages/search/search-page.tsx
+++ b/webui/src/pages/search/search-page.tsx
@@ -19,7 +19,8 @@ import { ExtensionList } from '../../components/extension-list';
 import { CATEGORY_ICONS, DefaultCategoryIcon } from '../../components/categories';
 import { CategoryPill } from '../../components/category-pill';
 import { CategoryListItem } from '../../components/category-list-item';
-import { Eyebrow, Section } from '../../components/page-primitives';
+import { Eyebrow } from '../../components/page-primitives';
+import { PageContainer } from '../../components/page-container';
 import { NAVBAR_HEIGHT } from '../../default/theme';
 import { useSearch } from '../../hooks/use-search';
 import { useCategories } from '../../components/categories';
@@ -33,10 +34,8 @@ export const SearchPage: FunctionComponent = () => {
     const [resultNumber, setResultNumber] = useState(0);
 
     return (
-        <Section
-            sx={{
-                pb: { xs: '1.125rem', sm: '1.875rem' }
-            }}>
+        // flushTop: hug the nav; keep the default footer gap.
+        <PageContainer flushTop>
             {/* Mobile category pills — outside the flex row so negative-margin bleed isn't clipped */}
             {categories.length > 0 && (
                 <Box
@@ -121,6 +120,6 @@ export const SearchPage: FunctionComponent = () => {
                     />
                 </Box>
             </Box>
-        </Section>
+        </PageContainer>
     );
 };

--- a/webui/src/pages/user/user-settings.tsx
+++ b/webui/src/pages/user/user-settings.tsx
@@ -10,8 +10,9 @@
 
 import { FunctionComponent, ReactNode, useContext } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { Grid, Container, Box, Typography, Link } from '@mui/material';
+import { Grid, Box, Typography, Link } from '@mui/material';
 import { useParams } from 'react-router-dom';
+import { PageContainer } from '../../components/page-container';
 import { DelayedLoadIndicator } from '../../components/delayed-load-indicator';
 import { UserSettingTabs } from './user-setting-tabs';
 import { UserSettingsTokens } from './user-settings-tokens';
@@ -56,52 +57,48 @@ export const UserSettings: FunctionComponent<UserSettingsProps> = props => {
 
         if (!user) {
             return loginProviders ? (
-                <Container>
-                    <Box mt={6}>
-                        <Typography variant='h4'>Not Logged In</Typography>
-                        <Box mt={2}>
-                            <Typography variant='body1'>
-                                Please{' '}
-                                <LoginComponent
-                                    loginProviders={loginProviders}
-                                    renderButton={(href, onClick) => {
-                                        return (
-                                            <Link color='secondary' href={href} onClick={onClick}>
-                                                log in
-                                            </Link>
-                                        );
-                                    }}
-                                />{' '}
-                                to access your account settings.
-                            </Typography>
-                        </Box>
+                <PageContainer>
+                    <Typography variant='h4'>Not Logged In</Typography>
+                    <Box mt={2}>
+                        <Typography variant='body1'>
+                            Please{' '}
+                            <LoginComponent
+                                loginProviders={loginProviders}
+                                renderButton={(href, onClick) => {
+                                    return (
+                                        <Link color='secondary' href={href} onClick={onClick}>
+                                            log in
+                                        </Link>
+                                    );
+                                }}
+                            />{' '}
+                            to access your account settings.
+                        </Typography>
                     </Box>
-                </Container>
+                </PageContainer>
             ) : null;
         }
 
         return (
-            <Container maxWidth={'xl'}>
-                <Box mt={6}>
-                    <Grid
-                        container
-                        sx={{ flexDirection: { xs: 'column', sm: 'column', md: 'column', lg: 'row', xl: 'row' } }}>
-                        <Grid item sx={{ mb: { xs: '3rem', sm: '3rem', md: '3rem', lg: '3rem', xl: 0 } }}>
-                            <UserSettingTabs />
-                        </Grid>
-                        <Grid
-                            item
-                            sx={{
-                                pt: { xs: 0, sm: 0, md: 0, lg: '.5rem', xl: '.5rem' },
-                                pl: { xs: 0, sm: 0, md: 0, lg: '3rem', xl: '3rem' },
-                                flex: { xs: 'none', sm: 'none', md: 'none', lg: '1', xl: '1' },
-                                width: { xs: '100%', sm: '100%', md: '100%', lg: 'auto', xl: 'auto' }
-                            }}>
-                            <Box>{renderTab(user, tab, namespace, extension)}</Box>
-                        </Grid>
+            <PageContainer>
+                <Grid
+                    container
+                    sx={{ flexDirection: { xs: 'column', sm: 'column', md: 'column', lg: 'row', xl: 'row' } }}>
+                    <Grid item sx={{ mb: { xs: '3rem', sm: '3rem', md: '3rem', lg: '3rem', xl: 0 } }}>
+                        <UserSettingTabs />
                     </Grid>
-                </Box>
-            </Container>
+                    <Grid
+                        item
+                        sx={{
+                            pt: { xs: 0, sm: 0, md: 0, lg: '.5rem', xl: '.5rem' },
+                            pl: { xs: 0, sm: 0, md: 0, lg: '3rem', xl: '3rem' },
+                            flex: { xs: 'none', sm: 'none', md: 'none', lg: '1', xl: '1' },
+                            width: { xs: '100%', sm: '100%', md: '100%', lg: 'auto', xl: 'auto' }
+                        }}>
+                        <Box>{renderTab(user, tab, namespace, extension)}</Box>
+                    </Grid>
+                </Grid>
+            </PageContainer>
         );
     };
 


### PR DESCRIPTION
In the restyle PR we added a homepage with some sections, those sections are basically fully customizable, the only thing we did not take into account was that in order to allow positioning sections on a different order the sections should not hard-code the margins.

This patch fixes that by using an styled parent component that sets different margin top's to it's children.