### PR TITLE
chore: remove deprecated fields in ExtensionJson

### DIFF
--- a/server/src/dev/resources/application.yml
+++ b/server/src/dev/resources/application.yml
@@ -130,8 +130,6 @@ ovsx:
     enabled: false
   eclipse:
     base-url: https://api.eclipse.org
-    publisher-agreement:
-      timezone: US/Eastern
   extension-control:
     enabled: false
     update-on-start: false

--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -64,7 +64,6 @@ public class LocalRegistryService implements IExtensionRegistry {
 
     protected final Logger logger = LoggerFactory.getLogger(LocalRegistryService.class);
 
-    private static final String RESTRICTED_ACCESS = "restricted";
     private static final String ACCESS_TOKEN_ERROR = "Invalid access token.";
 
     private final EntityManager entityManager;
@@ -1007,8 +1006,6 @@ public class LocalRegistryService implements IExtensionRegistry {
 
         json.setVersionAlias(versionAlias);
         json.setVerified(isVerified(extVersion));
-        json.setNamespaceAccess(RESTRICTED_ACCESS);
-        json.setUnrelatedPublisher(!json.getVerified());
         json.setReviewCount(Optional.ofNullable(extension.getReviewCount()).orElse(0L));
         var serverUrl = UrlUtil.getBaseUrl();
         json.setNamespaceUrl(createApiUrl(serverUrl, "api", json.getNamespace()));
@@ -1067,8 +1064,6 @@ public class LocalRegistryService implements IExtensionRegistry {
         var json = extVersion.toExtensionJson();
         json.setPreview(preview);
         json.setVerified(isVerified(extVersion, membershipsByNamespaceId));
-        json.setNamespaceAccess(RESTRICTED_ACCESS);
-        json.setUnrelatedPublisher(!json.getVerified());
         json.setReviewCount(reviewCount);
         var serverUrl = UrlUtil.getBaseUrl();
         json.setNamespaceUrl(createApiUrl(serverUrl, "api", json.getNamespace()));
@@ -1151,8 +1146,6 @@ public class LocalRegistryService implements IExtensionRegistry {
         var json = extVersion.toExtensionJson();
         json.setPreview(preview);
         json.setVerified(isVerified(extVersion, membershipsByNamespaceId));
-        json.setNamespaceAccess(RESTRICTED_ACCESS);
-        json.setUnrelatedPublisher(!json.getVerified());
         json.setReviewCount(reviewCount);
         var serverUrl = UrlUtil.getBaseUrl();
         json.setNamespaceUrl(createApiUrl(serverUrl, "api", json.getNamespace()));

--- a/server/src/main/java/org/eclipse/openvsx/json/ExtensionJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/ExtensionJson.java
@@ -110,25 +110,6 @@ public class ExtensionJson extends ResultJson {
     /**
      * @deprecated
      */
-    @Schema(description = "Deprecated: use 'verified' instead (this property is just the negation of 'verified')")
-    @NotNull
-    @Deprecated
-    private Boolean unrelatedPublisher;
-
-    /**
-     * @deprecated
-     */
-    @Schema(
-        description = "Access level of the extension's namespace. Deprecated: namespaces are now always restricted",
-        allowableValues = { "public", "restricted" }
-    )
-    @NotNull
-    @Deprecated
-    private String namespaceAccess;
-
-    /**
-     * @deprecated
-     */
     @Schema(
         description = "Map of available versions to their metadata URLs. Deprecated: only returns the last 100 versions. Use allVersionsUrl instead."
     )
@@ -352,22 +333,6 @@ public class ExtensionJson extends ResultJson {
 
     public void setVerified(Boolean verified) {
         this.verified = verified;
-    }
-
-    public Boolean getUnrelatedPublisher() {
-        return unrelatedPublisher;
-    }
-
-    public void setUnrelatedPublisher(Boolean unrelatedPublisher) {
-        this.unrelatedPublisher = unrelatedPublisher;
-    }
-
-    public String getNamespaceAccess() {
-        return namespaceAccess;
-    }
-
-    public void setNamespaceAccess(String namespaceAccess) {
-        this.namespaceAccess = namespaceAccess;
     }
 
     public Map<String, String> getAllVersions() {
@@ -665,8 +630,6 @@ public class ExtensionJson extends ResultJson {
                 && Objects.equals(reviewStatus, that.reviewStatus)
                 && Objects.equals(reviewMessage, that.reviewMessage)
                 && Objects.equals(verified, that.verified)
-                && Objects.equals(unrelatedPublisher, that.unrelatedPublisher)
-                && Objects.equals(namespaceAccess, that.namespaceAccess)
                 && Objects.equals(allVersions, that.allVersions)
                 && Objects.equals(allVersionsUrl, that.allVersionsUrl)
                 && Objects.equals(averageRating, that.averageRating)
@@ -717,8 +680,6 @@ public class ExtensionJson extends ResultJson {
                 reviewStatus,
                 reviewMessage,
                 verified,
-                unrelatedPublisher,
-                namespaceAccess,
                 allVersions,
                 allVersionsUrl,
                 averageRating,

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishingConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishingConfig.java
@@ -57,7 +57,7 @@ public class PublishingConfig {
         return maxContentSize;
     }
 
-    public void setMaxContentSize(int maxContentSize) {
+    public void setMaxContentSize(long maxContentSize) {
         this.maxContentSize = maxContentSize;
     }
 

--- a/server/src/test/java/org/eclipse/openvsx/IntegrationTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/IntegrationTest.java
@@ -113,6 +113,7 @@ class IntegrationTest extends AbstractPostgresContainerTest {
                 ResultJson.class,
                 "test_token");
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().getError()).isNull();
         assertThat(response.getBody().getSuccess()).isEqualTo("Created namespace " + requestBody.getName());
     }
@@ -126,6 +127,7 @@ class IntegrationTest extends AbstractPostgresContainerTest {
                 ResultJson.class,
                 "test_token");
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().getSuccess()).isNull();
         assertThat(response.getBody().getError()).isEqualTo("Namespace already exists: EditorConfig");
     }
@@ -134,8 +136,9 @@ class IntegrationTest extends AbstractPostgresContainerTest {
         var response = restTemplate.getForEntity(apiCall(path), JsonNode.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         var json = response.getBody();
+        assertThat(json).isNotNull();
         assertThat(json.get("error")).isNull();
-        assertThat(json.get("name").asText()).isEqualTo("EditorConfig");
+        assertThat(json.get("name").asString()).isEqualTo("EditorConfig");
     }
 
     private void verifyToken() {
@@ -143,6 +146,7 @@ class IntegrationTest extends AbstractPostgresContainerTest {
                 .getForEntity(apiCall("/api/editorconfig/verify-pat?token=test_token"), ResultJson.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         var json = response.getBody();
+        assertThat(json).isNotNull();
         assertThat(json.getError()).isNull();
         assertThat(json.getSuccess()).isEqualTo("Valid token");
     }
@@ -178,6 +182,7 @@ class IntegrationTest extends AbstractPostgresContainerTest {
     private void getExtensionMetadata(String url) {
         var response = restTemplate.getForEntity(apiCall(url), ExtensionJson.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().getDescription()).isEqualTo("EditorConfig Support for Visual Studio Code");
     }
 
@@ -188,6 +193,7 @@ class IntegrationTest extends AbstractPostgresContainerTest {
         }
 
         var response = restTemplate.getForEntity(apiCall(path + "/versions"), VersionsJson.class);
+        assertThat(response.getBody()).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getVersions().size()).isEqualTo(1);
 
@@ -198,9 +204,10 @@ class IntegrationTest extends AbstractPostgresContainerTest {
 
     private void getVersionReferencesMetadata(String path) {
         var response = restTemplate.getForEntity(apiCall(path), VersionReferencesJson.class);
+        assertThat(response.getBody()).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getVersions().size()).isEqualTo(1);
-        assertThat(response.getBody().getVersions().get(0).getVersion()).isEqualTo("0.16.6");
+        assertThat(response.getBody().getVersions().getFirst().getVersion()).isEqualTo("0.16.6");
     }
 
     private void getFile(String path) {
@@ -213,6 +220,7 @@ class IntegrationTest extends AbstractPostgresContainerTest {
     private void getReviews() {
         var response = restTemplate
                 .getForEntity(apiCall("/api/editorconfig/editorconfig/reviews"), ReviewListJson.class);
+        assertThat(response.getBody()).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getError()).isNull();
         assertThat(response.getBody().getReviews().size()).isZero();
@@ -220,6 +228,7 @@ class IntegrationTest extends AbstractPostgresContainerTest {
 
     private void searchExtension() {
         var response = restTemplate.getForEntity(apiCall("/api/-/search?query=editorconfig"), SearchResultJson.class);
+        assertThat(response.getBody()).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getExtensions().size()).isEqualTo(1);
         assertThat(response.getBody().getExtensions().getFirst().getDescription())

--- a/webui/src/extension-registry-service.ts
+++ b/webui/src/extension-registry-service.ts
@@ -9,9 +9,7 @@
  ********************************************************************************/
 
 import {
-    CATEGORIES,
     Extension,
-    ExtensionCategory,
     UserData,
     ExtensionReviewList,
     PersonalAccessToken,
@@ -204,11 +202,6 @@ export class ExtensionRegistryService {
             const blob = value as Blob;
             return URL.createObjectURL(blob);
         });
-    }
-
-    /** @deprecated Use the CATEGORIES constant from extension-registry-types instead. */
-    getCategories(): ExtensionCategory[] {
-        return [...CATEGORIES];
     }
 
     async getExtensionReviews(


### PR DESCRIPTION
This PR removes two fields in the `ExtensionJson` response object that are deprecated for a long time:

 - namespaceAccess
 - unrelatedPublisher

The do not fit into the current model anymore and should not be used.