### PR TITLE
doc(security): revise security vulnerability reporting instructions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,6 @@ If you think you have found a vulnerability in Eclipse Open VSX, please report i
 
 Instead, you can report it using one of the following ways:
 
-* Contact the [Eclipse Foundation Security Team](mailto:security@eclipse-foundation.org) via email
 * Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
 * Report a [vulnerability](https://github.com/eclipse-openvsx/openvsx/security/advisories/new) directly via private vulnerability reporting on GitHub
 


### PR DESCRIPTION
Removed email as a contact method from the list of acceptable channels for reporting vulnerabilities.