### PR TITLE
fix: add validation for file resource name collisions

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -402,14 +402,30 @@ public class PublishExtensionVersionHandler {
         reservedNames.add(NamingUtil.toFileFormat(extVersion, ".vsix"));
         reservedNames.add(NamingUtil.toFileFormat(extVersion, ".sha256"));
         reservedNames.add(NamingUtil.toFileFormat(extVersion, ".sigzip"));
+
+        // Collect every colliding name instead of failing on the first one, so a publisher fixing one
+        // collision does not have to republish repeatedly just to discover the next.
+        var collisions = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         for (var name : names) {
             if (!reservedNames.add(name)) {
-                throw new ErrorResultException(
-                        "Extension contains multiple files named '" + name + "' (case-insensitive)."
-                                + " Rename the conflicting asset so that it does not collide with another"
-                                + " published file.");
+                collisions.add(name);
             }
         }
+
+        if (collisions.isEmpty()) {
+            return;
+        }
+        if (collisions.size() == 1) {
+            throw new ErrorResultException(collisionMessage(collisions.first()));
+        }
+        throw new ErrorResultException(
+                "Multiple file name collisions were found in the extension:\n"
+                        + collisions.stream().map(this::collisionMessage).collect(Collectors.joining("\n")));
+    }
+
+    private String collisionMessage(String name) {
+        return "Extension contains multiple files named '" + name + "' (case-insensitive)."
+                + " Rename the conflicting asset so that it does not collide with another published file.";
     }
 
     private void validateMetadata(ExtensionVersion extVersion) {

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -12,7 +12,9 @@ package org.eclipse.openvsx.publish;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -371,15 +373,42 @@ public class PublishExtensionVersionHandler {
     }
 
     private void validateFileResources(ExtensionProcessor processor, ExtensionVersion extVersion) {
-        try {
-            // Validate that all file resources are readable/accessible during synchronous publishing
-            // to avoid failing during async publishing and report errors directly back to publishers.
-            // This creates unnecessary temp files, however these are usually small and thus it is
-            // acceptable in this case.
-            processor.getFileResources(extVersion, _ -> {
-            });
-        } catch (ErrorResultException exc) {
-            throw new ErrorResultException("Validation failed: " + exc.getMessage());
+        // Validate that all file resources are readable/accessible during synchronous publishing
+        // to avoid failing during async publishing and report errors directly back to publishers.
+        // This creates unnecessary temp files, however these are usually small, and thus it is
+        // acceptable in this case.
+        var names = new ArrayList<String>();
+        processor.getFileResources(extVersion, tempFile -> names.add(tempFile.getResource().getName()));
+
+        // Additionally check that there are no name collisions within the file resources as the file
+        // names are used as object key when uploading to the storage provider and would overwrite each other.
+        checkForNameCollisions(extVersion, names);
+    }
+
+    /**
+     * Object keys within a version share one flat namespace (see {@code IStorageService#getObjectKey}), so a
+     * resource name that collides with another resource's name, or with the reserved name of the binary, its
+     * checksum or its signature, would silently overwrite that other file on the storage backend once uploaded.
+     * Resource names come from the VSIX manifest and are therefore attacker-controlled, so this has to be
+     * rejected before any of these files are stored.
+     * <p>
+     * Storage object keys are matched case-sensitively, but {@code FileResourceJooqRepository#findByName}
+     * looks up a requested file case-insensitively and returns whichever resource sorts first by type, so a
+     * same-name-different-case resource can still shadow another one at the API level even though it would not
+     * overwrite it in storage. Collisions are therefore checked case-insensitively as well.
+     */
+    private void checkForNameCollisions(ExtensionVersion extVersion, List<String> names) {
+        var reservedNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        reservedNames.add(NamingUtil.toFileFormat(extVersion, ".vsix"));
+        reservedNames.add(NamingUtil.toFileFormat(extVersion, ".sha256"));
+        reservedNames.add(NamingUtil.toFileFormat(extVersion, ".sigzip"));
+        for (var name : names) {
+            if (!reservedNames.add(name)) {
+                throw new ErrorResultException(
+                        "Extension contains multiple files named '" + name + "' (case-insensitive)."
+                                + " Rename the conflicting asset so that it does not collide with another"
+                                + " published file.");
+            }
         }
     }
 

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -11,6 +11,7 @@ package org.eclipse.openvsx;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -81,6 +82,7 @@ import org.eclipse.openvsx.storage.*;
 import org.eclipse.openvsx.storage.log.DownloadCountService;
 import org.eclipse.openvsx.util.ChangesCursor;
 import org.eclipse.openvsx.util.LogService;
+import org.eclipse.openvsx.util.NamingUtil;
 import org.eclipse.openvsx.util.TargetPlatform;
 import org.eclipse.openvsx.util.TimeUtil;
 import org.eclipse.openvsx.util.VersionAlias;
@@ -1819,6 +1821,27 @@ class RegistryAPITest {
     }
 
     @Test
+    void testPublishRejectsReadmeCollidingWithBinaryName() throws Exception {
+        // Reproduces TOB-OVSX-15: object keys for a version share one flat namespace, so a README
+        // declared under the derived name of the .vsix binary would silently overwrite it in storage
+        // once uploaded. That name is attacker-controlled (it comes from the VSIX manifest), so
+        // publication of a colliding package must be rejected before anything is stored.
+        mockForPublish("contributor");
+        var bytes = createExtensionPackageWithCollidingReadme("bar", "1.0.0");
+        mockMvc.perform(
+                post("/api/-/publish?token={token}", "my_token")
+                        .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                        .content(bytes))
+                .andExpect(status().isBadRequest())
+                .andExpect(
+                        content().json(
+                                errorJson(
+                                        "Extension contains multiple files named 'foo.bar-1.0.0.vsix'"
+                                                + " (case-insensitive). Rename the conflicting asset so that it does not"
+                                                + " collide with another published file.")));
+    }
+
+    @Test
     void testPublishLimitsTags() throws Exception {
         var previousMaxTags = publishingConfig.getMaxTags();
         try {
@@ -3257,6 +3280,65 @@ class RegistryAPITest {
                 (license == null ? "" : ",\"license\": \"" + license + "\"") +
                 "}";
         archive.write(packageJson.getBytes());
+        archive.closeEntry();
+        archive.finish();
+        return bytes.toByteArray();
+    }
+
+    /**
+     * Builds a package whose README asset resolves to the derived name of the .vsix binary
+     * ("foo.&lt;name&gt;-&lt;version&gt;.vsix"), reproducing TOB-OVSX-15.
+     */
+    private byte[] createExtensionPackageWithCollidingReadme(String name, String version) throws IOException {
+        var maliciousPath = "extension/"
+                + NamingUtil.toFileFormat("foo", name, TargetPlatform.NAME_UNIVERSAL, version, ".vsix");
+        var bytes = new ByteArrayOutputStream();
+        var archive = new ZipOutputStream(bytes);
+        archive.putNextEntry(new ZipEntry("extension.vsixmanifest"));
+        var vsixmanifest = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                "<PackageManifest Version=\"2.0.0\" xmlns=\"http://schemas.microsoft.com/developer/vsx-schema/2011\" xmlns:d=\"http://schemas.microsoft.com/developer/vsx-schema-design/2011\">"
+                +
+                "<Metadata>" +
+                "<Identity Language=\"en-US\" Id=\"" + name + "\" Version=\"" + version + "\" Publisher=\"foo\" />" +
+                "<DisplayName>foo</DisplayName>" +
+                "<Description xml:space=\"preserve\"></Description>" +
+                "<Tags></Tags>" +
+                "<Categories>Other</Categories>" +
+                "<GalleryFlags>Public</GalleryFlags>" +
+                "<Badges></Badges>" +
+                "<Properties>" +
+                "<Property Id=\"Microsoft.VisualStudio.Code.Engine\" Value=\"^1.57.0\" />" +
+                "<Property Id=\"Microsoft.VisualStudio.Code.ExtensionDependencies\" Value=\"\" />" +
+                "<Property Id=\"Microsoft.VisualStudio.Code.ExtensionPack\" Value=\"\" />" +
+                "<Property Id=\"Microsoft.VisualStudio.Code.ExtensionKind\" Value=\"ui,web,workspace\" />" +
+                "<Property Id=\"Microsoft.VisualStudio.Code.LocalizedLanguages\" Value=\"\" />" +
+                "<Property Id=\"Microsoft.VisualStudio.Services.GitHubFlavoredMarkdown\" Value=\"true\" />" +
+                "</Properties>" +
+                "</Metadata>" +
+                "<Installation>" +
+                "<InstallationTarget Id=\"Microsoft.VisualStudio.Code\"/>" +
+                "</Installation>" +
+                "<Dependencies/>" +
+                "<Assets>" +
+                "<Asset Type=\"Microsoft.VisualStudio.Code.Manifest\" Path=\"extension/package.json\" Addressable=\"true\" />"
+                +
+                "<Asset Type=\"Microsoft.VisualStudio.Services.Content.Details\" Path=\"" + maliciousPath
+                + "\" Addressable=\"true\" />" +
+                "</Assets>" +
+                "</PackageManifest>";
+        archive.write(vsixmanifest.getBytes());
+        archive.closeEntry();
+        archive.putNextEntry(new ZipEntry("extension/package.json"));
+        var packageJson = "{" +
+                "\"publisher\": \"foo\"," +
+                "\"name\": \"" + name + "\"," +
+                "\"version\": \"" + version + "\"," +
+                "\"displayName\": \"foo\"" +
+                "}";
+        archive.write(packageJson.getBytes());
+        archive.closeEntry();
+        archive.putNextEntry(new ZipEntry(maliciousPath));
+        archive.write("DATA FROM THE ARCHIVE".getBytes(StandardCharsets.UTF_8));
         archive.closeEntry();
         archive.finish();
         return bytes.toByteArray();

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
@@ -240,6 +240,61 @@ class PublishExtensionVersionHandlerTest {
     }
 
     @Test
+    void shouldReportAllFileResourceCollisionsAtOnce() throws IOException {
+        // Reports every colliding name in one error instead of failing on the first, so a publisher
+        // does not have to republish repeatedly just to discover the next collision.
+        try (
+                var processor = org.mockito.Mockito.mock(ExtensionProcessor.class);
+                var readme = new TempFile("readme_", ".md");
+                var changelog = new TempFile("changelog_", ".md");
+                var license = new TempFile("license_", ".md")
+        ) {
+            mockExtensionVersion("publisher", "demo", "2.0.0", null, processor);
+
+            var namespace = buildNamespace("publisher");
+            var user = new UserData();
+            var token = new PersonalAccessToken();
+            token.setUser(user);
+
+            when(repositories.findNamespace("publisher")).thenReturn(namespace);
+            when(users.hasPublishPermission(user, namespace)).thenReturn(true);
+            when(validator.validateExtensionVersion("2.0.0")).thenReturn(Optional.empty());
+            when(validator.validateExtensionName("demo")).thenReturn(Optional.empty());
+            when(repositories.findExtensionForUpdate("demo", "publisher")).thenReturn(null);
+            when(processor.getPackageMetadata()).thenReturn(
+                    new ExtensionProcessor.PackageMetadata("publisher", "demo", "2.0.0", "Demo OK"));
+
+            var maliciousName = NamingUtil.toFileFormat("publisher", "demo", "any", "2.0.0", ".vsix");
+            var readmeResource = new FileResource();
+            readmeResource.setName(maliciousName);
+            readme.setResource(readmeResource);
+
+            var changelogResource = new FileResource();
+            changelogResource.setName("CHANGELOG.md");
+            changelog.setResource(changelogResource);
+
+            // A second, independent collision alongside the readme/binary one above.
+            var licenseResource = new FileResource();
+            licenseResource.setName("CHANGELOG.md");
+            license.setResource(licenseResource);
+
+            doAnswer(invocation -> {
+                Consumer<TempFile> consumer = invocation.getArgument(1);
+                consumer.accept(readme);
+                consumer.accept(changelog);
+                consumer.accept(license);
+                return null;
+            }).when(processor).getFileResources(any(), any());
+
+            assertThatThrownBy(() -> handler.createExtensionVersion(processor, token, LocalDateTime.now(), false))
+                    .isInstanceOf(ErrorResultException.class)
+                    .hasMessageContaining("Multiple file name collisions")
+                    .hasMessageContaining(maliciousName)
+                    .hasMessageContaining("CHANGELOG.md");
+        }
+    }
+
+    @Test
     void shouldFailWhenNamespaceDoesNotExist() {
         // When namespace doesn't exist, handler should throw an error.
         try (var processor = org.mockito.Mockito.mock(ExtensionProcessor.class)) {

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import jakarta.persistence.EntityManager;
 import org.jobrunr.scheduling.JobRequestScheduler;
@@ -35,13 +36,17 @@ import org.eclipse.openvsx.extension_control.ExtensionControlService;
 import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.scanning.ExtensionScanService;
 import org.eclipse.openvsx.util.ErrorResultException;
+import org.eclipse.openvsx.util.NamingUtil;
 import org.eclipse.openvsx.util.TargetPlatform;
+import org.eclipse.openvsx.util.TempFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -139,6 +144,98 @@ class PublishExtensionVersionHandlerTest {
             assertThat(result.getPublishedWith()).isEqualTo(token);
             assertThat(result.getExtension()).isSameAs(capturedExtension.getValue());
             assertThat(result.getExtension().getNamespace()).isSameAs(namespace);
+        }
+    }
+
+    @Test
+    void shouldFailWhenFileResourceCollidesWithDerivedDownloadName() throws IOException {
+        // TOB-OVSX-15: object keys for a version share one flat namespace, so a README (or any other
+        // asset) declared under the binary's derived name would silently overwrite it in storage once
+        // uploaded. That resource name is attacker-controlled (it comes from the VSIX manifest), so
+        // publication of a colliding package must be rejected before anything is stored.
+        try (
+                var processor = org.mockito.Mockito.mock(ExtensionProcessor.class);
+                var readme = new TempFile("readme_", ".md")
+        ) {
+            var metadata = mockExtensionVersion("publisher", "demo", "2.0.0", null, processor);
+
+            var namespace = buildNamespace("publisher");
+            var user = new UserData();
+            var token = new PersonalAccessToken();
+            token.setUser(user);
+
+            when(repositories.findNamespace("publisher")).thenReturn(namespace);
+            when(users.hasPublishPermission(user, namespace)).thenReturn(true);
+            when(validator.validateExtensionVersion("2.0.0")).thenReturn(Optional.empty());
+            when(validator.validateExtensionName("demo")).thenReturn(Optional.empty());
+            when(repositories.findExtensionForUpdate("demo", "publisher")).thenReturn(null);
+            when(processor.getPackageMetadata()).thenReturn(
+                    new ExtensionProcessor.PackageMetadata("publisher", "demo", "2.0.0", "Demo OK"));
+
+            // Matches what createExtensionVersion will derive for the download once extVersion is wired
+            // up with its extension/namespace, which happens after this point in the real flow.
+            var maliciousName = NamingUtil.toFileFormat("publisher", "demo", "any", "2.0.0", ".vsix");
+            var readmeResource = new FileResource();
+            readmeResource.setName(maliciousName);
+            readme.setResource(readmeResource);
+
+            doAnswer(invocation -> {
+                Consumer<TempFile> consumer = invocation.getArgument(1);
+                consumer.accept(readme);
+                return null;
+            }).when(processor).getFileResources(any(), any());
+
+            assertThatThrownBy(() -> handler.createExtensionVersion(processor, token, LocalDateTime.now(), false))
+                    .isInstanceOf(ErrorResultException.class)
+                    .hasMessageContaining(maliciousName);
+
+            // the version must not be persisted once its file resources are rejected
+            org.mockito.Mockito.verify(entityManager, never()).persist(metadata);
+        }
+    }
+
+    @Test
+    void shouldFailWhenTwoFileResourcesHaveTheSameName() throws IOException {
+        try (
+                var processor = org.mockito.Mockito.mock(ExtensionProcessor.class);
+                var changelog = new TempFile("changelog_", ".md");
+                var license = new TempFile("license_", ".md")
+        ) {
+            var metadata = mockExtensionVersion("publisher", "demo", "2.0.0", null, processor);
+
+            var namespace = buildNamespace("publisher");
+            var user = new UserData();
+            var token = new PersonalAccessToken();
+            token.setUser(user);
+
+            when(repositories.findNamespace("publisher")).thenReturn(namespace);
+            when(users.hasPublishPermission(user, namespace)).thenReturn(true);
+            when(validator.validateExtensionVersion("2.0.0")).thenReturn(Optional.empty());
+            when(validator.validateExtensionName("demo")).thenReturn(Optional.empty());
+            when(repositories.findExtensionForUpdate("demo", "publisher")).thenReturn(null);
+            when(processor.getPackageMetadata()).thenReturn(
+                    new ExtensionProcessor.PackageMetadata("publisher", "demo", "2.0.0", "Demo OK"));
+
+            var changelogResource = new FileResource();
+            changelogResource.setName("CHANGELOG.md");
+            changelog.setResource(changelogResource);
+
+            // The license is repointed at the same file as the changelog, so both resolve to the same
+            // name under different resource types.
+            var licenseResource = new FileResource();
+            licenseResource.setName("CHANGELOG.md");
+            license.setResource(licenseResource);
+
+            doAnswer(invocation -> {
+                Consumer<TempFile> consumer = invocation.getArgument(1);
+                consumer.accept(changelog);
+                consumer.accept(license);
+                return null;
+            }).when(processor).getFileResources(any(), any());
+
+            assertThatThrownBy(() -> handler.createExtensionVersion(processor, token, LocalDateTime.now(), false))
+                    .isInstanceOf(ErrorResultException.class)
+                    .hasMessageContaining("CHANGELOG.md");
         }
     }
 


### PR DESCRIPTION
Currently various files are extracted from the vsix extension and stored as separate `FileResource` and uploaded to the storage provider for quick access.

There was no check to validate that the file names do not have collisions with each other, so it could happen that these file resources were overwriting each other, depending on the sequence in which they are stored.

This PR adds a strict check that none of these distinguished files can be named the same to avoid collisions.