### PR TITLE
fix: use non-generic jackson serializers for various caches

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/cache/CacheConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/cache/CacheConfig.java
@@ -284,12 +284,12 @@ public class CacheConfig {
                                 .withValueInclusion(JsonInclude.Include.NON_NULL))
                 .build();
 
-        var genericMapper = JsonMapper.shared();
+        var sharedMapper = JsonMapper.shared();
 
         return RedisCacheManager.builder(redisConnectionFactory)
                 .withCacheConfiguration(
                         CACHE_AVERAGE_REVIEW_RATING,
-                        redisCacheConfig(new GenericJacksonJsonRedisSerializer(genericMapper), averageReviewRatingTtl))
+                        redisCacheConfig(new JacksonJsonRedisSerializer<>(Double.class), averageReviewRatingTtl))
                 .withCacheConfiguration(
                         CACHE_NAMESPACE_DETAILS_JSON,
                         redisCacheConfig(
@@ -324,7 +324,12 @@ public class CacheConfig {
                         redisCacheConfig(new StringRedisSerializer(), sitemapTtl))
                 .withCacheConfiguration(
                         CACHE_MALICIOUS_EXTENSIONS,
-                        redisCacheConfig(new GenericJacksonJsonRedisSerializer(genericMapper), maliciousExtensionsTtl))
+                        redisCacheConfig(
+                                new JacksonJsonRedisSerializer<>(
+                                        sharedMapper,
+                                        sharedMapper.getTypeFactory()
+                                                .constructParametricType(List.class, String.class)),
+                                maliciousExtensionsTtl))
                 .build();
     }
 


### PR DESCRIPTION
This uses concrete jackson serializers for the 2 remaining caches that did not use them already.

No additional tests are added for this change, already covered by existing tests.