### PR TITLE
fix: limit the maximum number of tags per extensin version

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionProcessor.java
@@ -50,6 +50,16 @@ public class ExtensionProcessor implements AutoCloseable {
         "extension/CHANGELOG.txt"
     };
 
+    /**
+     * Number of tags kept per extension version unless a different limit is configured.
+     * <p>
+     * See: <a href="https://github.com/eclipse-openvsx/openvsx/issues/1968">Limit the number of
+     * processed tags per extension</a>
+     */
+    public static final int DEFAULT_MAX_TAGS = 20;
+
+    private static final int NO_TAG_LIMIT = Integer.MAX_VALUE;
+
     private static final String MANIFEST_METADATA = "Metadata";
     private static final String MANIFEST_IDENTITY = "Identity";
     private static final String MANIFEST_PROPERTIES = "Properties";
@@ -259,7 +269,17 @@ public class ExtensionProcessor implements AutoCloseable {
         return sponsorLinkNode.path(MANIFEST_VALUE).asString();
     }
 
+    /**
+     * Extracts the metadata, keeping at most {@link #DEFAULT_MAX_TAGS} tags.
+     */
     public ExtensionVersion getMetadata() {
+        return getMetadata(DEFAULT_MAX_TAGS);
+    }
+
+    /**
+     * @param maxTags maximum number of tags to extract, a negative value keeps all of them
+     */
+    public ExtensionVersion getMetadata(int maxTags) {
         loadPackageJson();
         loadVsixManifest();
         var extVersion = new ExtensionVersion();
@@ -275,7 +295,7 @@ public class ExtensionProcessor implements AutoCloseable {
         extVersion.setEngines(getEngines(packageJson.path("engines")));
         extVersion.setCategories(asStringList(vsixManifest.path(MANIFEST_METADATA).path("Categories").asString(), ","));
         extVersion.setExtensionKind(getExtensionKinds());
-        extVersion.setTags(getTags());
+        extVersion.setTags(getTags(maxTags));
         extVersion.setLicense(packageJson.path("license").stringValue(null));
         extVersion.setHomepage(getHomepage());
         extVersion.setRepository(getRepository());
@@ -324,11 +344,15 @@ public class ExtensionProcessor implements AutoCloseable {
         return displayName;
     }
 
-    private List<String> getTags() {
+    private List<String> getTags(int maxTags) {
         var tags = vsixManifest.path(MANIFEST_METADATA).path("Tags").asString();
+        // Group case-insensitively into a map that keeps the order in which the package declares the
+        // tags, so that capping the amount of tags keeps the ones the extension considers the most
+        // relevant. Duplicates are removed before the cap and therefore don't take up a slot.
         return asStringList(tags, ",").stream()
-                .collect(Collectors.groupingBy(String::toLowerCase))
+                .collect(Collectors.groupingBy(String::toLowerCase, LinkedHashMap::new, Collectors.toList()))
                 .entrySet().stream()
+                .limit(maxTags < 0 ? NO_TAG_LIMIT : maxTags)
                 .sorted(Map.Entry.comparingByKey())
                 .map(e -> e.getValue().getFirst())
                 .collect(Collectors.toList());

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -230,7 +230,9 @@ public class PublishExtensionVersionHandler {
         var extensionName = processor.getExtensionName();
         validateExtensionVersion(processor, namespaceName, extensionName);
 
-        var extVersion = processor.getMetadata();
+        // This is the only place where extracted metadata gets persisted, so it is the one that has to
+        // honour the configured tag limit.
+        var extVersion = processor.getMetadata(config.getMaxTags());
         var displayName = extVersion.getDisplayName();
         validateExtensionName(namespaceName, extensionName, displayName, user);
 

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishingConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishingConfig.java
@@ -18,6 +18,8 @@ import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import org.eclipse.openvsx.ExtensionProcessor;
+
 @Configuration
 @ConfigurationProperties("ovsx.publishing")
 public class PublishingConfig {
@@ -33,6 +35,15 @@ public class PublishingConfig {
      * See: <a href="https://github.com/eclipse-openvsx/openvsx/issues/2">Block SVG Images</a>
      */
     private List<String> unsupportedIconFormats = List.of("svg");
+
+    /**
+     * Maximum number of tags to extract from a package and store with an extension version. Tags
+     * beyond that limit are dropped, a negative value keeps all of them.
+     * <p>
+     * See: <a href="https://github.com/eclipse-openvsx/openvsx/issues/1968">Limit the number of
+     * processed tags per extension</a>
+     */
+    private int maxTags = ExtensionProcessor.DEFAULT_MAX_TAGS;
 
     public long getMaxContentSize() {
         return maxContentSize;
@@ -56,5 +67,13 @@ public class PublishingConfig {
 
     public void setUnsupportedIconFormats(List<String> unsupportedIconFormats) {
         this.unsupportedIconFormats = unsupportedIconFormats;
+    }
+
+    public int getMaxTags() {
+        return maxTags;
+    }
+
+    public void setMaxTags(int maxTags) {
+        this.maxTags = maxTags;
     }
 }

--- a/server/src/test/java/org/eclipse/openvsx/ExtensionProcessorTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/ExtensionProcessorTest.java
@@ -10,10 +10,16 @@
 package org.eclipse.openvsx;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
 
 import org.junit.jupiter.api.Test;
 
@@ -94,6 +100,88 @@ class ExtensionProcessorTest {
             processor.getFileResources(processor.getMetadata(), consumer);
             assertThat(count.get()).isEqualTo(5);
         }
+    }
+
+    @Test
+    void testTagsAreCappedAtTheDefaultLimit() throws Exception {
+        var declaredTags = tags(25);
+        try (
+                var file = writeTagsToTempFile(declaredTags);
+                var processor = new ExtensionProcessor(file)
+        ) {
+            // The tags an extension declares first are the ones that are kept.
+            assertThat(processor.getMetadata().getTags())
+                    .hasSize(20)
+                    .containsExactlyElementsOf(declaredTags.subList(0, 20));
+        }
+    }
+
+    @Test
+    void testTagLimitIsConfigurable() throws Exception {
+        var declaredTags = tags(25);
+        try (
+                var file = writeTagsToTempFile(declaredTags);
+                var processor = new ExtensionProcessor(file)
+        ) {
+            assertThat(processor.getMetadata(3).getTags()).containsExactlyElementsOf(declaredTags.subList(0, 3));
+        }
+    }
+
+    @Test
+    void testTagLimitIsDisabledForANegativeLimit() throws Exception {
+        var declaredTags = tags(25);
+        try (
+                var file = writeTagsToTempFile(declaredTags);
+                var processor = new ExtensionProcessor(file)
+        ) {
+            assertThat(processor.getMetadata(-1).getTags()).containsExactlyElementsOf(declaredTags);
+        }
+    }
+
+    @Test
+    void testTagLimitCountsDistinctTagsOnly() throws Exception {
+        try (
+                var file = writeTagsToTempFile(List.of("Todo", "todo", "task"));
+                var processor = new ExtensionProcessor(file)
+        ) {
+            // The duplicate does not take up one of the two slots, and the first spelling wins.
+            assertThat(processor.getMetadata(2).getTags()).containsExactly("task", "Todo");
+        }
+    }
+
+    private List<String> tags(int count) {
+        // Named so that the alphabetical order the tags are stored in matches the declaration order.
+        return IntStream.rangeClosed(1, count).mapToObj(i -> String.format("tag-%02d", i)).toList();
+    }
+
+    /**
+     * Writes a package that declares the given tags, based on an existing extension so that the rest of
+     * the manifest stays valid.
+     */
+    private TempFile writeTagsToTempFile(List<String> tags) throws IOException {
+        var target = new TempFile("test", ".zip");
+        try (
+                var source = writeToTempFile("util/todo-tree.zip");
+                var zipFile = new ZipFile(source.getPath().toFile());
+                var out = new ZipOutputStream(Files.newOutputStream(target.getPath()))
+        ) {
+            for (var name : List.of("extension.vsixmanifest", "extension/package.json")) {
+                var content = new String(
+                        zipFile.getInputStream(zipFile.getEntry(name)).readAllBytes(),
+                        StandardCharsets.UTF_8);
+                if (name.equals("extension.vsixmanifest")) {
+                    content = content.replace(
+                            "<Tags>todo,task,tasklist,multi-root ready</Tags>",
+                            "<Tags>" + String.join(",", tags) + "</Tags>");
+                }
+
+                out.putNextEntry(new ZipEntry(name));
+                out.write(content.getBytes(StandardCharsets.UTF_8));
+                out.closeEntry();
+            }
+        }
+
+        return target;
     }
 
     private TempFile writeToTempFile(String resource) throws IOException {

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -1805,6 +1805,32 @@ class RegistryAPITest {
     }
 
     @Test
+    void testPublishLimitsTags() throws Exception {
+        var previousMaxTags = publishingConfig.getMaxTags();
+        try {
+            publishingConfig.setMaxTags(2);
+            mockForPublish("contributor");
+            mockActiveVersion();
+            var bytes = createExtensionPackage("bar", "1.0.0", null, false, null, List.of("beta", "alpha", "gamma"));
+            mockMvc.perform(
+                    post("/api/-/publish?token={token}", "my_token")
+                            .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                            .content(bytes))
+                    .andExpect(status().isCreated())
+                    .andExpect(content().json(extensionJson(e -> {
+                        e.setNamespace("foo");
+                        e.setName("bar");
+                        e.setVersion("1.0.0");
+                        e.setDownloadable(true);
+                        // The third declared tag is dropped, the kept ones are stored sorted.
+                        e.setTags(List.of("alpha", "beta"));
+                    })));
+        } finally {
+            publishingConfig.setMaxTags(previousMaxTags);
+        }
+    }
+
+    @Test
     void testPublishInactiveToken() throws Exception {
         mockForPublish("invalid");
         var bytes = createExtensionPackage("bar", "1.0.0", null);
@@ -2853,6 +2879,17 @@ class RegistryAPITest {
             boolean preRelease,
             String targetPlatform
     ) throws IOException {
+        return createExtensionPackage(name, version, license, preRelease, targetPlatform, List.of());
+    }
+
+    private byte[] createExtensionPackage(
+            String name,
+            String version,
+            String license,
+            boolean preRelease,
+            String targetPlatform,
+            List<String> tags
+    ) throws IOException {
         var bytes = new ByteArrayOutputStream();
         var archive = new ZipOutputStream(bytes);
         archive.putNextEntry(new ZipEntry("extension.vsixmanifest"));
@@ -2864,7 +2901,7 @@ class RegistryAPITest {
                 + (targetPlatform != null ? "TargetPlatform=\"" + targetPlatform + "\"" : "") + " />" +
                 "<DisplayName>foo</DisplayName>" +
                 "<Description xml:space=\"preserve\"></Description>" +
-                "<Tags></Tags>" +
+                "<Tags>" + String.join(",", tags) + "</Tags>" +
                 "<Categories>Other</Categories>" +
                 "<GalleryFlags>Public</GalleryFlags>" +
                 "<Badges></Badges>" +

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionConcurrencyTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionConcurrencyTest.java
@@ -44,6 +44,7 @@ import org.eclipse.openvsx.util.TargetPlatform;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -295,7 +296,7 @@ class PublishExtensionVersionConcurrencyTest extends AbstractPostgresContainerTe
                 .thenReturn(new ExtensionProcessor.PackageMetadata(NAMESPACE, EXTENSION, VERSION, "Race Test"));
         // Like the real processor, hand out a fresh instance per call: a retried attempt must not
         // reuse the entity of the attempt that was rolled back.
-        when(processor.getMetadata()).thenAnswer(invocation -> {
+        when(processor.getMetadata(anyInt())).thenAnswer(invocation -> {
             var extVersion = new ExtensionVersion();
             extVersion.setVersion(VERSION);
             extVersion.setTargetPlatform(targetPlatform);

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
@@ -40,6 +40,7 @@ import org.eclipse.openvsx.util.TargetPlatform;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -401,7 +402,7 @@ class PublishExtensionVersionHandlerTest {
         ev.setDisplayName("Demo OK");
         ev.setVersion("2.0.0");
         ev.setTargetPlatform("any");
-        when(processor.getMetadata()).thenReturn(ev);
+        when(processor.getMetadata(anyInt())).thenReturn(ev);
 
         return ev;
     }


### PR DESCRIPTION
This fixes #1968 .

There is now a new configuration value `ovsx.publishing.max-tags` with a default of `20.