### PR TITLE
feat: fail-fast the publication when missing permissions or duplicate version an retry on DataIntegrityViolations due to concurrent publications

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
@@ -300,6 +300,7 @@ public class ExtensionProcessor implements AutoCloseable {
     }
 
     public String getVersion() {
+        loadVsixManifest();
         return vsixManifest.path(MANIFEST_METADATA).path(MANIFEST_IDENTITY).path("Version").asString();
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
@@ -127,6 +127,11 @@ public class ExtensionService {
         ExtensionScan scan = null;
 
         try (var processor = new ExtensionProcessor(extensionFile)) {
+            // Fail before any validation or scanning happens (and before a scan record is stored) if the
+            // extension version can not be published anyway, e.g. because the publisher lacks the access
+            // rights for the namespace or the version is published already.
+            publishHandler.checkPublishPreconditions(processor, token);
+
             scan = scanService.initializeScan(processor, token.getUser());
 
             scanService.runValidation(scan, extensionFile, token.getUser());

--- a/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionService.java
@@ -138,7 +138,7 @@ public class ExtensionService {
 
             doPublish(extensionFile, null, token, TimeUtil.getCurrentUTC(), true);
 
-            // Publish async handles requesting the longrunning scans
+            // Publish async handles requesting the long-running scans
             publishHandler.publishAsync(extensionFile, this, scan);
             var download = extensionFile.getResource();
             publishHandler.schedulePublicIdJob(extensionFile.getResource());

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -136,8 +136,8 @@ public class PublishExtensionVersionHandler {
     }
 
     /**
-     * Checks the preconditions that do not depend on the contents of the extension package: the publisher
-     * must exist, the user of {@code token} must be allowed to publish to it, and the version must not be
+     * Checks publish preconditions that should be evaluated before running any package validation or scanning: the
+     * publisher must exist, the user of {@code token} must be allowed to publish to it, and the version must not be
      * published already.
      * <p>
      * Callers publishing with scanning enabled have to invoke this before validating or scanning the
@@ -202,7 +202,7 @@ public class PublishExtensionVersionHandler {
             LocalDateTime timestamp
     ) {
         var namespace = checkPublishPermission(processor, user);
-        var namespaceName = processor.getNamespace();
+        var namespaceName = namespace.getName();
 
         var extensionName = processor.getExtensionName();
         validateExtensionVersion(processor, namespaceName, extensionName);

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -39,6 +39,7 @@ import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.ExtensionScan;
 import org.eclipse.openvsx.entities.ExtensionVersion;
 import org.eclipse.openvsx.entities.FileResource;
+import org.eclipse.openvsx.entities.Namespace;
 import org.eclipse.openvsx.entities.PersonalAccessToken;
 import org.eclipse.openvsx.entities.UserData;
 import org.eclipse.openvsx.extension_control.ExtensionControlService;
@@ -134,12 +135,30 @@ public class PublishExtensionVersionHandler {
         return extVersion;
     }
 
-    private ExtensionVersion createExtensionVersion(
-            ExtensionProcessor processor,
-            UserData user,
-            PersonalAccessToken token,
-            LocalDateTime timestamp
-    ) {
+    /**
+     * Checks the preconditions that do not depend on the contents of the extension package: the publisher
+     * must exist, the user of {@code token} must be allowed to publish to it, and the version must not be
+     * published already.
+     * <p>
+     * Callers publishing with scanning enabled have to invoke this before validating or scanning the
+     * package, as neither is of any use for a package that can not be published in the first place.
+     * The checks are repeated by {@link #createExtensionVersion(ExtensionProcessor, PersonalAccessToken,
+     * LocalDateTime, boolean)}, which enforces them while holding the extension lock.
+     *
+     * @throws ErrorResultException if the extension version can not be published
+     */
+    public void checkPublishPreconditions(ExtensionProcessor processor, PersonalAccessToken token) {
+        var namespace = checkPublishPermission(processor, token.getUser());
+        var extensionName = processor.getExtensionName();
+        var existingVersion = repositories
+                .findVersion(processor.getVersion(), processor.getTargetPlatform(), extensionName, namespace.getName());
+        if (existingVersion != null) {
+            throw new ErrorResultException(
+                    alreadyPublishedMessage(namespace.getName(), extensionName, existingVersion));
+        }
+    }
+
+    private Namespace checkPublishPermission(ExtensionProcessor processor, UserData user) {
         var namespaceName = processor.getNamespace();
         var namespace = repositories.findNamespace(namespaceName);
         if (namespace == null) {
@@ -150,6 +169,40 @@ public class PublishExtensionVersionHandler {
         if (!users.hasPublishPermission(user, namespace)) {
             throw new ErrorResultException("Insufficient access rights for publisher: " + namespace.getName());
         }
+        return namespace;
+    }
+
+    private String alreadyPublishedMessage(
+            String namespaceName,
+            String extensionName,
+            ExtensionVersion existingVersion
+    ) {
+        var extVersionId = NamingUtil.toLogFormat(
+                namespaceName,
+                extensionName,
+                existingVersion.getTargetPlatform(),
+                existingVersion.getVersion());
+        var message = "Extension " + extVersionId + " is already published";
+        if (existingVersion.isRemoved()) {
+            message += " and was removed. Extension versions are immutable, so this version's identity"
+                    + " stays permanently reserved and cannot be republished."
+                    + " Ask an administrator to purge it if it must be republished.";
+        } else {
+            message += existingVersion.isActive()
+                    ? "."
+                    : ", but currently isn't active and therefore not visible.";
+        }
+        return message;
+    }
+
+    private ExtensionVersion createExtensionVersion(
+            ExtensionProcessor processor,
+            UserData user,
+            PersonalAccessToken token,
+            LocalDateTime timestamp
+    ) {
+        var namespace = checkPublishPermission(processor, user);
+        var namespaceName = processor.getNamespace();
 
         var extensionName = processor.getExtensionName();
         validateExtensionVersion(processor, namespaceName, extensionName);
@@ -184,22 +237,8 @@ public class PublishExtensionVersionHandler {
             var existingVersion = repositories
                     .findVersion(extVersion.getVersion(), extVersion.getTargetPlatform(), extension);
             if (existingVersion != null) {
-                var extVersionId = NamingUtil.toLogFormat(
-                        namespaceName,
-                        extensionName,
-                        extVersion.getTargetPlatform(),
-                        extVersion.getVersion());
-                var message = "Extension " + extVersionId + " is already published";
-                if (existingVersion.isRemoved()) {
-                    message += " and was removed. Extension versions are immutable, so this version's identity"
-                            + " stays permanently reserved and cannot be republished."
-                            + " Ask an administrator to purge it if it must be republished.";
-                } else {
-                    message += existingVersion.isActive()
-                            ? "."
-                            : ", but currently isn't active and therefore not visible.";
-                }
-                throw new ErrorResultException(message);
+                throw new ErrorResultException(
+                        alreadyPublishedMessage(namespaceName, extensionName, existingVersion));
             }
         }
 

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -202,7 +202,7 @@ public class PublishExtensionVersionHandler {
             LocalDateTime timestamp
     ) {
         var namespace = checkPublishPermission(processor, user);
-        var namespaceName = namespace.getName();
+        var namespaceName = processor.getNamespace();
 
         var extensionName = processor.getExtensionName();
         validateExtensionVersion(processor, namespaceName, extensionName);

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -10,6 +10,7 @@
 package org.eclipse.openvsx.publish;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.function.Consumer;
@@ -22,10 +23,13 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.hibernate.exception.ConstraintViolationException;
 import org.jobrunr.scheduling.JobRequestScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.resilience.annotation.Retryable;
+import org.springframework.resilience.retry.MethodRetryPredicate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerErrorException;
@@ -104,6 +108,25 @@ public class PublishExtensionVersionHandler {
         return config.isRequireLicense();
     }
 
+    /**
+     * Backstop for a lost race on the creation of the extension row: a writer that does not take the
+     * namespace lock (e.g. a namespace change moving an extension in) can still commit the extension
+     * between our lookup and our insert. PostgreSQL only reports the duplicate once that writer has
+     * committed, so a single retry is enough — it finds the committed extension and adds the version
+     * to it. Retrying is safe because the method derives all of its state from {@code processor} and
+     * the retry advice runs outside the transaction advice, so every attempt gets a fresh transaction.
+     * <p>
+     * Note that this only holds for callers that publish without a transaction of their own, which is
+     * every caller but {@link ExtensionService#mirrorVersion}: an attempt joining an outer transaction
+     * can not commit after that transaction was marked for rollback, so mirroring relies on the
+     * namespace lock alone.
+     */
+    @Retryable(
+        includes = DataIntegrityViolationException.class,
+        predicate = DuplicateExtensionPredicate.class,
+        maxRetries = 1,
+        delay = 100
+    )
     @Transactional(rollbackOn = ErrorResultException.class)
     public ExtensionVersion createExtensionVersion(
             ExtensionProcessor processor,
@@ -223,6 +246,17 @@ public class PublishExtensionVersionHandler {
         // Lock the extension row while adding a version so a concurrent delete-all serializes
         // against this publish (and fails fast with a retry instead of removing it under us).
         var extension = repositories.findExtensionForUpdate(extensionName, namespace.getName());
+        if (extension == null) {
+            // Nothing got locked: the extension does not exist yet, and a FOR UPDATE on a row that
+            // does not exist locks nothing. Serialize concurrent publications that create the same
+            // extension on the namespace row instead, then look again — a racing publish may have
+            // created the extension in the meantime.
+            // This is only reached while holding no extension lock, so the namespace lock is always
+            // taken before the extension lock and cannot invert the lock order of another path.
+            repositories.lockNamespace(namespace);
+            extension = repositories.findExtensionForUpdate(extensionName, namespace.getName());
+        }
+
         if (extension == null) {
             extension = new Extension();
             extension.setActive(false);
@@ -530,6 +564,36 @@ public class PublishExtensionVersionHandler {
         if (StringUtils.isEmpty(extension.getPublicId())) {
             var namespace = extension.getNamespace();
             scheduler.enqueue(new VSCodeIdNewExtensionJobRequest(namespace.getName(), extension.getName()));
+        }
+    }
+
+    /**
+     * Matches only the violation that a concurrently created extension causes, so that publications
+     * failing on any other constraint are reported instead of being retried pointlessly.
+     */
+    public static class DuplicateExtensionPredicate implements MethodRetryPredicate {
+
+        // Unique index on extension(namespace_id, upper(name)), see the V1_20 migration.
+        private static final String UNIQUE_EXTENSION = "unique_extension";
+
+        private static final Logger logger = LoggerFactory.getLogger(DuplicateExtensionPredicate.class);
+
+        @Override
+        public boolean shouldRetry(Method method, Throwable exception) {
+            for (var cause = exception; cause != null; cause = cause.getCause()) {
+                var isDuplicateExtension = cause instanceof ConstraintViolationException violation
+                        && UNIQUE_EXTENSION.equals(violation.getConstraintName());
+                // The constraint name is not always available, so fall back to the reported message.
+                // The quotes keep this from matching unique_extension_version as well.
+                isDuplicateExtension |= cause.getMessage() != null
+                        && cause.getMessage().contains('"' + UNIQUE_EXTENSION + '"');
+
+                if (isDuplicateExtension) {
+                    logger.warn("Extension was created concurrently, retrying the publication", exception);
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/repositories/NamespaceRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/NamespaceRepository.java
@@ -36,6 +36,20 @@ public interface NamespaceRepository extends Repository<Namespace, Long> {
 
     Namespace findByPublicId(String publicId);
 
+    // Publish takes this lock before creating a new extension. A SELECT ... FOR UPDATE on an
+    // extension that does not exist yet locks nothing — there is no row to lock and PostgreSQL has no
+    // gap locking — so two publishes racing for the first version of a new extension would both miss
+    // it and both insert, colliding on the unique_extension index. The namespace does exist at that
+    // point, so it is the row they can serialize on.
+    // FOR NO KEY UPDATE is deliberately weaker than the FOR UPDATE taken on the extension row: it
+    // conflicts with itself, which is all the mutual exclusion needed here, while still allowing the
+    // FOR KEY SHARE locks that rows referencing this namespace take when they are inserted.
+    @Query(
+        value = "select n.* from namespace n where n.id = :id for no key update of n",
+        nativeQuery = true
+    )
+    Namespace findByIdForUpdate(@Param("id") long id);
+
     @Query("from Namespace n where not exists (from NamespaceMembership nm where nm.namespace = n)")
     Streamable<Namespace> findOrphans();
 

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -195,6 +195,14 @@ public class RepositoryService {
         return namespaceJooqRepo.findNameByNameIgnoreCase(name);
     }
 
+    /**
+     * Locks the namespace row so that concurrent publications creating the same extension serialize
+     * against each other, see {@link NamespaceRepository#findByIdForUpdate(long)}.
+     */
+    public void lockNamespace(Namespace namespace) {
+        namespaceRepo.findByIdForUpdate(namespace.getId());
+    }
+
     public Streamable<Namespace> findOrphanNamespaces() {
         return namespaceRepo.findOrphans();
     }

--- a/server/src/test/java/org/eclipse/openvsx/ExtensionServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/ExtensionServiceTest.java
@@ -12,6 +12,8 @@
  *****************************************************************************/
 package org.eclipse.openvsx;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -34,9 +36,11 @@ import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.scanning.ExtensionScanPersistenceService;
 import org.eclipse.openvsx.scanning.ExtensionScanService;
 import org.eclipse.openvsx.search.SearchUtilService;
+import org.eclipse.openvsx.util.ErrorResultException;
 import org.eclipse.openvsx.util.LogService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(MockitoExtension.class)
 class ExtensionServiceTest {
@@ -163,6 +167,33 @@ class ExtensionServiceTest {
         Mockito.verify(repositories, Mockito.never()).findLatestExtensionScan(Mockito.any());
     }
 
+    /**
+     * Validating and scanning a package that can not be published anyway is pointless, so the publish
+     * preconditions (publisher exists, access rights, version not published yet) are checked first and
+     * no scan is initialized or run when they fail.
+     */
+    @Test
+    void shouldNotScanWhenPublishPreconditionsFail() {
+        Mockito.when(publishingConfig.getMaxContentSize()).thenReturn(1024L);
+        Mockito.when(scanService.isEnabled()).thenReturn(true);
+        Mockito.doThrow(new ErrorResultException("Insufficient access rights for publisher: redhat"))
+                .when(publishHandler).checkPublishPreconditions(Mockito.any(), Mockito.any());
+
+        var token = mockToken();
+        var content = new ByteArrayInputStream("extension package".getBytes(StandardCharsets.UTF_8));
+
+        assertThatThrownBy(() -> svc.publishVersion(content, token))
+                .isInstanceOf(ErrorResultException.class)
+                .hasMessageContaining("Insufficient access rights");
+
+        Mockito.verify(scanService, Mockito.never()).initializeScan(Mockito.any(), Mockito.any());
+        Mockito.verify(scanService, Mockito.never())
+                .runValidation(Mockito.any(), Mockito.any(), Mockito.any());
+        Mockito.verify(scanService, Mockito.never()).removeScan(Mockito.any());
+        Mockito.verify(publishHandler, Mockito.never())
+                .publishAsync(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
     // ---------- UTILITY ----------//
 
     private Extension mockExtension() {
@@ -227,5 +258,13 @@ class ExtensionServiceTest {
         user.setProvider("github");
         user.setEclipseToken(new AuthToken("12345", null, null, null, null, null));
         return user;
+    }
+
+    private PersonalAccessToken mockToken() {
+        var token = new PersonalAccessToken();
+        token.setId(1L);
+        token.setValue("token");
+        token.setUser(mockUser());
+        return token;
     }
 }

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionConcurrencyTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionConcurrencyTest.java
@@ -1,0 +1,380 @@
+/********************************************************************************
+ * Copyright (c) 2026 Eclipse Foundation and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.publish;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.persistence.EntityManager;
+import org.jobrunr.scheduling.JobRequestScheduler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import org.eclipse.openvsx.AbstractPostgresContainerTest;
+import org.eclipse.openvsx.ExtensionProcessor;
+import org.eclipse.openvsx.entities.Extension;
+import org.eclipse.openvsx.entities.ExtensionVersion;
+import org.eclipse.openvsx.entities.Namespace;
+import org.eclipse.openvsx.entities.NamespaceMembership;
+import org.eclipse.openvsx.entities.PersonalAccessToken;
+import org.eclipse.openvsx.entities.UserData;
+import org.eclipse.openvsx.repositories.RepositoryService;
+import org.eclipse.openvsx.search.SearchUtilService;
+import org.eclipse.openvsx.util.TargetPlatform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Concurrency tests for the very first publication of an extension.
+ * <p>
+ * Publishing takes a write lock on the extension row before adding a version, but that lock does not
+ * exist yet while the extension itself is being created: {@code SELECT … FOR UPDATE} on a row that
+ * does not exist locks nothing. Two publications racing for the first version of the same extension
+ * (typically the platform-specific packages of one release, published in parallel) therefore both saw
+ * that the extension was missing and both inserted it, so the loser failed with a duplicate key error
+ * on the {@code unique_extension} index.
+ * <p>
+ * The races are deliberately triggered by intercepting the extension lookup (using a spy) and letting
+ * the competing writer commit in exactly the window that used to break.
+ */
+@SpringBootTest
+class PublishExtensionVersionConcurrencyTest extends AbstractPostgresContainerTest {
+
+    private static final String NAMESPACE = "race-publishns";
+    private static final String EXTENSION = "race-publishext";
+    private static final String PUBLISHER_LOGIN = "race-publisher";
+    private static final String VERSION = "1.0.0";
+
+    // Time given to an operation that is expected to complete.
+    private static final long COMPLETION_TIMEOUT_SECONDS = 30;
+
+    // Time an operation blocked on the namespace lock gets to prove that it is not blocked.
+    private static final long BLOCKED_TIMEOUT_SECONDS = 2;
+
+    @Autowired
+    PublishExtensionVersionHandler publishHandler;
+
+    @MockitoSpyBean
+    RepositoryService repositories;
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    PlatformTransactionManager txManager;
+
+    @MockitoBean
+    SearchUtilService search;
+
+    @MockitoBean
+    JobRequestScheduler scheduler;
+
+    private long namespaceId;
+    private long userId;
+    private long tokenId;
+
+    @BeforeEach
+    void setUp() {
+        new TransactionTemplate(txManager).executeWithoutResult(status -> {
+            var user = new UserData();
+            user.setLoginName(PUBLISHER_LOGIN);
+            em.persist(user);
+
+            var token = new PersonalAccessToken();
+            token.setUser(user);
+            token.setValue(PUBLISHER_LOGIN + "_token");
+            token.setCreatedTimestamp(LocalDateTime.now());
+            token.setActive(true);
+            em.persist(token);
+
+            // The namespace exists, the extension does not: this is a first-time publication.
+            var namespace = new Namespace();
+            namespace.setName(NAMESPACE);
+            em.persist(namespace);
+
+            var membership = new NamespaceMembership();
+            membership.setUser(user);
+            membership.setNamespace(namespace);
+            membership.setRole(NamespaceMembership.ROLE_OWNER);
+            em.persist(membership);
+            em.flush();
+
+            namespaceId = namespace.getId();
+            userId = user.getId();
+            tokenId = token.getId();
+        });
+    }
+
+    /**
+     * The reported race: two platform-specific packages of the same new extension are published at the
+     * same time. Both must succeed, and both versions must end up on a single extension record.
+     */
+    @Test
+    void createExtensionVersion_addsToTheExtensionCreatedByAConcurrentPublication() throws Exception {
+        var mainThread = Thread.currentThread();
+        var raceTriggered = new AtomicBoolean();
+        var otherPublishSucceeded = new AtomicBoolean();
+        var otherPublishFinished = new CountDownLatch(1);
+        var otherPublishFailure = new AtomicReference<Throwable>();
+
+        // Let the competing publication create and commit the extension while this one has already
+        // seen that it does not exist yet.
+        doAnswer(invocation -> {
+            var result = invocation.callRealMethod();
+            if (Thread.currentThread() == mainThread && result == null && raceTriggered.compareAndSet(false, true)) {
+                var other = new Thread(() -> {
+                    try {
+                        publish(TargetPlatform.NAME_LINUX_X64);
+                        otherPublishSucceeded.set(true);
+                    } catch (Throwable t) {
+                        otherPublishFailure.set(t);
+                    } finally {
+                        otherPublishFinished.countDown();
+                    }
+                }, "concurrent-publisher");
+                other.start();
+                otherPublishFinished.await(COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            }
+            return result;
+        }).when(repositories).findExtensionForUpdate(EXTENSION, NAMESPACE);
+
+        var extVersion = publish(TargetPlatform.NAME_WIN32_X64);
+
+        assertThat(raceTriggered).as("the race must have been triggered, otherwise nothing was tested").isTrue();
+        assertThat(otherPublishFinished.await(COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+        assertThat(otherPublishFailure.get())
+                .as("the publication that created the extension must not fail")
+                .isNull();
+        assertThat(otherPublishSucceeded).isTrue();
+
+        // The publication that lost the race must have serialized on the namespace row and picked up
+        // the extension created by the winner, instead of inserting a second one. Both publications
+        // take the lock once — the winner to create the extension, the loser to discover it — so a
+        // third call would mean the loser had to fall back to a retry.
+        verify(repositories, times(2)).lockNamespace(any());
+        assertThat(extensionIds())
+                .as("concurrent first-time publications must not create the extension twice")
+                .hasSize(1);
+        assertThat(extVersion.getExtension().getId()).isEqualTo(extensionIds().getFirst());
+        assertThat(targetPlatformsOfPublishedVersions())
+                .containsExactlyInAnyOrder(TargetPlatform.NAME_WIN32_X64, TargetPlatform.NAME_LINUX_X64);
+    }
+
+    /**
+     * Lock contract: while the namespace row is locked, a publication that has to create the extension
+     * must wait for that lock rather than racing ahead into the unique index.
+     */
+    @Test
+    void createExtensionVersion_waitsForTheNamespaceLockBeforeCreatingTheExtension() throws Exception {
+        var lockHeld = new CountDownLatch(1);
+        var releaseLock = new CountDownLatch(1);
+
+        // Uses a self-contained SELECT ... FOR NO KEY UPDATE so this test does not depend on the
+        // production lock method (and therefore also fails on a fix that locks nothing).
+        var lockHolder = new Thread(() -> new TransactionTemplate(txManager).executeWithoutResult(status -> {
+            em.createNativeQuery("select id from namespace where id = ?1 for no key update")
+                    .setParameter(1, namespaceId)
+                    .getSingleResult();
+            lockHeld.countDown();
+            try {
+                releaseLock.await(COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }), "namespace-lock-holder");
+        lockHolder.start();
+        assertThat(lockHeld.await(COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+
+        var publishSucceeded = new AtomicBoolean();
+        var publishFinished = new CountDownLatch(1);
+        var publisher = new Thread(() -> {
+            try {
+                publish(TargetPlatform.NAME_WIN32_X64);
+                publishSucceeded.set(true);
+            } finally {
+                publishFinished.countDown();
+            }
+        }, "publisher");
+
+        try {
+            publisher.start();
+            assertThat(publishFinished.await(BLOCKED_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                    .as("creating the extension must block while the namespace row is locked")
+                    .isFalse();
+        } finally {
+            releaseLock.countDown();
+            lockHolder.join(TimeUnit.SECONDS.toMillis(COMPLETION_TIMEOUT_SECONDS));
+        }
+
+        assertThat(publishFinished.await(COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .as("the publication must proceed once the namespace lock is released")
+                .isTrue();
+        assertThat(publishSucceeded).isTrue();
+        assertThat(extensionIds()).hasSize(1);
+    }
+
+    /**
+     * Retry backstop: a writer that creates the extension without taking the namespace lock (e.g. a
+     * namespace change moving an extension in) can still win the race. The publication then runs into
+     * the unique index and must recover by retrying, not by failing the publisher's request.
+     */
+    @Test
+    void createExtensionVersion_retriesWhenAnotherWriterCreatedTheExtension() {
+        var mainThread = Thread.currentThread();
+        var lookups = new AtomicInteger();
+        var lookupAfterLock = new AtomicReference<Object>();
+        var conflictingExtensionId = new AtomicReference<Long>();
+
+        doAnswer(invocation -> {
+            var result = invocation.callRealMethod();
+            // The second lookup is the one after the namespace lock was taken; a writer committing
+            // right after it leaves this publication with no way to see the extension.
+            if (Thread.currentThread() == mainThread && lookups.incrementAndGet() == 2) {
+                lookupAfterLock.set(result);
+                conflictingExtensionId.set(createExtensionInSeparateTransaction());
+            }
+            return result;
+        }).when(repositories).findExtensionForUpdate(EXTENSION, NAMESPACE);
+
+        var extVersion = publish(TargetPlatform.NAME_WIN32_X64);
+
+        assertThat(lookupAfterLock.get())
+                .as("the extension must still have been absent when the conflict was injected")
+                .isNull();
+        assertThat(lookups.get())
+                .as("the publication must have been retried, adding a third lookup")
+                .isEqualTo(3);
+        assertThat(extensionIds())
+                .as("the retry must reuse the extension created by the other writer")
+                .containsExactly(conflictingExtensionId.get());
+        assertThat(extVersion.getExtension().getId()).isEqualTo(conflictingExtensionId.get());
+        assertThat(targetPlatformsOfPublishedVersions()).containsExactly(TargetPlatform.NAME_WIN32_X64);
+    }
+
+    private ExtensionVersion publish(String targetPlatform) {
+        try (var processor = mockProcessor(targetPlatform)) {
+            return publishHandler.createExtensionVersion(processor, publishToken(), LocalDateTime.now(), false);
+        }
+    }
+
+    private ExtensionProcessor mockProcessor(String targetPlatform) {
+        var processor = mock(ExtensionProcessor.class);
+        when(processor.getNamespace()).thenReturn(NAMESPACE);
+        when(processor.getExtensionName()).thenReturn(EXTENSION);
+        when(processor.getVersion()).thenReturn(VERSION);
+        when(processor.getTargetPlatform()).thenReturn(targetPlatform);
+        when(processor.getExtensionDependencies()).thenReturn(List.of());
+        when(processor.getBundledExtensions()).thenReturn(List.of());
+        when(processor.getPackageMetadata())
+                .thenReturn(new ExtensionProcessor.PackageMetadata(NAMESPACE, EXTENSION, VERSION, "Race Test"));
+        // Like the real processor, hand out a fresh instance per call: a retried attempt must not
+        // reuse the entity of the attempt that was rolled back.
+        when(processor.getMetadata()).thenAnswer(invocation -> {
+            var extVersion = new ExtensionVersion();
+            extVersion.setVersion(VERSION);
+            extVersion.setTargetPlatform(targetPlatform);
+            extVersion.setDisplayName("Race Test");
+            return extVersion;
+        });
+        return processor;
+    }
+
+    /**
+     * The publishing token as the publish endpoint passes it in: detached, with its user attached.
+     */
+    private PersonalAccessToken publishToken() {
+        var user = new UserData();
+        user.setId(userId);
+        user.setLoginName(PUBLISHER_LOGIN);
+        var token = new PersonalAccessToken();
+        token.setId(tokenId);
+        token.setUser(user);
+        return token;
+    }
+
+    /**
+     * Creates the extension in its own transaction, without taking the namespace lock, and returns its id.
+     */
+    private long createExtensionInSeparateTransaction() {
+        var template = new TransactionTemplate(txManager);
+        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return template.execute(status -> {
+            var extension = new Extension();
+            extension.setName(EXTENSION);
+            extension.setNamespace(em.getReference(Namespace.class, namespaceId));
+            extension.setActive(false);
+            extension.setDeprecated(false);
+            extension.setDownloadable(true);
+            extension.setPublishedDate(LocalDateTime.now());
+            extension.setLastUpdatedDate(LocalDateTime.now());
+            em.persist(extension);
+            em.flush();
+            return extension.getId();
+        });
+    }
+
+    private List<Long> extensionIds() {
+        return new TransactionTemplate(txManager).execute(
+                status -> em.createQuery(
+                        "select e.id from Extension e where e.name = :name and e.namespace.name = :namespace",
+                        Long.class)
+                        .setParameter("name", EXTENSION)
+                        .setParameter("namespace", NAMESPACE)
+                        .getResultList());
+    }
+
+    private List<String> targetPlatformsOfPublishedVersions() {
+        return new TransactionTemplate(txManager).execute(
+                status -> em.createQuery(
+                        "select ev.targetPlatform from ExtensionVersion ev "
+                                + "where ev.extension.name = :name and ev.extension.namespace.name = :namespace",
+                        String.class)
+                        .setParameter("name", EXTENSION)
+                        .setParameter("namespace", NAMESPACE)
+                        .getResultList());
+    }
+
+    @AfterEach
+    void tearDown() {
+        new TransactionTemplate(txManager).executeWithoutResult(status -> {
+            em.createQuery("delete from ExtensionVersion ev where ev.extension.namespace.name = :namespace")
+                    .setParameter("namespace", NAMESPACE).executeUpdate();
+            em.createQuery("delete from Extension e where e.namespace.name = :namespace")
+                    .setParameter("namespace", NAMESPACE).executeUpdate();
+            em.createQuery("delete from NamespaceMembership nm where nm.namespace.name = :namespace")
+                    .setParameter("namespace", NAMESPACE).executeUpdate();
+            em.createQuery("delete from PersonalAccessToken t where t.user.loginName = :login")
+                    .setParameter("login", PUBLISHER_LOGIN).executeUpdate();
+            em.createQuery("delete from Namespace n where n.name = :namespace")
+                    .setParameter("namespace", NAMESPACE).executeUpdate();
+            em.createQuery("delete from UserData u where u.loginName = :login")
+                    .setParameter("login", PUBLISHER_LOGIN).executeUpdate();
+        });
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
@@ -35,9 +35,13 @@ import org.eclipse.openvsx.extension_control.ExtensionControlService;
 import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.scanning.ExtensionScanService;
 import org.eclipse.openvsx.util.ErrorResultException;
+import org.eclipse.openvsx.util.TargetPlatform;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -262,6 +266,120 @@ class PublishExtensionVersionHandlerTest {
             assertThatThrownBy(() -> handler.createExtensionVersion(processor, token, LocalDateTime.now(), false))
                     .isInstanceOf(ErrorResultException.class)
                     .hasMessageContaining("Extension version in extension.vsixmanifest");
+        }
+    }
+
+    @Test
+    void shouldPassPreconditionsForUnpublishedVersion() {
+        try (var processor = org.mockito.Mockito.mock(ExtensionProcessor.class)) {
+            var namespace = buildNamespace("publisher");
+            var user = new UserData();
+            var token = new PersonalAccessToken();
+            token.setUser(user);
+
+            when(processor.getNamespace()).thenReturn("publisher");
+            when(processor.getExtensionName()).thenReturn("demo");
+            when(processor.getVersion()).thenReturn("2.0.0");
+            when(processor.getTargetPlatform()).thenReturn(TargetPlatform.NAME_UNIVERSAL);
+            when(repositories.findNamespace("publisher")).thenReturn(namespace);
+            when(users.hasPublishPermission(user, namespace)).thenReturn(true);
+            when(repositories.findVersion("2.0.0", TargetPlatform.NAME_UNIVERSAL, "demo", "publisher"))
+                    .thenReturn(null);
+
+            assertThatCode(() -> handler.checkPublishPreconditions(processor, token)).doesNotThrowAnyException();
+        }
+    }
+
+    @Test
+    void shouldFailPreconditionsWithoutPublishPermission() {
+        try (var processor = org.mockito.Mockito.mock(ExtensionProcessor.class)) {
+            var namespace = buildNamespace("publisher");
+            var user = new UserData();
+            var token = new PersonalAccessToken();
+            token.setUser(user);
+
+            when(processor.getNamespace()).thenReturn("publisher");
+            when(repositories.findNamespace("publisher")).thenReturn(namespace);
+            when(users.hasPublishPermission(user, namespace)).thenReturn(false);
+
+            assertThatThrownBy(() -> handler.checkPublishPreconditions(processor, token))
+                    .isInstanceOf(ErrorResultException.class)
+                    .hasMessageContaining("Insufficient access rights for publisher: publisher");
+
+            // the package is not inspected any further once the access rights are missing
+            verify(repositories, never()).findVersion(anyString(), anyString(), anyString(), anyString());
+        }
+    }
+
+    @Test
+    void shouldFailPreconditionsWithUnknownNamespace() {
+        try (var processor = org.mockito.Mockito.mock(ExtensionProcessor.class)) {
+            var token = new PersonalAccessToken();
+            token.setUser(new UserData());
+
+            when(processor.getNamespace()).thenReturn("unknown");
+            when(repositories.findNamespace("unknown")).thenReturn(null);
+
+            assertThatThrownBy(() -> handler.checkPublishPreconditions(processor, token))
+                    .isInstanceOf(ErrorResultException.class)
+                    .hasMessageContaining("Unknown publisher: unknown");
+        }
+    }
+
+    @Test
+    void shouldFailPreconditionsForAlreadyPublishedVersion() {
+        try (var processor = org.mockito.Mockito.mock(ExtensionProcessor.class)) {
+            var namespace = buildNamespace("publisher");
+            var user = new UserData();
+            var token = new PersonalAccessToken();
+            token.setUser(user);
+
+            var existing = new ExtensionVersion();
+            existing.setVersion("2.0.0");
+            existing.setTargetPlatform(TargetPlatform.NAME_UNIVERSAL);
+            existing.setActive(true);
+
+            when(processor.getNamespace()).thenReturn("publisher");
+            when(processor.getExtensionName()).thenReturn("demo");
+            when(processor.getVersion()).thenReturn("2.0.0");
+            when(processor.getTargetPlatform()).thenReturn(TargetPlatform.NAME_UNIVERSAL);
+            when(repositories.findNamespace("publisher")).thenReturn(namespace);
+            when(users.hasPublishPermission(user, namespace)).thenReturn(true);
+            when(repositories.findVersion("2.0.0", TargetPlatform.NAME_UNIVERSAL, "demo", "publisher"))
+                    .thenReturn(existing);
+
+            assertThatThrownBy(() -> handler.checkPublishPreconditions(processor, token))
+                    .isInstanceOf(ErrorResultException.class)
+                    .hasMessageContaining("is already published.");
+        }
+    }
+
+    @Test
+    void shouldFailPreconditionsForRemovedVersion() {
+        try (var processor = org.mockito.Mockito.mock(ExtensionProcessor.class)) {
+            var namespace = buildNamespace("publisher");
+            var user = new UserData();
+            var token = new PersonalAccessToken();
+            token.setUser(user);
+
+            var tombstone = new ExtensionVersion();
+            tombstone.setVersion("2.0.0");
+            tombstone.setTargetPlatform(TargetPlatform.NAME_UNIVERSAL);
+            tombstone.setActive(false);
+            tombstone.setRemoved(true);
+
+            when(processor.getNamespace()).thenReturn("publisher");
+            when(processor.getExtensionName()).thenReturn("demo");
+            when(processor.getVersion()).thenReturn("2.0.0");
+            when(processor.getTargetPlatform()).thenReturn(TargetPlatform.NAME_UNIVERSAL);
+            when(repositories.findNamespace("publisher")).thenReturn(namespace);
+            when(users.hasPublishPermission(user, namespace)).thenReturn(true);
+            when(repositories.findVersion("2.0.0", TargetPlatform.NAME_UNIVERSAL, "demo", "publisher"))
+                    .thenReturn(tombstone);
+
+            assertThatThrownBy(() -> handler.checkPublishPreconditions(processor, token))
+                    .isInstanceOf(ErrorResultException.class)
+                    .hasMessageContaining("stays permanently reserved");
         }
     }
 

--- a/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
@@ -223,6 +223,7 @@ class RepositoryServiceSmokeTest extends AbstractPostgresContainerTest {
                 () -> repositories.findMemberships(namespace, "role"),
                 () -> repositories.deleteMemberships(userData),
                 () -> repositories.findNamespace("name"),
+                () -> repositories.lockNamespace(namespace),
                 () -> repositories.findConflictingNamespaces("displayName", namespace),
                 () -> repositories.findOrphanNamespaces(),
                 () -> repositories.findPersistedLogsAfter(NOW),


### PR DESCRIPTION
This fixes #1961 .

Currently, some publication checks are only performed after some pre-publication checks which is unnecessary.

This PR does the following checks before the pre-publication checks:

 - does the current user has permissions to publish to the namespace
 - does the extension version already exist

If one of these checks fail, the publication is aborted before any pre-publication check even happens.

Additionally, a race condition that happens when an extension is published the first time with multiple `targetPlatforms`. Each platform has its own vsix and they race for the creation of the `Extension`. Now there is a reliable retry mechanism in such a case to avoid such errors which happen from time to time.