### PR TITLE
fix: correctly encode + chars in storage location URLs in case of AWS

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
@@ -33,7 +33,6 @@ import software.amazon.awssdk.awscore.defaultsmode.DefaultsMode;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
-import software.amazon.awssdk.services.s3.S3ServiceClientConfiguration;
 import software.amazon.awssdk.services.s3.endpoints.S3EndpointParams;
 import software.amazon.awssdk.services.s3.endpoints.S3EndpointProvider;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
@@ -279,7 +278,37 @@ public class AwsStorageService implements IStorageService {
         return getLocation(getObjectKey(namespace));
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Percent-encodes the {@code +} that {@link #getObjectKey(FileResource)} leaves in the key: RFC 3986
+     * allows it in a path segment, but S3 (and a CDN in front of it) decodes {@code +} in a path as a
+     * space, which makes every version carrying semver build metadata such as {@code 1.0.0+10}
+     * unresolvable. See <a href="https://github.com/eclipse-openvsx/openvsx/issues/1459">issue 1459</a>.
+     * <p>
+     * The result must only ever be passed to {@link URI#create(String)}: encoding it a second time —
+     * {@code UriUtils.encodePathSegment}, {@code UriComponentsBuilder.encode()},
+     * {@code UriComponents.toUri()} or the multi-argument {@link URI} constructor — escapes the
+     * {@code %} again and produces {@code %252B}.
+     */
+    @Override
+    public String getObjectKeyAsUrlPath(FileResource resource) {
+        return encodeObjectKeyAsUrlPath(getObjectKey(resource));
+    }
+
+    @Override
+    public String getObjectKeyAsUrlPath(Namespace namespace) {
+        return encodeObjectKeyAsUrlPath(getObjectKey(namespace));
+    }
+
+    private String encodeObjectKeyAsUrlPath(String objectKey) {
+        return objectKey.replace("+", "%2B");
+    }
+
     private URI getLocation(String objectKey) {
+        // The presigner encodes the object key itself ('+' becomes %2B) and signs that form, so the key
+        // must be handed over unencoded here: encoding it as well would both double-encode the path and
+        // invalidate the signature.
         var objectRequest = GetObjectRequest.builder()
                 .bucket(bucket)
                 .key(objectKey)

--- a/server/src/main/java/org/eclipse/openvsx/storage/IStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/IStorageService.java
@@ -81,11 +81,30 @@ public interface IStorageService {
         segments = ArrayUtils.add(segments, extVersion.getVersion());
         segments = ArrayUtils.addAll(segments, resource.getName().split("/"));
         var url = UrlUtil.createApiUrl("", segments);
-        return url != null ? url.substring(1) : null; // remove first '/'
+        return url.substring(1); // remove first '/'
     }
 
     default String getObjectKey(Namespace namespace) {
         var url = UrlUtil.createApiUrl("", namespace.getName(), "logo", namespace.getLogoName());
-        return url != null ? url.substring(1) : null; // remove first '/'
+        return url.substring(1); // remove first '/'
+    }
+
+    /**
+     * Returns the object key of {@code resource} in the form it has to take within a URL path.
+     * <p>
+     * Defaults to the object key itself, which {@link #getObjectKey(FileResource)} already encoded
+     * per path segment. Storage providers that do not interpret a path the way RFC 3986 defines it
+     * can override this to escape what they need on top of that.
+     */
+    default String getObjectKeyAsUrlPath(FileResource resource) {
+        return getObjectKey(resource);
+    }
+
+    /**
+     * Returns the object key of the logo of {@code namespace} in the form it has to take within a URL
+     * path, see {@link #getObjectKeyAsUrlPath(FileResource)}.
+     */
+    default String getObjectKeyAsUrlPath(Namespace namespace) {
+        return getObjectKey(namespace);
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
@@ -244,7 +244,7 @@ public class StorageUtilService implements IStorageService {
         if (storageService != null) {
             String cdnFrontUrl = cdnServiceConfig.getCdnFrontUrl(storageType);
             if (cdnFrontUrl != null) {
-                return UrlUtil.createURI(cdnFrontUrl, storageService.getObjectKey(resource));
+                return UrlUtil.createURI(cdnFrontUrl, storageService.getObjectKeyAsUrlPath(resource));
             } else {
                 return storageService.getLocation(resource);
             }
@@ -260,7 +260,7 @@ public class StorageUtilService implements IStorageService {
         if (storageService != null) {
             String cdnFrontUrl = cdnServiceConfig.getCdnFrontUrl(storageType);
             if (cdnFrontUrl != null) {
-                return UrlUtil.createURI(cdnFrontUrl, storageService.getObjectKey(namespace));
+                return UrlUtil.createURI(cdnFrontUrl, storageService.getObjectKeyAsUrlPath(namespace));
             } else {
                 return storageService.getNamespaceLogoLocation(namespace);
             }

--- a/server/src/test/java/org/eclipse/openvsx/storage/AwsStorageServiceIntegrationTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/storage/AwsStorageServiceIntegrationTest.java
@@ -10,6 +10,10 @@
 package org.eclipse.openvsx.storage;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
@@ -240,6 +244,39 @@ class AwsStorageServiceIntegrationTest {
         assertTrue(locationStr.contains(TEST_BUCKET));
         assertTrue(locationStr.contains("testnamespace/test-extension/1.0.0/extension.vsix"));
         assertTrue(locationStr.contains("X-Amz-Algorithm"));
+
+        tempFile.close();
+    }
+
+    /**
+     * A version with semver build metadata is stored under a key containing a literal {@code +}, which the
+     * presigner has to hand out percent-encoded because S3 reads a {@code +} in a URL path as a space.
+     * See <a href="https://github.com/eclipse-openvsx/openvsx/issues/1459">issue 1459</a>.
+     * <p>
+     * Note that LocalStack does not reproduce that behaviour — it resolves a literal {@code +} in the path
+     * just fine — so this test guards the encoding of the URL rather than reproducing the failure.
+     */
+    @Test
+    void testGetPresignedUrlForVersionWithPlusSign() throws Exception {
+        extVersion.setVersion("1.0.0+10");
+        var tempFile = new TempFile("test_", ".vsix");
+        Files.write(tempFile.getPath(), "test content".getBytes(), StandardOpenOption.CREATE);
+        tempFile.setResource(resource);
+        storageService.uploadFile(tempFile);
+
+        var objectKey = (String) ReflectionTestUtils.invokeMethod(storageService, "getObjectKey", resource);
+        assertEquals("testnamespace/test-extension/1.0.0+10/extension.vsix", objectKey);
+
+        var location = storageService.getLocation(resource).toString();
+        assertTrue(
+                location.contains("testnamespace/test-extension/1.0.0%2B10/extension.vsix"),
+                "expected an encoded '+' in " + location);
+
+        var response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(URI.create(location)).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+        assertEquals("test content", response.body());
 
         tempFile.close();
     }

--- a/server/src/test/java/org/eclipse/openvsx/storage/AwsStorageServiceIntegrationTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/storage/AwsStorageServiceIntegrationTest.java
@@ -269,7 +269,7 @@ class AwsStorageServiceIntegrationTest {
 
         var location = storageService.getLocation(resource).toString();
         assertTrue(
-                location.contains("testnamespace/test-extension/1.0.0%2B10/extension.vsix"),
+                location.matches("(?i).*testnamespace/test-extension/1\\.0\\.0%2b10/extension\\.vsix.*"),
                 "expected an encoded '+' in " + location);
 
         var response = HttpClient.newHttpClient().send(

--- a/server/src/test/java/org/eclipse/openvsx/storage/AwsStorageServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/storage/AwsStorageServiceTest.java
@@ -170,6 +170,31 @@ class AwsStorageServiceTest {
     }
 
     @Test
+    void testObjectKeyAsUrlPathEncodesPlusSign() {
+        // Semver build metadata, see https://github.com/eclipse-openvsx/openvsx/issues/1459
+        extVersion.setVersion("1.0.0+10");
+
+        // The object key must keep the literal '+': it identifies the stored object, and changing it
+        // would leave every file published so far unreachable.
+        assertEquals(
+                "testnamespace/test-extension/1.0.0+10/extension.vsix",
+                ReflectionTestUtils.invokeMethod(storageService, "getObjectKey", resource));
+
+        // S3 reads a '+' in a URL path as a space, so the URL form has to escape it.
+        assertEquals(
+                "testnamespace/test-extension/1.0.0%2B10/extension.vsix",
+                storageService.getObjectKeyAsUrlPath(resource));
+    }
+
+    @Test
+    void testObjectKeyAsUrlPathKeepsKeysWithoutPlusSign() {
+        assertEquals(
+                "testnamespace/test-extension/1.0.0/extension.vsix",
+                storageService.getObjectKeyAsUrlPath(resource));
+        assertEquals("testnamespace/logo/logo.png", storageService.getObjectKeyAsUrlPath(namespace));
+    }
+
+    @Test
     void testObjectKeyGenerationWithComplexNames() {
         // Test with complex namespace and extension names
         namespace.setName("my-complex-namespace");

--- a/server/src/test/java/org/eclipse/openvsx/storage/StorageUtilServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/storage/StorageUtilServiceTest.java
@@ -84,6 +84,31 @@ public class StorageUtilServiceTest {
         cdnServiceConfig.setEnabled(false);
     }
 
+    /**
+     * A version may carry semver build metadata, and S3 reads the {@code +} in a URL path as a space, so
+     * the CDN URL for an AWS resource has to escape it. Other storage types keep the literal {@code +}.
+     * See <a href="https://github.com/eclipse-openvsx/openvsx/issues/1459">issue 1459</a>.
+     */
+    @Test
+    public void testCdnEnabledWithPlusSignInVersion() {
+        cdnServiceConfig.setEnabled(true);
+        try {
+            var extension = mockExtension();
+            var extensionVersion = mockExtensionVersion(extension, 1, "1.0.0+10", "universal");
+            var resourceAws = mockFileResource(1, extensionVersion, "README.md", README, FileResource.STORAGE_AWS);
+            var resourceAzure = mockFileResource(1, extensionVersion, "README.md", README, FileResource.STORAGE_AZURE);
+
+            assertEquals(
+                    "https://test.cloudfront.com/aws/redhat/vscode-yaml/1.0.0%2B10/README.md",
+                    storageUtilService.getLocation(resourceAws).toString());
+            assertEquals(
+                    "https://test.cloudfront.com/azure/redhat/vscode-yaml/1.0.0+10/README.md",
+                    storageUtilService.getLocation(resourceAzure).toString());
+        } finally {
+            cdnServiceConfig.setEnabled(false);
+        }
+    }
+
     @Test
     public void testCdnDisabled() {
         // Test a file resource for which no cdn prefix is enabled


### PR DESCRIPTION
This fixes #1459 and supersedes #1541.

`+` is treated by AWS as a space so it must be encoded properly when part of a storage location URL.

It is an allowed character for a semantic version string.

Tested locally with minio as storage backend and it correctly can resolve artifacts with a `+` sign in them.